### PR TITLE
Support for Lorex E891AB NVR

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -184,7 +184,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     data.update(response)
 
                 device_type = data.get("deviceType", None)
-                if device_type == "IP Camera" or device_type is None:
+                if device_type in ["IP Camera", "31"] or device_type is None:
                     # Some firmwares put the device type in the "updateSerial" field. Weird.
                     device_type = data.get("updateSerial", None)
                     if device_type is None:

--- a/custom_components/dahua/camera.py
+++ b/custom_components/dahua/camera.py
@@ -290,7 +290,12 @@ class DahuaCamera(DahuaBaseEntity, Camera):
     async def async_set_video_profile_mode(self, mode: str):
         """ Handles the service call from SERVICE_SET_VIDEO_PROFILE_MODE to set profile mode to day/night """
         channel = self._coordinator.get_channel()
-        await self._coordinator.client.async_set_video_profile_mode(channel, mode)
+        model = self._coordinator.get_model()
+        # Some NVRs like the Lorex DHI-NVR4108HS-8P-4KS2 change the day/night mode through a switch
+        if 'NVR4108HS' in model:
+            await self._coordinator.client.async_set_night_switch_mode(channel, mode)
+        else:
+            await self._coordinator.client.async_set_video_profile_mode(channel, mode)
 
     async def async_set_enable_channel_title(self, enabled: bool):
         """ Handles the service call from SERVICE_ENABLE_CHANNEL_TITLE """

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -272,6 +272,23 @@ class DahuaClient:
         url = "/cgi-bin/configManager.cgi?action=setConfig&VideoInMode[{0}].Config[0]={1}".format(channel, mode)
         return await self.get(url, True)
 
+    async def async_set_night_switch_mode(self, channel: int, mode: str):
+        """
+        async_set_night_switch_mode is the same as async_set_video_profile_mode when accessing the camera
+        through a lorex NVR
+        Mode should be one of: Day or Night
+        """
+
+        if mode.lower() == "night":
+            mode = "3"
+        else:
+            # Default to "day", which is 0
+            mode = "0"
+
+        url = f"/cgi-bin/configManager.cgi?action=setConfig&VideoInOptions[{channel}].NightOptions.SwitchMode={mode}"
+        _LOGGER.debug("Switching night mode: %s", url)
+        return await self.get(url, True)
+
     async def async_enable_channel_title(self, channel: int, enabled: bool, ):
         """ async_set_enable_channel_title will enable or disables the camera's channel title overlay """
         url = "/cgi-bin/configManager.cgi?action=setConfig&VideoWidget[{0}].ChannelTitle.EncodeBlend={1}".format(

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -12,7 +12,7 @@
                     "rtsp_port": "RTSP Port",
                     "streams": "RTSP Streams",
                     "events": "Events",
-                    "channel": "Channel (Usually 0 unless you use an nvr)"
+                    "channel": "Channel (single cameras are 0, NVRs are the 0 based index)"
                 }
             },
             "name": {


### PR DESCRIPTION
I have an eight channel Lorex NVR (along with various Amcrest/Loryta) cams. Unfortunately, four of the lorex cams are still using the PoE on the NVR. 

Lorex is returning "31" for the model, but has the model in the unqueSerial field. Also, the day/night mode access through the NVR uses a different method. The Dahua method works on the direct connected NVRs, but not through the Lorex firmware. 