### PR TITLE
VTO buffer and keepalive fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Brand | 2 Megapixels | 4 Megapixels | 5 Megapixels | 8 Megapixels
 | *Dahua* |
 | | DHI-VTO2202F-P |
 | | DHI-VTO2211G-P |
+| | DHI-VTO3311Q-WP |
 | *IMOU* |
 | | IMOU C26EP-V2 |
 

--- a/custom_components/dahua/vto.py
+++ b/custom_components/dahua/vto.py
@@ -337,6 +337,12 @@ class DahuaVTOClient(asyncio.Protocol):
         def handle_keep_alive(message):
             Timer(self.keep_alive_interval, self.keep_alive).start()
 
+            message_id = message.get('id')
+            if message_id is not None and message_id in self.data_handlers:
+                del self.data_handlers[message_id]
+            else:
+                _LOGGER.warning(f'Could not delete keep alive handler with message ID {message_id}.')
+
         request_data = {
             "timeout": self.keep_alive_interval,
             "action": True


### PR DESCRIPTION
I had some issues running this integration with DHI-VTO3311Q-WP. After some time, the integration stopped working and I had to restart homeassistant to fix it.

After some debugging, it turns out that asyncio does not forward the entire message to the data_received function if the message is too large. In turn this sometimes messes up the future messages and the integration stops working. To remedy that, I added a buffer to the data_received function.

During debugging I also noticed that data_handlers is growing due to keep_alive handlers being added constantly. To fix that I added code to remove the handler after response from keep-alive has been received. I don't think this has anything to do with the above issue, however I still think it should be fixed.

And for the last change - I added DHI-VTO3311Q-WP to the list of supported devices, since I had no further issues running the integration with the above fixes.