### PR TITLE
Added support for Amcrest Flood Lights (ASH26)

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -308,7 +308,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 if result is not None:
                     data.update(result)
 
-            if self.supports_security_light() or self.is_amcrest_flood_light:
+            if self.supports_security_light() or self.is_amcrest_flood_light():
                 light_v2 = await self.client.async_get_lighting_v2()
                 if light_v2 is not None:
                     data.update(light_v2)

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -234,13 +234,16 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 is_doorbell = self.is_doorbell()
                 _LOGGER.info("Device is a doorbell=%s", is_doorbell)
 
+                is_amcrest_flood_light = self.is_amcrest_flood_light()
+                _LOGGER.info("Device is an Amcrest floodlight=%s",is_amcrest_flood_light)
+
                 try:
                     await self.client.async_get_config_lighting(self._channel, self._profile_mode)
                     self._supports_lighting = True
                 except ClientError:
                     self._supports_lighting = False
                     pass
-                _LOGGER.info("Device supports lighting=%s", self.supports_infrared_light())
+                _LOGGER.info("Device supports infrared lighting=%s",self.supports_infrared_light())
 
                 if not is_doorbell:
                     # Start the event listeners for IP cameras
@@ -305,7 +308,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 if result is not None:
                     data.update(result)
 
-            if self.supports_security_light():
+            if self.supports_security_light() or self.is_amcrest_flood_light:
                 light_v2 = await self.client.async_get_lighting_v2()
                 if light_v2 is not None:
                     data.update(light_v2)
@@ -510,6 +513,10 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         """ Returns true if this is an Amcrest doorbell """
         return self.model.upper().startswith("AD")
 
+    def is_amcrest_flood_light(self) -> bool:
+        """ Returns true if this camera is an Amcrest Floodlight camera (eg.ASH26-W) """
+        return self.model.upper().startswith("ASH26")
+
     def supports_infrared_light(self) -> bool:
         """
         Returns true if this camera has an infrared light.  For example, the IPC-HDW3849HP-AS-PV does not, but most
@@ -524,7 +531,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         Returns true if this camera has an illuminator (white light for color cameras).  For example, the
         IPC-HDW3849HP-AS-PV does
         """
-        return not self.is_amcrest_doorbell() and "table.Lighting_V2[{0}][0][0].Mode".format(self._channel) in self.data
+        return not ( self.is_amcrest_doorbell() or self.is_amcrest_flood_light() ) and "table.Lighting_V2[{0}][0][0].Mode".format(self._channel) in self.data
 
     def is_motion_detection_enabled(self) -> bool:
         """ Returns true if motion detection is enabled for the camera """
@@ -591,6 +598,13 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         profile_mode = self.get_profile_mode()
 
         return self.data.get("table.Lighting_V2[{0}][{1}][0].Mode".format(self._channel, profile_mode), "") == "Manual"
+
+    def is_amcrest_flood_light_on(self) -> bool:
+        """Return true if the amcrest flood light light is on"""
+        # profile_mode 0=day, 1=night, 2=scene
+        profile_mode = self.get_profile_mode()
+
+        return self.data.get(f'table.Lighting_V2[{self._channel}][{profile_mode}][1].Mode') == "Manual"
 
     def is_ring_light_on(self) -> bool:
         """Return true if ring light is on for an Amcrest Doorbell"""

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -136,7 +136,7 @@ class DahuaClient:
         """
         async_get_lighting_v2 will fetch the status of the camera light (also known as the illuminator)
         NOTE: this is not the same as the infrared (IR) light. This is the white visible light on the camera
-        Note all cameras have this feature.
+        Not all cameras have this feature.
 
         Example response:
         table.Lighting_V2[0][2][0].Correction=50
@@ -408,6 +408,29 @@ class DahuaClient:
         _LOGGER.debug("Turning light on: %s", url)
         return await self.get(url)
 
+    # async def async_set_lighting_v2_for_amcrest_flood_lights(self, channel: int, enabled: bool, brightness: int, profile_mode: str) -> dict:
+    async def async_set_lighting_v2_for_amcrest_flood_lights(self, channel: int, enabled: bool, profile_mode: str) -> dict:
+        """
+        async_set_lighting_v2_for_amcrest_floodlights will turn on or off the flood light on the camera. If turning on, the brightness will be used.
+        brightness is in the range of 0 to 100 inclusive where 100 is the brightest.
+        NOTE: While the flood lights do support an auto or "smart" mode, the api does not handle this change properly.
+              If one wishes to make the change back to auto, it must be done in the 'Amcrest Smart Home' smartphone app.
+
+        profile_mode: 0=day, 1=night, 2=scene
+        """
+
+        # on = Manual, off = Off
+        mode = "Manual"
+        if not enabled:
+            mode = "Off"
+        url_base = "/cgi-bin/configManager.cgi?action=setConfig"
+        mode_cmnd = f'Lighting_V2[{channel}][{profile_mode}][1].Mode={mode}'
+        # brightness_cmnd = f'Lighting_V2[{channel}][{profile_mode}][1].MiddleLight[0].Light={brightness}'
+        # url = f'{url_base}&{mode_cmnd}&{brightness_cmnd}'
+        url = f'{url_base}&{mode_cmnd}'
+        _LOGGER.debug("Switching light: %s", url)
+        return await self.get(url)
+
     async def async_set_lighting_v2_for_amcrest_doorbells(self, mode: str) -> dict:
         """
         async_set_lighting_v2_for_amcrest_doorbells will turn on or off the white light on Amcrest doorbells
