### PR TITLE
Fix event stream disconnections with heartbeat monitoring

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -763,12 +763,32 @@ class DahuaClient:
 
             try:
                 auth = DigestAuth(self._username, self._password, self._session)
-                response = await auth.request("GET", url)
+                response = await auth.request("GET", url, timeout=aiohttp.ClientTimeout(total=3600))
                 response.raise_for_status()
 
                 # https://docs.aiohttp.org/en/stable/streams.html
-                async for data, _ in response.content.iter_chunks():
-                    on_receive(data, channel)
+                # Monitor heartbeat - timeout if no data for 15 seconds (3x heartbeat interval)
+                chunk_iterator = response.content.iter_chunks()
+
+                while True:
+                    try:
+                        # Wait for next chunk with 15-second timeout
+                        data, _ = await asyncio.wait_for(
+                            chunk_iterator.__anext__(),
+                            timeout=15.0
+                        )
+
+                        on_receive(data, channel)
+
+                    except asyncio.TimeoutError:
+                        _LOGGER.debug("No data received for 15+ seconds, reconnecting...")
+                        raise
+                    except StopAsyncIteration:
+                        break
+
+            except asyncio.TimeoutError:
+                # Re-raise to trigger reconnection in thread.py
+                raise
             except Exception as exception:
                 pass
             finally:


### PR DESCRIPTION
## Summary
Fixes event stream disconnections by implementing heartbeat monitoring to detect camera restarts and network issues.

## Changes
- Implement 15-second heartbeat monitoring with `asyncio.wait_for()` to detect missed heartbeats
- Reconnect automatically when camera stops sending heartbeats (camera restarts, network issues)
- Add 1-hour timeout as fallback (was using 5-minute default that caused frequent disconnections)

## Testing
Tested for 38+ hours:
- Camera events continue working after camera restarts (3 restarts tested, all detected and recovered within 15 seconds)
- No missed events during entire test period
- Fallback 1-hour timeout working as safety net

Fixes issues where camera events would stop working after camera restarts or disconnect every 5 minutes due to default timeout.