### PR TITLE
Illuminator support for IPC-HFW2439SP-SA-LED-S2

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -131,6 +131,8 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         self._address = address
         self._max_streams = 3  # 1 main stream + 2 sub-streams by default
 
+        self._supports_lighting_v2 = False
+
         # channel_number is not the channel_index. channel_number is the index + 1.
         # So channel index 0 is channel number 1. Except for some older firmwares where channel
         # and channel number are the same! We check for this in _async_update_data and adjust the
@@ -280,6 +282,16 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     pass
                 _LOGGER.info("Device supports infrared lighting=%s", self.supports_infrared_light())
 
+#Checking lighting_v2 support
+                try:
+                    await self.client.async_get_lighting_v2()
+                    self._supports_lighting_v2 = True
+                except ClientError:
+                    self._supports_lighting_v2 = False
+                    pass
+                _LOGGER.info("Device supports Lighting_V2=%s", self._supports_lighting_v2)
+
+
                 if not is_doorbell:
                     # Start the event listeners for IP cameras
                     await self.async_start_event_listener()
@@ -338,6 +350,9 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 coros.append(asyncio.ensure_future(self.client.async_get_video_analyse_rules_for_amcrest()))
             if self.is_amcrest_doorbell():
                 coros.append(asyncio.ensure_future(self.client.async_get_light_global_enabled()))
+            if self._supports_lighting_v2:   #add lighing_v2 API if it is supported
+                coros.append(asyncio.ensure_future(self.client.async_get_lighting_v2()))
+
 
             # Gather results and update the data map
             results = await asyncio.gather(*coros)
@@ -581,7 +596,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         """
         if not self._supports_lighting:
             return False
-        return "-AS-PV" not in self.model and "-AS-NI" not in self.model
+        return "-AS-PV" not in self.model and "-AS-NI" not in self.model and "LED-S2" not in self.model     #IPC-HFW2439SP-SA-LED-S2 also has no infrared light
 
     def supports_floodlightmode(self) -> bool:
         """ Returns true if this camera supports floodlight mode """
@@ -592,9 +607,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         Returns true if this camera has an illuminator (white light for color cameras).  For example, the
         IPC-HDW3849HP-AS-PV does
         """
-        return not (
-            self.is_amcrest_doorbell() or self.is_flood_light()) and "table.Lighting_V2[{0}][0][0].Mode".format(
-            self._channel) in self.data
+        return  not (self.is_amcrest_doorbell() or self.is_flood_light()) and "table.Lighting_V2[{0}][0][0].Mode".format(self._channel) in self.data   
 
     def is_motion_detection_enabled(self) -> bool:
         """ Returns true if motion detection is enabled for the camera """
@@ -651,7 +664,9 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
     def is_infrared_light_on(self) -> bool:
         """ returns true if the infrared light is on """
-        return self.data.get("table.Lighting[{0}][0].Mode".format(self._channel), "") == "Manual"
+        _LOGGER.info("is_infrared_on_channel=%s", self._channel)
+ #       _LOGGER.info("infrared_state=%s", self.data.get("table.Lighting[{0}][0].Mode".format(self._channel),""))
+        return self.data.get("table.Lighting[{0}][0].Mode".format(self._channel),"") == "Manual"
 
     def get_infrared_brightness(self) -> int:
         """Return the brightness of this light, as reported by the camera itself, between 0..255 inclusive"""
@@ -662,8 +677,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     def is_illuminator_on(self) -> bool:
         """Return true if the illuminator light is on"""
         # profile_mode 0=day, 1=night, 2=scene
-        profile_mode = self.get_profile_mode()
-
+        profile_mode = self.get_profile_mode()       
         return self.data.get("table.Lighting_V2[{0}][{1}][0].Mode".format(self._channel, profile_mode), "") == "Manual"
 
     def is_flood_light_on(self) -> bool:

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -664,8 +664,6 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
     def is_infrared_light_on(self) -> bool:
         """ returns true if the infrared light is on """
-        _LOGGER.info("is_infrared_on_channel=%s", self._channel)
- #       _LOGGER.info("infrared_state=%s", self.data.get("table.Lighting[{0}][0].Mode".format(self._channel),""))
         return self.data.get("table.Lighting[{0}][0].Mode".format(self._channel),"") == "Manual"
 
     def get_infrared_brightness(self) -> int:


### PR DESCRIPTION
Added check for Lighing_V2 support and API call if it supported in init.py

Also edit check for infrared light support. IPC-HFW2439SP-SA-LED-S2 has no infrared light but it was found by integration.