### PR TITLE
Fix #558 - Deadlock on AccessControl

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -484,9 +484,9 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             card_id = event.get("Data", {}).get("CardNo", "")
             if card_id:
                 card_id_md5 = hashlib.md5(card_id.encode()).hexdigest()
-                asyncio.run_coroutine_threadsafe(
-                    async_scan_tag(self.hass, card_id_md5, self.get_device_name()), self.hass.loop
-                ).result()
+                self.hass.async_create_task(
+                    async_scan_tag(self.hass, card_id_md5, self.get_device_name())
+                )
 
         listener = self._dahua_event_listeners.get(event_key)
         if listener is not None:


### PR DESCRIPTION
Fix #558 - Deadlock on AccessControl Event 

When a Dahua VTO successfully scans a fingerprint or an NFC tag, the integration completely freezes the Home Assistant Core instance. The system becomes entirely unresponsive, and no further logs or automations execute until the Home Assistant container is forcefully restarted.

Analysis showed that the refactoring of the async flows was forgotten here, making the integration wait on the main thread.

Tested successfully for 3 days in my own instance.