### PR TITLE
Reduce error message verbosity for simple connection errors

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -296,12 +296,6 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 # gracefully handles some common errors like timeout and connection errors.
                 raise
             except Exception as exception:
-                _LOGGER.warning("before")
-                _LOGGER.error("Failed to initialize device at %s", self._address, exc_info=exception)
-                _LOGGER.warning("after")
-                _LOGGER.warning("after2: %s" % exception)
-                _LOGGER.warning("after3: %s" % dir(exception))
-                _LOGGER.warning("after4")
                 raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet") from exception
 
         # This is the event loop code that's called every n seconds

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -296,6 +296,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 # gracefully handles some common errors like timeout and connection errors.
                 raise
             except Exception as exception:
+                _LOGGER.error("Failed to initialize device at %s", self._address, exc_info=exception)
                 raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet") from exception
 
         # This is the event loop code that's called every n seconds

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -70,6 +70,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     await coordinator.async_config_entry_first_refresh()
 
     if not coordinator.last_update_success:
+        _LOGGER.warning("dahua async_setup_entry for init, data not ready")
         raise ConfigEntryNotReady
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
@@ -180,7 +181,8 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         try:
-            await self._async_update_data_int()
+            data = await self._async_update_data_int()
+            return data
         except Exception as ex:
             # If we let an exception bubble up, it seems to result in self being
             # deleted. So clean up first.

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -291,7 +291,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 self.initialized = True
             except (ClientConnectorError, asyncio.TimeoutError) as exception:
                 _LOGGER.warning(exception)
-                # Pass the exception on up.
+                # Pass the exception on up. Our caller
                 # homeassistant/helpers/update_coordinator.py:_async_refresh()
                 # gracefully handles some common errors like timeout and connection errors.
                 raise

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -9,7 +9,7 @@ import time
 
 from datetime import timedelta
 
-from aiohttp import ClientError, ClientResponseError, ClientSession, TCPConnector
+from aiohttp import ClientError, ClientResponseError, ClientConnectorError, ClientSession, TCPConnector
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, PlatformNotReady
@@ -280,9 +280,18 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     await self.async_start_vto_event_listener()
 
                 self.initialized = True
+            except ClientConnectorError as exception:
+                #_LOGGER.warning(exception)
+                raise
+                # raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet") from exception
             except Exception as exception:
+                _LOGGER.warning("before")
                 _LOGGER.error("Failed to initialize device at %s", self._address, exc_info=exception)
-                raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet")
+                _LOGGER.warning("after")
+                _LOGGER.warning("after2: %s" % exception)
+                _LOGGER.warning("after3: %s" % dir(exception))
+                _LOGGER.warning("after4")
+                raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet") from exception
 
         # This is the event loop code that's called every n seconds
         try:


### PR DESCRIPTION
A bit of cleanup around log messages and error handling when connection to a camera fails (e.g., the camera isn't plugged in). The component used to add a lot of long stack trace and error messages if a connection error happened. Now it's more like a single warning line saying the connection failed (with host & port).