### PR TITLE
Detect VTO-2211 (newer firmware?) as doorbell

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -507,7 +507,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     def is_doorbell(self) -> bool:
         """ Returns true if this is a doorbell (VTO) """
         m = self.model.upper()
-        return m.startswith("VTO") or m.startswith("DHI") or self.is_amcrest_doorbell()
+        return m.startswith("VTO") or m.startswith("DH-VTO") or m.startswith("DHI") or self.is_amcrest_doorbell()
 
     def is_amcrest_doorbell(self) -> bool:
         """ Returns true if this is an Amcrest doorbell """


### PR DESCRIPTION
Hi, my VTO-2211-P was not detected as doorbell. Device name is DH-VTO2211G-P (it doesn't match VTO-* DHI-* etc.)
Firmware version is 4.511.0000000.0.R,build:2021-11-16.
This is probably related to https://github.com/rroller/dahua/issues/61
Now it's detected as doorbell and the binary sensor works.
Thank you very much for this integration