### PR TITLE
Deprecation fixes for Illuminator and FloodLight

### DIFF
--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -261,6 +261,16 @@ class FloodLight(DahuaBaseEntity, LightEntity):
     def supported_features(self):
         """Flag supported features."""
         return LightEntityFeature.EFFECT
+    
+    @property
+    def color_mode(self) -> ColorMode | str | None:
+        """Return the color mode of the light."""
+        return ColorMode.ONOFF
+
+    @property
+    def supported_color_modes(self) -> set[str]:
+        """Flag supported color modes."""
+        return {self.color_mode}
 
     @property
     def should_poll(self):

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -149,11 +149,11 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
     def color_mode(self) -> ColorMode | str | None:
         """Return the color mode of the light."""
         return ColorMode.BRIGHTNESS
-
+    
     @property
-    def supported_features(self):
-        """Flag supported features."""
-        return 0
+    def supported_color_modes(self) -> set[str]:
+        """Flag supported color modes."""
+        return {self.color_mode}
 
     @property
     def should_poll(self):


### PR DESCRIPTION
- Removed `supported_features` (return 0) from Illuminator. Fixing deprecation mentioned in https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation/ Fixes #443 and #438  
- Added `supported_color_modes` to Illuminator. Fixing deprecation mentioned in https://developers.home-assistant.io/blog/2024/02/12/light-color-mode-mandatory/ Fixes #438 
- Also added `color_mode` and `supported_color_modes` to FloodLight.