### PR TITLE
fix MaxExtraStream spelling

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -139,7 +139,7 @@ class DahuaClient:
         """ get_max_extra_streams returns the max number of sub streams supported by the camera """
         try:
             result = await self.get("/cgi-bin/magicBox.cgi?action=getProductDefinition&name=MaxExtraStream")
-            return int(result.get("table.MaxExtraStreams", "2"))
+            return int(result.get("table.MaxExtraStream", "2"))
         except aiohttp.ClientResponseError as e:
             pass
         # If we can't fetch, just assume 2 since that's pretty standard


### PR DESCRIPTION
the checker is looking for the wrong spelling
checked my XVR (BNC) and its showing 1 extra stream `table.MaxExtraStream=1`
checked my NVR (IP) which returns 2 extra stream `table.MaxExtraStream=2`

also fixes my other issue where the XVR keeps returning 3 streams
because it cant find the value so just assumes its 2 extra streams when really it should be 1
