### PR TITLE
Fix HA camera deprecated constant

### DIFF
--- a/custom_components/dahua/camera.py
+++ b/custom_components/dahua/camera.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
-from homeassistant.components.camera import SUPPORT_STREAM, Camera
+from homeassistant.components.camera import Camera, CameraEntityFeature
 
 from custom_components.dahua import DahuaDataUpdateCoordinator
 from custom_components.dahua.entity import DahuaBaseEntity
@@ -254,8 +254,8 @@ class DahuaCamera(DahuaBaseEntity, Camera):
 
     @property
     def supported_features(self):
-        """Return supported features."""
-        return SUPPORT_STREAM
+        """Flag supported features."""
+        return CameraEntityFeature.STREAM
 
     async def stream_source(self):
         """Return the RTSP stream source."""
@@ -325,7 +325,7 @@ class DahuaCamera(DahuaBaseEntity, Camera):
         """ Handles the service call from SERVICE_SET_INFRARED_MODE to set zoom and focus """
         await self._coordinator.client.async_adjustfocus_v1(focus, zoom)
         await self._coordinator.async_refresh()
-        
+
     async def async_set_privacy_masking(self, index: int, enabled: bool):
         """ Handles the service call from SERVICE_SET_PRIVACY_MASKING to control the privacy masking """
         await self._coordinator.client.async_setprivacymask(index, enabled)

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Dahua",
     "hacs": "1.6.0",
-    "homeassistant": "2021.7.0",
+    "homeassistant": "2024.1.0",
     "render_readme": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-homeassistant~=2021.7.0
+homeassistant~=2024.1.0
 ha-ffmpeg==3.0.2
 voluptuous~=0.12.1
 aiohttp~=3.7.4.post0


### PR DESCRIPTION
Since HA core 2024.1.0 `supported_features` should use the `CameraEntityFeature` `IntFlag`
https://developers.home-assistant.io/docs/core/entity/camera/#supported-features
`SUPPORT_STREAM` will be removed in HA Core 2025.1

Fixes https://github.com/rroller/dahua/issues/328

PR for fixing Light deprecated constants will follow