### PR TITLE
Removed manual setting of self.config_entry

### DIFF
--- a/custom_components/dahua/config_flow.py
+++ b/custom_components/dahua/config_flow.py
@@ -148,7 +148,7 @@ class DahuaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
-        return DahuaOptionsFlowHandler(config_entry)
+        return DahuaOptionsFlowHandler()
 
     async def _show_config_form_user(self, user_input):  # pylint: disable=unused-argument
         """Show the configuration form to edit camera name."""
@@ -200,13 +200,9 @@ class DahuaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 class DahuaOptionsFlowHandler(config_entries.OptionsFlow):
     """Dahua config flow options handler."""
 
-    def __init__(self, config_entry):
-        """Initialize HACS options flow."""
-        self.config_entry = config_entry
-        self.options = dict(config_entry.options)
-
     async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument
         """Manage the options."""
+        self.options = dict(self.config_entry.options)
         return await self.async_step_user()
 
     async def async_step_user(self, user_input=None):


### PR DESCRIPTION
This is a fix for #440 and removes the deprecated option of setting the self.config_entry in the OptionsFlowHandler (see https://developers.home-assistant.io/blog/2024/11/12/options-flow/)

Successfully tested locally