### PR TITLE
Fix light with supported_features and add supported_color_modes

### DIFF
--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -149,11 +149,16 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
     def color_mode(self) -> ColorMode | str | None:
         """Return the color mode of the light."""
         return ColorMode.BRIGHTNESS
+    
+    @property
+    def supported_color_modes(self) -> set[str]:
+        """Flag supported color modes."""
+        return {self.color_mode}
 
     @property
     def supported_features(self):
         """Flag supported features."""
-        return 0
+        return {0}
 
     @property
     def should_poll(self):


### PR DESCRIPTION
After updating to hass 2025.1.0 the binary sensor light entries no longer worked with following error:
```
...
  File "/usr/src/homeassistant/homeassistant/components/light/__init__.py", line 1116, in capability_attributes
    if LightEntityFeature.EFFECT in supported_features:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'int' is not iterable
```

fix: return dict `{0}` instead of int `0`

and also while at it fixed deprecated logs of:

```

2025-01-05 20:36:11.843 WARNING (MainThread) [homeassistant.components.light] None (<class 'custom_components.dahua.light.DahuaIlluminator'>) does not set supported color modes, this will stop working in Home Assistant Core 2025.3, please create a bug report at https://github.com/rroller/dahua/issues
2025-01-05 20:36:12.014 WARNING (MainThread) [homeassistant.components.light] None (<class 'custom_components.dahua.light.DahuaIlluminator'>) does not set supported color modes, this will stop working in Home Assistant Core 2025.3, please create a bug report at https://github.com/rroller/dahua/issues
``` 