@@ -417,7 +440,7 @@ class DahuaClient:
         cmd = "Off"
         if mode == "on":
             cmd = "ForceOn&Lighting_V2[0][0][1].State=On"
-        elif mode == "strobe" or mode == "flicker":
+        elif mode in ('strobe', 'flicker'):
             cmd = "ForceOn&Lighting_V2[0][0][1].State=Flicker"
 
         url = "/cgi-bin/configManager.cgi?action=setConfig&Lighting_V2[0][0][1].Mode={cmd}".format(cmd=cmd)

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -30,6 +30,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     if coordinator.supports_illuminator():
         entities.append(DahuaIlluminator(coordinator, entry, "Illuminator"))
 
+    if coordinator.is_amcrest_flood_light():
+        entities.append(AmcrestFloodLight(coordinator, entry, "Flood Light"))
+
     if coordinator.supports_security_light() and not coordinator.is_amcrest_doorbell():
         #  The Amcrest doorbell works a little different and is added in select.py
         entities.append(DahuaSecurityLight(coordinator, entry, "Security Light"))
@@ -199,6 +202,61 @@ class AmcrestRingLight(DahuaBaseEntity, LightEntity):
     async def async_turn_off(self, **kwargs):
         """Turn the light off"""
         await self._coordinator.client.async_set_light_global_enabled(False)
+        await self._coordinator.async_refresh()
+
+
+class AmcrestFloodLight(DahuaBaseEntity, LightEntity):
+    """
+        Representation of a Amcrest Flood Light (for cameras that have them)
+        Unlike the 'Dahua Illuminator', Amcrest Flood Lights do not play nicely
+        with adjusting the 'White Light' brightness.
+    """
+
+    def __init__(self, coordinator: DahuaDataUpdateCoordinator, entry, name):
+        super().__init__(coordinator, entry)
+        self._name = name
+        self._coordinator = coordinator
+
+    @property
+    def name(self):
+        """Return the name of the light."""
+        return self._coordinator.get_device_name() + " " + self._name
+
+    @property
+    def unique_id(self):
+        """
+        A unique identifier for this entity. Needs to be unique within a platform (ie light.hue). Should not be configurable by the user or be changeable
+        see https://developers.home-assistant.io/docs/entity_registry_index/#unique-id-requirements
+        """
+        return self._coordinator.get_serial_number() + "_flood_light"
+
+    @property
+    def is_on(self):
+        """Return true if the light is on"""
+        return self._coordinator.is_amcrest_flood_light_on()
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return DAHUA_SUPPORTED_OPTIONS
+
+    @property
+    def should_poll(self):
+        """Don't poll."""
+        return False
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the light on"""
+        channel = self._coordinator.get_channel()
+        profile_mode = self._coordinator.get_profile_mode()
+        await self._coordinator.client.async_set_lighting_v2_for_amcrest_flood_lights(channel, True, profile_mode)
+        await self._coordinator.async_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the light off"""
+        channel = self._coordinator.get_channel()
+        profile_mode = self._coordinator.get_profile_mode()
+        await self._coordinator.client.async_set_lighting_v2_for_amcrest_flood_lights(channel, False, profile_mode)
         await self._coordinator.async_refresh()
 
 

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -141,7 +141,7 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return DAHUA_SUPPORTED_OPTIONS
+        return 0
 
     @property
     def should_poll(self):


### PR DESCRIPTION
Resolves issue #151 

For Amcrest Flood Lights table.Lighting_V2[channel][profile_mode][0] points to 'Infrared'.
Added ASH26 specific data checks, classes and methods for table.Lighting_V2[channel][profile_mode][1] which is for 'WhiteLight'.
Also, changing the brightness (like in the Dahua Illuminator) seems to cause errors within the device it self and invalidates the light on/off command entirely.