### PR TITLE
Fix SmartMotionHuman/Vehicle not triggered with CrossLine/CrossRegion events

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -594,6 +594,11 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         if code == "CrossLineDetection" or code == "CrossRegionDetection":
             data = event.get("data", event.get("Data", {}))
             is_human = data.get("Object", {}).get("ObjectType", "").lower() == "human"
+            is_vehicle = data.get("Object", {}).get("ObjectType", "").lower() == "vehicle"
+            if is_human and self._dahua_event_listeners.get(self.get_event_key("SmartMotionHuman")) is not None:
+                return "SmartMotionHuman"
+            if is_vehicle and self._dahua_event_listeners.get(self.get_event_key("SmartMotionVehicle")) is not None:
+                return "SmartMotionVehicle"
             if is_human and self._dahua_event_listeners.get(self.get_event_key(code)) is None:
                 return "SmartMotionHuman"
 


### PR DESCRIPTION
## Problem

When both `CrossLineDetection`/`CrossRegionDetection` and `SmartMotionHuman` are included in the configured events list, `translate_event_code()` fails to translate CrossLine/CrossRegion events with `ObjectType=Human` into `SmartMotionHuman`. This leaves the `SmartMotionHuman` binary sensor permanently off, even though the camera correctly detects humans.

### Root cause

In `translate_event_code()`, the existing logic at line 597:

```python
if is_human and self._dahua_event_listeners.get(self.get_event_key(code)) is None:
    return "SmartMotionHuman"
```

checks whether the listener for the **CrossLineDetection** event key is `None`. But when both `CrossLineDetection` and `SmartMotionHuman` are in the events list, the CrossLineDetection listener **is** registered, so `get()` returns the listener (not `None`), and the condition always evaluates to `False`. The translation never happens.

This affects users who have both IVS (CrossLineDetection/CrossRegionDetection) and SmartMotion events enabled — a common setup with WizSense cameras (e.g. IPC-HDW3441TM-AS) connected through an NVR.

## Fix

Added a priority check **before** the existing fallback: if a `SmartMotionHuman` or `SmartMotionVehicle` listener exists, translate to it directly when the `ObjectType` matches. The original fallback logic is preserved for backward compatibility (translates to SmartMotionHuman when no CrossLine listener exists).

```python
is_vehicle = data.get("Object", {}).get("ObjectType", "").lower() == "vehicle"
if is_human and self._dahua_event_listeners.get(self.get_event_key("SmartMotionHuman")) is not None:
    return "SmartMotionHuman"
if is_vehicle and self._dahua_event_listeners.get(self.get_event_key("SmartMotionVehicle")) is not None:
    return "SmartMotionVehicle"
```

## Testing

- Tested with 4x IPC-HDW3441TM-AS cameras connected via NVR DHI-NVR4104HS-P-4KS2
- Both `CrossRegionDetection` and `SmartMotionHuman` in the events list
- Before fix: `SmartMotionHuman` binary sensors never turned on
- After fix: `SmartMotionHuman` correctly triggers on human detection events
- No regressions observed on other event types