### PR TITLE
Add `ObjectRemovalDetection` and `ObjectPlacementDetection`

### DIFF
--- a/custom_components/dahua/config_flow.py
+++ b/custom_components/dahua/config_flow.py
@@ -66,6 +66,8 @@ ALL_EVENTS = ["VideoMotion",
               "CrowdDetection",
               "FireWarning",
               "FireWarningInfo",
+              "ObjectPlacementDetection",
+              "ObjectRemovalDetection",
               ]
 
 """


### PR DESCRIPTION
I have an IPC-T5442T-ZE running on firmware V2.840.15OG008.0.R (Build Date: 2022-02-18). I wanted to use the "Smart Object Detection" feature via this integration to detect when packages were left and removed. Initially I tried to do this by selecting the `TakenAwayDetection` and `LeftDetection` events but that didn't do anything. After some digging I realized its because my camera fires events with codes `ObjectRemovalDetection` and `ObjectPlacementDetection` here.

I'm not sure if this changed in newer firmware or different models do different things so I didn't modify the existing events. But it would be good if these two could get added to the list so folks like myself could use them.