### PR TITLE
Update night switch mode for specific NVR and IPC models

### DIFF
--- a/custom_components/dahua/camera.py
+++ b/custom_components/dahua/camera.py
@@ -316,7 +316,7 @@ class DahuaCamera(DahuaBaseEntity, Camera):
         channel = self._coordinator.get_channel()
         model = self._coordinator.get_model()
         # Some NVRs like the Lorex DHI-NVR4108HS-8P-4KS2 change the day/night mode through a switch
-        if 'NVR4108HS' in model:
+        if 'NVR4108HS' or 'IPC-Color4K' in model:
             await self._coordinator.client.async_set_night_switch_mode(channel, mode)
         else:
             await self._coordinator.client.async_set_video_profile_mode(channel, mode)


### PR DESCRIPTION
I recently purchased an IPC-Color4K-T-2.8mm and while integrating it with Home Assistant, the call to flip between day and night mode was failing with a "501 Not Implemented", after looking at some tcpdump traffic and also the ipcamtalk forums, this camera seems to use the newer web 5.0 interface. I found a string in the forums that worked. Originally i modified the call `async_set_video_profile_mode`, and that worked, but then i noticed that the call for `async_set_night_switch_mode` is basically the same code as what i had modified.

I went back and found the logic in camera.py on line 319 and added part of this camera model there (they also make an X model and a 3.6mm version of each, so i trimmed the model name a bit). Not sure if this model logic should be handled in a different way, but im already running this at home and its working. (Trace log from home assistant)

> Triggered by the numeric state of sun.sun at December 31, 2023 at 7:46:06 AM
> Call a service 'Dahua: Set Dahua Video Profile Mode To Day or Night' on driveway_dahua
> Finished at December 31, 2023 at 7:46:08 AM (runtime: 1.51 seconds)
