### PR TITLE
vto: don't attempt to iterate over an empty table

### DIFF
--- a/custom_components/dahua/vto.py
+++ b/custom_components/dahua/vto.py
@@ -253,13 +253,14 @@ class DahuaVTOClient(asyncio.Protocol):
             params = message.get("params")
             table = params.get("table")
 
-            for item in table:
-                access_control = item.get('AccessProtocol')
+            if table is not None:
+                for item in table:
+                    access_control = item.get('AccessProtocol')
 
-                if access_control == 'Local':
-                    self.hold_time = item.get('UnlockReloadInterval')
+                    if access_control == 'Local':
+                        self.hold_time = item.get('UnlockReloadInterval')
 
-                    _LOGGER.info(f"Hold time: {self.hold_time}")
+                        _LOGGER.info(f"Hold time: {self.hold_time}")
 
         request_data = {
             "name": "AccessControl"


### PR DESCRIPTION
This fixes the bug described in #52 - the `table` variable is None and thus the for loop throws an exception. See here: https://github.com/rroller/dahua/blob/9910d0d/custom_components/dahua/vto.py#L256