### PR TITLE
Fixing hassfest validation

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -50,16 +50,6 @@ SSL_CONTEXT.verify_mode = ssl.CERT_NONE
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
-
-async def async_setup(hass: HomeAssistant, config: ConfigType):
-    """
-    Set up this integration with the UI. YAML is not supported.
-    https://developers.home-assistant.io/docs/asyncio_working_with_async/
-    """
-    hass.data.setdefault(DOMAIN, {})
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up this integration using UI."""
     if hass.data.get(DOMAIN) is None:

--- a/custom_components/dahua/manifest.json
+++ b/custom_components/dahua/manifest.json
@@ -1,14 +1,12 @@
 {
   "domain": "dahua",
   "name": "Dahua",
-  "iot_class": "local_polling",
-  "documentation": "https://github.com/rroller/dahua",
-  "issue_tracker": "https://github.com/rroller/dahua/issues",
-  "dependencies": [],
-  "version": "0.9.71",
-  "config_flow": true,
   "codeowners": [
     "@rroller"
   ],
-  "requirements": []
+  "config_flow": true,
+  "documentation": "https://github.com/rroller/dahua",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/rroller/dahua/issues",
+  "version": "0.9.71"
 }

--- a/custom_components/dahua/manifest.json
+++ b/custom_components/dahua/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "dahua",
   "name": "Dahua",
+  "after_dependencies": ["tag"],
   "codeowners": [
     "@rroller"
   ],

--- a/custom_components/dahua/services.yaml
+++ b/custom_components/dahua/services.yaml
@@ -10,6 +10,7 @@ set_infrared_mode:
       domain: camera
   fields:
     mode:
+      name: Mode
       description: "The infrared mode: Auto, On, Off"
       example: "Auto"
       default: "Auto"
@@ -20,6 +21,7 @@ set_infrared_mode:
             - "On"
             - "Off"
     brightness:
+      name: Brightness
       description: The infrared brightness, from 0 to 100 inclusive. 100 is the brightest
       example: 100
       default: 100
@@ -40,6 +42,7 @@ set_video_profile_mode:
       domain: camera
   fields:
     mode:
+      name: Mode
       description: "The profile: Day, Night"
       example: "Day"
       selector:
@@ -266,6 +269,7 @@ set_video_in_day_night_mode:
       domain: camera
   fields:
     config_type:
+      name: Config Type
       description: "The config type: general, day, night"
       example: "general"
       default: "general"
@@ -276,6 +280,7 @@ set_video_in_day_night_mode:
             - "day"
             - "night"
     mode:
+      name: Mode
       description: "The mode: Auto, Color, BlackWhite. Note Auto is also known as Brightness by Dahua"
       example: "Auto"
       default: "Auto"
@@ -303,6 +308,7 @@ set_record_mode:
       domain: camera
   fields:
     mode:
+      name: Mode
       description: "The mode: Auto, On, Off"
       example: "Auto"
       default: "Auto"


### PR DESCRIPTION
I noticed that my previous PRs failed the hassfest validation on existing code. This change should bring that code in line with the hassfest checks.
```
Error: R] [DEPENDENCIES] Using component tag but it's not in 'dependencies' or 'after_dependencies'
```
- Fixed in `manifest.json` by adding `tag` to `after_dependencies`. It was triggered because of `from homeassistant.components.tag import async_scan_tag` in `__init__.py`. Added the `after_dependencies` makes sure that the home assistant tag component is loaded before the Dahua integration. 
- Also reordered the fields in `manifest.json` as "Manifest keys should be sorted: domain, name, then alphabetical order"

```
Error: R] [SERVICES] Service set_infrared_mode has a field mode with no name and is not in the translations file
Error: R] [SERVICES] Service set_infrared_mode has a field brightness with no name and is not in the translations file
Error: R] [SERVICES] Service set_video_profile_mode has a field mode with no name and is not in the translations file
Error: R] [SERVICES] Service set_video_in_day_night_mode has a field config_type with no name and is not in the translations file
Error: R] [SERVICES] Service set_video_in_day_night_mode has a field mode with no name and is not in the translations file
Error: R] [SERVICES] Service set_record_mode has a field mode with no name and is not in the translations file
```
- Fixed in `services.yaml` by adding a name attribute to the mentioned fields.

```
Warning: G] [CONFIG_SCHEMA] Integrations which implement 'async_setup' or 'setup' must define either 'CONFIG_SCHEMA', 'PLATFORM_SCHEMA' or 'PLATFORM_SCHEMA_BASE'. If the integration has no configuration parameters, can only be set up from platforms or can only be set up from config entries, one of the helpers cv.empty_config_schema, cv.platform_only_config_schema or cv.config_entry_only_config_schema can be used.
```
- Fixed in `__init__.py` by removing `async_setup` as its not implemented and YAML setup is not supported