### PR TITLE
Update pytest-homeassistant-custom-component to fix test failures

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,1 @@
-pytest-homeassistant-custom-component==0.13.133
+pytest-homeassistant-custom-component==0.13.286


### PR DESCRIPTION
## Issue
All tests have been failing with:
```
AttributeError: module 'josepy' has no attribute 'ComparableX509'
```

## Fix
Update `pytest-homeassistant-custom-component` from 0.13.133 to 0.13.286 to resolve compatibility with newer josepy versions.

## Testing
Verified locally that pytest can now import dependencies and collect tests without errors.