### PR TITLE
Fix disarming linkage 400 error on cameras without channel-indexed config

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -630,7 +630,12 @@ class DahuaClient:
             value = "true"
 
         url = "/cgi-bin/configManager.cgi?action=setConfig&DisableLinkage[{0}].Enable={1}".format(channel, value)
-        return await self.get(url)
+        try:
+            return await self.get(url)
+        except aiohttp.ClientResponseError:
+            # Some cameras (e.g. DH-P3D-3F-PV-P) don't support channel-indexed disarming linkage
+            url = "/cgi-bin/configManager.cgi?action=setConfig&DisableLinkage.Enable={0}".format(value)
+            return await self.get(url)
 
     async def async_set_event_notifications(self, channel: int, enabled: bool) -> dict:
         """
@@ -642,7 +647,12 @@ class DahuaClient:
             value = "false"
 
         url = "/cgi-bin/configManager.cgi?action=setConfig&DisableEventNotify[{0}].Enable={1}".format(channel, value)
-        return await self.get(url)
+        try:
+            return await self.get(url)
+        except aiohttp.ClientResponseError:
+            # Some cameras (e.g. DH-P3D-3F-PV-P) don't support channel-indexed event notifications
+            url = "/cgi-bin/configManager.cgi?action=setConfig&DisableEventNotify.Enable={0}".format(value)
+            return await self.get(url)
 
     async def async_set_record_mode(self, channel: int, mode: str) -> dict:
         """


### PR DESCRIPTION
## Summary
- Some cameras (e.g. DH-P3D-3F-PV-P) return `400 Bad Request` when setting `DisableLinkage` and `DisableEventNotify` with a channel index, even though the read (`getConfig`) succeeds
- Fall back to the non-indexed URL if the channel-indexed `setConfig` call fails

## Test plan
- Tested on DH-P3D-3F-PV-P (firmware 3.000.0000000.6.R, build:2025-09-25)
- Toggling Disarming and Event Notifications switches in Home Assistant now works without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)