### PR TITLE
fix: use split('=', 1) in parse_event to handle '=' in values (#477)

### DIFF
--- a/.agents/summary/architecture.md
+++ b/.agents/summary/architecture.md
@@ -1,0 +1,99 @@
+# Architecture
+
+## System Architecture
+
+```mermaid
+graph TB
+    subgraph "Home Assistant"
+        CF[Config Flow<br/>config_flow.py]
+        COORD[DahuaDataUpdateCoordinator<br/>__init__.py]
+        CAM[Camera Entity<br/>camera.py]
+        BS[Binary Sensors<br/>binary_sensor.py]
+        SW[Switches<br/>switch.py]
+        LT[Lights<br/>light.py]
+        SEL[Select Entities<br/>select.py]
+        BASE[DahuaBaseEntity<br/>entity.py]
+        EB[HA Event Bus]
+    end
+
+    subgraph "API Layer"
+        CLIENT[DahuaClient<br/>client.py]
+        DIGEST[DigestAuth<br/>digest.py]
+        VTO[DahuaVTOClient<br/>vto.py]
+        RPC2[DahuaRpc2Client<br/>rpc2.py]
+    end
+
+    subgraph "Dahua Device"
+        CGI[CGI HTTP API]
+        RTSP[RTSP Stream]
+        VTOP[VTO TCP:5000]
+        RPC2P[RPC2 JSON API]
+    end
+
+    CF -->|creates| COORD
+    COORD -->|manages| CAM
+    COORD -->|manages| BS
+    COORD -->|manages| SW
+    COORD -->|manages| LT
+    COORD -->|manages| SEL
+    CAM --> BASE
+    BS --> BASE
+    SW --> BASE
+    LT --> BASE
+    SEL --> BASE
+
+    COORD -->|polling + commands| CLIENT
+    COORD -->|event streaming| CLIENT
+    COORD -->|VTO events| VTO
+    COORD -->|fires events| EB
+    BS -->|listens| EB
+
+    CLIENT -->|digest auth| DIGEST
+    CLIENT -->|HTTP GET| CGI
+    CLIENT -->|RTSP URL| RTSP
+    VTO -->|binary protocol| VTOP
+    RPC2 -->|JSON POST| RPC2P
+```
+
+## Design Patterns
+
+### Coordinator Pattern
+The integration uses Home Assistant's `DataUpdateCoordinator` pattern. `DahuaDataUpdateCoordinator` is the central hub that:
+1. Initializes device capabilities on first refresh (feature detection)
+2. Polls device state every 30 seconds via `_async_update_data`
+3. Manages persistent event stream connections (IP cameras and VTO doorbells)
+4. Stores event timestamps for binary sensor state
+5. Provides capability-check methods consumed by entities
+
+### Feature Detection
+During initialization, the coordinator probes the device to determine supported features:
+- Coaxial control (speaker/white light)
+- Disarming linkage
+- Smart motion detection
+- PTZ position
+- Lighting (IR and V2)
+- Profile modes
+- Floodlight mode
+
+Each probe wraps the API call in a try/except — if the call fails, the feature is marked unsupported.
+
+### Dual Event Streaming
+Two separate event streaming mechanisms exist:
+1. **IP Camera events**: HTTP long-polling via `eventManager.cgi?action=attach` — parsed from `--myboundary`-delimited text with `Code=X;action=Y;index=Z;data={...}` format
+2. **VTO/Doorbell events**: Binary TCP protocol on port 5000 using `asyncio.Protocol` — JSON messages wrapped in a 32-byte binary header (DHIP protocol)
+
+Both streams fire events on the HA event bus as `dahua_event_received`.
+
+### Entity Hierarchy
+All entities inherit from `DahuaBaseEntity` → `CoordinatorEntity`, which provides:
+- Device info (model, serial, firmware, manufacturer)
+- Unique ID based on serial number
+- Automatic state updates from coordinator data
+
+### API Communication
+- **Primary**: `DahuaClient` uses HTTP GET with Digest Auth to Dahua CGI endpoints
+- **Alternative**: `DahuaRpc2Client` uses HTTP POST with JSON-RPC to `/RPC2` endpoint
+- **VTO**: `DahuaVTOClient` uses a custom binary TCP protocol with MD5 challenge-response auth
+
+### Channel Handling
+The integration supports multi-channel devices (NVRs). Channel index is 0-based, but channel number is 1-based (index + 1). Some older firmwares use the same value for both — the coordinator detects this during initialization by attempting a snapshot with channel 0.

--- a/.agents/summary/codebase_info.md
+++ b/.agents/summary/codebase_info.md
@@ -1,0 +1,79 @@
+# Codebase Information
+
+## Project Overview
+
+- **Name**: Dahua
+- **Domain**: `dahua`
+- **Version**: 0.9.81
+- **Type**: Home Assistant Custom Integration (HACS)
+- **Language**: Python
+- **IoT Class**: Local Polling
+- **Repository**: https://github.com/rroller/dahua
+- **Maintainer**: @rroller
+
+## Purpose
+
+Custom Home Assistant integration for Dahua IP cameras, doorbells (VTO), NVRs, and DVRs. Also supports rebranded devices from Amcrest, Lorex, IMOU, EmpireTech, and Avaloid Goliath.
+
+## Technology Stack
+
+- **Runtime**: Home Assistant (Python async)
+- **HTTP Client**: aiohttp with custom Digest Auth
+- **Camera Protocol**: RTSP for streaming, HTTP CGI API for control
+- **VTO Protocol**: Custom binary TCP protocol on port 5000 (RPC-style JSON over binary framing)
+- **Authentication**: HTTP Digest Auth (cameras), MD5 challenge-response (VTO)
+- **Installation**: HACS or manual copy to `custom_components/`
+
+## Directory Structure
+
+```
+dahua/
+├── custom_components/dahua/    # Main integration code
+│   ├── __init__.py             # Entry point, coordinator, event handling
+│   ├── client.py               # HTTP API client for Dahua CGI endpoints
+│   ├── camera.py               # Camera entity + service registrations
+│   ├── binary_sensor.py        # Event-driven binary sensors
+│   ├── switch.py               # Motion detection, siren, disarming switches
+│   ├── light.py                # Infrared, illuminator, flood, security lights
+│   ├── select.py               # Doorbell light mode, PTZ preset selects
+│   ├── button.py               # Placeholder (not yet implemented)
+│   ├── config_flow.py          # UI-based setup and reauthentication flow
+│   ├── const.py                # Constants, domain, platform list, icons
+│   ├── entity.py               # Base entity class (device info, unique ID)
+│   ├── dahua_utils.py          # Brightness conversion, event stream parsing
+│   ├── digest.py               # Custom aiohttp Digest Auth implementation
+│   ├── models.py               # Dataclass for coaxial control IO status
+│   ├── rpc2.py                 # RPC2 JSON API client (alternative API)
+│   ├── vto.py                  # VTO doorbell binary protocol client
+│   ├── services.yaml           # HA service definitions
+│   ├── manifest.json           # Integration manifest
+│   ├── translations/           # UI translations (en, es, fr, it, etc.)
+│   └── brand/                  # Brand icons and logos
+├── tests/                      # Test directory (minimal)
+├── scripts/                    # Dev scripts (develop, lint, setup)
+├── config/                     # HA dev config (configuration.yaml)
+├── .github/workflows/          # CI: push.yml, pull.yml
+├── .devcontainer.json          # VS Code devcontainer config
+├── requirements.txt            # Runtime dependencies
+├── requirements_dev.txt        # Dev dependencies
+├── requirements_test.txt       # Test dependencies
+└── setup.cfg                   # Flake8 and isort config
+```
+
+## Supported Platforms
+
+| Platform | Entity Type | Description |
+|----------|-------------|-------------|
+| `camera` | Camera | RTSP streaming, snapshots, service host |
+| `binary_sensor` | BinarySensor | Event-driven sensors (motion, tripwire, doorbell, etc.) |
+| `switch` | Switch | Motion detection, siren, disarming, smart motion |
+| `light` | Light | Infrared, illuminator, flood light, security light, ring light |
+| `select` | Select | Doorbell light mode, PTZ preset position |
+| `button` | Button | Placeholder (not implemented) |
+
+## CI/CD
+
+- **Push to master/dev**: HACS validation, Hassfest validation, Black formatting, pytest
+- **Pull requests**: Same pipeline
+- **Linting**: flake8 (via setup.cfg), Black formatter, isort
+- **Testing**: pytest with `pytest-homeassistant-custom-component`

--- a/.agents/summary/components.md
+++ b/.agents/summary/components.md
@@ -1,0 +1,129 @@
+# Components
+
+## DahuaDataUpdateCoordinator (`__init__.py`)
+
+Central coordinator managing all device communication and state.
+
+**Responsibilities:**
+- Device initialization and feature detection
+- Periodic state polling (30s interval)
+- Event stream management (IP camera and VTO)
+- Event listener registry and dispatch
+- Session lifecycle management
+
+**Key State:**
+- `self.data`: Dict of all polled device state (motion detection, lighting, profiles, etc.)
+- `self._dahua_event_listeners`: Dict mapping event keys to HA callbacks
+- `self._dahua_event_timestamp`: Dict mapping event keys to fire/clear timestamps
+- Feature flags: `_supports_coaxial_control`, `_supports_lighting`, `_supports_lighting_v2`, etc.
+
+**Event Translation:**
+- `CrossLineDetection`/`CrossRegionDetection` with `ObjectType=human` → also dispatches `SmartMotionHuman`
+- `BackKeyLight`/`PhoneCallDetect` → translated to `DoorbellPressed`
+
+## DahuaClient (`client.py`)
+
+HTTP API client wrapping Dahua's CGI-based HTTP API.
+
+**Responsibilities:**
+- All HTTP communication with the camera (GET requests with Digest Auth)
+- RTSP stream URL generation
+- API response parsing (key=value text → dict)
+- Event stream consumption (long-polling with `--myboundary` chunked responses)
+
+**Key Endpoints:**
+- `/cgi-bin/magicBox.cgi` — System info, device type, reboot, serial number
+- `/cgi-bin/configManager.cgi` — Get/set configuration (motion, lighting, IVS rules, etc.)
+- `/cgi-bin/coaxialControlIO.cgi` — Coaxial control (speaker, white light, siren)
+- `/cgi-bin/eventManager.cgi` — Event stream attachment
+- `/cgi-bin/snapshot.cgi` — Camera snapshots
+- `/cgi-bin/ptz.cgi` — PTZ control and status
+
+## DahuaVTOClient (`vto.py`)
+
+Binary TCP protocol client for VTO doorbell devices.
+
+**Responsibilities:**
+- TCP connection on port 5000
+- DHIP binary protocol framing (32-byte header + JSON payload)
+- MD5 challenge-response authentication
+- Event stream via `eventManager.attach`
+- Keep-alive management
+- Access control and door operations
+
+**Protocol:** Messages are JSON objects wrapped in a binary header with magic bytes `0x20000000 DHIP`.
+
+## Camera Entity (`camera.py`)
+
+HA camera entity providing streaming and snapshot capabilities, plus hosting most service registrations.
+
+**Responsibilities:**
+- RTSP stream source for live viewing
+- Snapshot capture
+- Motion detection enable/disable
+- Host for 18+ registered services (infrared mode, video profile, overlays, IVS rules, PTZ, reboot, etc.)
+
+**Streams:** Creates one entity per stream (1 main + N sub-streams, typically 3 total).
+
+## Binary Sensor Entity (`binary_sensor.py`)
+
+Event-driven binary sensors that turn on/off based on camera events.
+
+**Responsibilities:**
+- One sensor per selected event type (VideoMotion, CrossLineDetection, etc.)
+- Doorbell-specific sensors auto-added (DoorbellPressed, Invite, DoorStatus, CallNoAnswered)
+- Push-based state updates (no polling) via coordinator event listeners
+
+**Name Generation:** Event names are converted from CamelCase to spaced words (e.g., `SmartMotionHuman` → "Smart Motion Human") with overrides for common events.
+
+## Switch Entity (`switch.py`)
+
+Toggle switches for camera features.
+
+**Entities:**
+- Motion Detection — enable/disable motion detection
+- Siren — trigger camera siren (auto-off after ~10-15s)
+- Smart Motion Detection — enable/disable smart motion (Dahua and Amcrest variants)
+- Disarming Linkage — enable/disable disarming feature
+- Event Notifications — enable/disable event notifications when disarmed
+
+## Light Entity (`light.py`)
+
+Light controls for various camera illumination features.
+
+**Entities:**
+- `DahuaInfraredLight` — IR light with brightness control (Lighting V1 API)
+- `DahuaIlluminator` — White light with brightness control (Lighting V2 API)
+- `FloodLight` — Flood light for Amcrest/Dahua flood cameras (coaxial or V2 API)
+- `DahuaSecurityLight` — Red/blue flashing alarm light (coaxial API)
+- `AmcrestRingLight` — Blue ring light on Amcrest doorbells (LightGlobal API)
+
+## Select Entity (`select.py`)
+
+Dropdown selectors for multi-option features.
+
+**Entities:**
+- `DahuaDoorbellLightSelect` — Doorbell security light mode (Off/On/Strobe)
+- `DahuaCameraPresetPositionSelect` — PTZ preset position (Manual/1-10)
+
+## Config Flow (`config_flow.py`)
+
+UI-based setup and configuration flow.
+
+**Steps:**
+1. `user` — Credentials, address, port, channel, event selection
+2. `name` — Device name (pre-populated from camera)
+3. `reauth_confirm` — Re-authentication when credentials expire
+
+**Options Flow:** Toggle individual platforms on/off (binary_sensor, switch, light, camera, select).
+
+## Supporting Modules
+
+| Module | Purpose |
+|--------|---------|
+| `entity.py` | Base entity with device info and unique ID |
+| `const.py` | Constants: domain, platforms, config keys, icons |
+| `dahua_utils.py` | Brightness conversion, event stream text parsing |
+| `digest.py` | Custom aiohttp Digest Auth (aiohttp lacks native support) |
+| `models.py` | `CoaxialControlIOStatus` dataclass |
+| `rpc2.py` | Alternative RPC2 JSON API client (used by some devices) |

--- a/.agents/summary/data_models.md
+++ b/.agents/summary/data_models.md
@@ -1,0 +1,134 @@
+# Data Models
+
+## Core Data Structures
+
+### Coordinator State (`DahuaDataUpdateCoordinator.data`)
+
+The coordinator's `data` dict is a flat key-value store populated from Dahua API responses. Keys follow the Dahua API naming convention.
+
+```mermaid
+classDiagram
+    class CoordinatorData {
+        +str table.General.MachineName
+        +str table.MotionDetect[ch].Enable
+        +str table.Lighting[ch][mode].Mode
+        +str table.Lighting[ch][mode].MiddleLight[0].Light
+        +str table.Lighting_V2[ch][pm][idx].Mode
+        +str table.Lighting_V2[ch][pm][idx].MiddleLight[0].Light
+        +str table.Lighting_V2[ch][pm][idx].LightType
+        +str table.DisableLinkage.Enable
+        +str table.DisableEventNotify.Enable
+        +str table.SmartMotionDetect[0].Enable
+        +str table.VideoAnalyseRule[ch][idx].Enable
+        +str table.VideoInMode[0].Config[0]
+        +str table.LightGlobal[0].Enable
+        +str status.status.Speaker
+        +str status.status.WhiteLight
+        +str status.PresetID
+        +str deviceType
+        +str serialNumber
+        +str version
+        +str model
+    }
+```
+
+All values are strings. Boolean checks compare against `"true"` / `"false"` (case-insensitive).
+
+### CoaxialControlIOStatus (`models.py`)
+
+```mermaid
+classDiagram
+    class CoaxialControlIOStatus {
+        +bool speaker
+        +bool white_light
+        +__post_init__(api_response)
+    }
+```
+
+Dataclass parsing RPC2 API response for speaker and white light status.
+
+### Event Data Structures
+
+#### IP Camera Event (parsed from HTTP stream)
+
+```python
+{
+    "Code": "VideoMotion",       # Event type
+    "action": "Start",           # Start, Stop
+    "index": "0",                # Channel index
+    "data": {                    # Optional JSON payload
+        "Id": [0],
+        "RegionName": ["Region1"],
+        "SmartMotionEnable": False
+    },
+    "name": "Cam13",             # Added by coordinator
+    "DeviceName": "Cam13"        # Added by coordinator
+}
+```
+
+#### VTO Event (from binary protocol)
+
+```python
+{
+    "Code": "BackKeyLight",
+    "Action": "Pulse",           # Note: capitalized vs IP camera
+    "Data": {
+        "LocaleTime": "2021-06-20 13:52:20",
+        "State": 1,
+        "UTC": 1624168340.0
+    },
+    "Index": -1,
+    "DeviceName": "Doorbell"     # Added by coordinator
+}
+```
+
+Note: VTO events use capitalized keys (`Action`, `Data`, `Index`) while IP camera events use lowercase (`action`, `data`, `index`).
+
+### Event Timestamp Registry
+
+```python
+# Key: "{event_name}-{channel}" → Value: epoch seconds (active) or 0 (cleared)
+_dahua_event_timestamp: Dict[str, int] = {
+    "VideoMotion-0": 1624168340,      # Active
+    "CrossLineDetection-0": 0,         # Cleared
+}
+```
+
+### Config Entry Data
+
+```python
+{
+    "username": str,
+    "password": str,
+    "address": str,       # IP address or hostname
+    "port": str,          # HTTP port (default "80")
+    "rtsp_port": str,     # RTSP port (default "554")
+    "channel": int,       # 0-based channel index
+    "name": str,          # User-assigned device name
+    "events": list[str],  # Selected event codes
+}
+```
+
+### Dahua API Response Format
+
+Dahua CGI APIs return plain text with `key=value` pairs, one per line:
+
+```
+table.MotionDetect[0].Enable=true
+table.MotionDetect[0].DetectVersion=V3.0
+```
+
+Parsed by `DahuaClient.parse_dahua_api_response()` into a flat dict.
+
+### DHIP Binary Protocol Frame
+
+```
+Bytes 0-3:   Magic (0x20000000)
+Bytes 4-7:   Protocol ID (0x44484950 = "DHIP")
+Bytes 8-15:  Reserved (0)
+Bytes 16-19: Payload length (little-endian)
+Bytes 20-23: Reserved (0)
+Bytes 24-27: Payload length (little-endian, repeated)
+Bytes 28-31: Reserved (0)
+Bytes 32+:   JSON payload (UTF-8)
+```

--- a/.agents/summary/dependencies.md
+++ b/.agents/summary/dependencies.md
@@ -1,0 +1,71 @@
+# Dependencies
+
+## Runtime Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `homeassistant` | ~=2025.1.2 | Home Assistant core framework |
+| `ha-ffmpeg` | 3.2.2 | FFmpeg integration for video streaming |
+| `colorlog` | 6.8.2 | Colored logging output |
+| `pip` | >=24.3.1 | Package installer |
+| `ruff` | 0.7.3 | Linter (listed in requirements but used for dev) |
+
+## Home Assistant Dependencies (from manifest.json)
+
+| Dependency | Relationship | Purpose |
+|------------|-------------|---------|
+| `tag` | `after_dependencies` | NFC tag scanning for VTO access control cards |
+
+## Key HA Framework Components Used
+
+| Component | Usage |
+|-----------|-------|
+| `homeassistant.helpers.update_coordinator.DataUpdateCoordinator` | Polling coordinator pattern |
+| `homeassistant.components.camera.Camera` | Camera entity base |
+| `homeassistant.components.binary_sensor.BinarySensorEntity` | Binary sensor base |
+| `homeassistant.components.switch.SwitchEntity` | Switch entity base |
+| `homeassistant.components.light.LightEntity` | Light entity base |
+| `homeassistant.components.select.SelectEntity` | Select entity base |
+| `homeassistant.components.tag.async_scan_tag` | NFC tag scanning |
+| `homeassistant.config_entries.ConfigFlow` | UI config flow |
+| `homeassistant.helpers.entity_platform` | Service registration |
+| `aiohttp.ClientSession` | Async HTTP client |
+| `voluptuous` | Service parameter validation |
+
+## Third-Party Libraries
+
+| Library | Usage |
+|---------|-------|
+| `aiohttp` | HTTP client for camera API communication |
+| `async_timeout` | Request timeout management |
+| `requests` | `HTTPDigestAuth` imported in VTO client (type hint only) |
+| `yarl` | URL parsing in digest auth |
+
+## Development Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `homeassistant` | Dev environment |
+
+## Test Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `pytest-homeassistant-custom-component` | 0.13.286 | HA custom component test framework |
+| `pycares` | >=4.0.0,<5.0.0 | Async DNS resolver (test dependency) |
+
+## External Services
+
+| Service | Protocol | Port | Purpose |
+|---------|----------|------|---------|
+| Dahua CGI API | HTTP/HTTPS | 80/443 | Device control and configuration |
+| RTSP Stream | RTSP | 554 | Live video streaming |
+| VTO Protocol | TCP | 5000 | Doorbell event streaming and control |
+| RPC2 API | HTTP/HTTPS | 80/443 | Alternative JSON-RPC API |
+
+## HACS Requirements
+
+| Field | Value |
+|-------|-------|
+| HACS version | >=1.6.0 |
+| Home Assistant | >=2025.1.2 |

--- a/.agents/summary/index.md
+++ b/.agents/summary/index.md
@@ -1,0 +1,66 @@
+# Documentation Index
+
+## Purpose
+
+This index serves as the primary entry point for AI assistants working with the Dahua Home Assistant integration codebase. It provides metadata about each documentation file to help determine which files contain relevant information for a given question.
+
+## How to Use This Index
+
+1. **Start here** — Read this file first to understand what documentation is available
+2. **Identify the topic** — Match your question to the relevant documentation file(s) below
+3. **Read targeted files** — Only read the specific files needed for your task
+4. **Cross-reference** — Use the relationships section to find related information
+
+## Documentation Files
+
+### [codebase_info.md](codebase_info.md)
+**When to consult:** Project overview questions, technology stack, directory layout, supported platforms, CI/CD pipeline.
+**Contains:** Project metadata, version, directory tree, platform table, CI workflow summary.
+
+### [architecture.md](architecture.md)
+**When to consult:** Understanding system design, component relationships, data flow, design patterns, how the coordinator works, event streaming architecture.
+**Contains:** System architecture diagram, coordinator pattern, dual event streaming, entity hierarchy, API communication patterns, channel handling.
+**Related to:** components.md (detailed component descriptions), workflows.md (runtime behavior)
+
+### [components.md](components.md)
+**When to consult:** Understanding what a specific module does, entity types and their responsibilities, which file to modify for a feature.
+**Contains:** Detailed descriptions of every module — coordinator, client, VTO client, camera, binary sensor, switch, light, select, config flow, and supporting modules.
+**Related to:** architecture.md (how components connect), interfaces.md (APIs they use)
+
+### [interfaces.md](interfaces.md)
+**When to consult:** API endpoint details, request/response formats, service definitions, event data structures, RTSP URL format.
+**Contains:** Complete CGI API reference, VTO protocol methods, RPC2 API, HA service list, event bus format, RTSP stream URLs.
+**Related to:** data_models.md (data structures), components.md (which components use which APIs)
+
+### [data_models.md](data_models.md)
+**When to consult:** Understanding data structures, coordinator state format, event payloads, config entry schema, binary protocol framing.
+**Contains:** Coordinator data dict keys, event data structures (IP vs VTO), config entry schema, DHIP binary frame format, API response format.
+**Related to:** interfaces.md (API that produces the data), workflows.md (how data flows)
+
+### [workflows.md](workflows.md)
+**When to consult:** Understanding runtime behavior, setup flow, initialization sequence, event processing pipeline, polling cycle, reconnection logic, service call flow.
+**Contains:** Sequence and flow diagrams for setup, initialization, event processing (IP and VTO), periodic polling, reconnection, and service calls.
+**Related to:** architecture.md (design context), components.md (which components participate)
+
+### [dependencies.md](dependencies.md)
+**When to consult:** Dependency versions, external service requirements, HA framework components used, test dependencies.
+**Contains:** Runtime, dev, and test dependency tables, HA framework component usage, external service ports and protocols.
+
+### [review_notes.md](review_notes.md)
+**When to consult:** Known documentation gaps, inconsistencies, improvement recommendations.
+**Contains:** Review findings, completeness gaps, consistency issues, and recommendations.
+
+## Quick Reference: Common Questions
+
+| Question | File(s) to Read |
+|----------|----------------|
+| "What does this integration do?" | codebase_info.md |
+| "How do I add a new entity type?" | components.md, architecture.md |
+| "What API endpoint does X use?" | interfaces.md |
+| "How are events processed?" | workflows.md, architecture.md |
+| "What's the coordinator state format?" | data_models.md |
+| "How does VTO authentication work?" | interfaces.md, components.md (vto.py section) |
+| "What services are available?" | interfaces.md |
+| "How does feature detection work?" | workflows.md (initialization), architecture.md |
+| "What are the dependencies?" | dependencies.md |
+| "What's missing or inconsistent?" | review_notes.md |

--- a/.agents/summary/interfaces.md
+++ b/.agents/summary/interfaces.md
@@ -1,0 +1,122 @@
+# Interfaces
+
+## Dahua CGI HTTP API
+
+All requests use HTTP GET with Digest Authentication. Responses are `key=value` text parsed into dicts.
+
+### System APIs (`/cgi-bin/magicBox.cgi`)
+
+| Action | Description |
+|--------|-------------|
+| `getSystemInfo` | Device type, serial number, hardware version |
+| `getDeviceType` | Device model |
+| `getSoftwareVersion` | Firmware version |
+| `getMachineName` | Device name |
+| `getVendor` | Manufacturer |
+| `getProductDefinition&name=MaxExtraStream` | Max sub-streams |
+| `reboot` | Reboot device |
+
+### Configuration APIs (`/cgi-bin/configManager.cgi`)
+
+| Action | Description |
+|--------|-------------|
+| `getConfig&name=MotionDetect` | Motion detection status |
+| `getConfig&name=Lighting[ch][mode]` | IR light config |
+| `getConfig&name=Lighting_V2` | White light / illuminator config |
+| `getConfig&name=SmartMotionDetect` | Smart motion detection status |
+| `getConfig&name=VideoAnalyseRule` | IVS rules |
+| `getConfig&name=DisableLinkage` | Disarming linkage status |
+| `getConfig&name=DisableEventNotify` | Event notification status |
+| `getConfig&name=VideoInMode` | Day/night profile mode |
+| `getConfig&name=General.MachineName` | Machine name |
+| `getConfig&name=FloodLightMode.Mode` | Floodlight mode |
+| `setConfig&MotionDetect[ch].Enable=bool` | Enable/disable motion |
+| `setConfig&Lighting[ch][0].Mode=mode` | Set IR light mode |
+| `setConfig&Lighting_V2[ch][pm][0].Mode=mode` | Set illuminator mode |
+| `setConfig&VideoAnalyseRule[ch][idx].Enable=bool` | Enable/disable IVS rule |
+| `setConfig&VideoWidget[ch].CustomTitle[g].Text=text` | Set text overlay |
+| `setConfig&RecordMode[ch].Mode=mode` | Set record mode |
+| `setConfig&VideoInDayNight[ch][cfg].Mode=mode` | Set day/night color mode |
+
+### Coaxial Control (`/cgi-bin/coaxialControlIO.cgi`)
+
+| Action | Description |
+|--------|-------------|
+| `getStatus&channel=1` | Speaker and white light status |
+| `control&channel=ch&info[0].Type=type&info[0].IO=io` | Control speaker/light/siren |
+
+Type values: `1` = security light, `2` = siren. IO values: `1` = on, `2` = off.
+
+### PTZ Control (`/cgi-bin/ptz.cgi`)
+
+| Action | Description |
+|--------|-------------|
+| `getStatus` | Current PTZ position and preset ID |
+| `start&channel=ch&code=GotoPreset&arg2=pos` | Go to preset position |
+
+### Event Stream (`/cgi-bin/eventManager.cgi`)
+
+| Action | Description |
+|--------|-------------|
+| `attach&codes=[events]&heartbeat=5` | Long-polling event stream |
+
+Response format: `--myboundary` delimited chunks with `Code=X;action=Y;index=Z;data={json}`.
+
+### Snapshot (`/cgi-bin/snapshot.cgi`)
+
+| Action | Description |
+|--------|-------------|
+| `channel=N` | Capture JPEG snapshot |
+
+## VTO Binary Protocol (TCP Port 5000)
+
+Binary framing with DHIP header (32 bytes) + JSON payload.
+
+### Methods
+
+| Method | Description |
+|--------|-------------|
+| `global.login` | Two-phase MD5 challenge-response login |
+| `global.keepAlive` | Keep connection alive |
+| `eventManager.attach` | Subscribe to all events |
+| `configManager.getConfig` | Get configuration |
+| `magicBox.getSoftwareVersion` | Get firmware version |
+| `magicBox.getDeviceType` | Get device type |
+| `console.runCmd` | Run console command (e.g., cancel call) |
+
+### Event Notification
+
+Events arrive via `client.notifyEventStream` method with `eventList` array containing `Code`, `Action`, and `Data` fields.
+
+## RPC2 JSON API (`/RPC2`)
+
+Alternative JSON-RPC API via HTTP POST. Used by `DahuaRpc2Client`.
+
+| Method | Description |
+|--------|-------------|
+| `global.login` | Two-phase login (same MD5 scheme) |
+| `global.logout` | End session |
+| `global.getCurrentTime` | Device time |
+| `magicBox.getSerialNo` | Serial number |
+| `configManager.getConfig` | Get configuration |
+| `CoaxialControlIO.getStatus` | Coaxial IO status |
+
+## Home Assistant Services
+
+18 services registered on the camera entity platform. See `services.yaml` for full definitions.
+
+Key services: `set_infrared_mode`, `set_video_profile_mode`, `set_text_overlay`, `enable_all_ivs_rules`, `vto_open_door`, `reboot`, `set_record_mode`, `goto_preset_position`.
+
+## Home Assistant Events
+
+| Event | Description |
+|-------|-------------|
+| `dahua_event_received` | Fired for every camera/VTO event. Contains `name`, `Code`, `action`, `index`, `data`, `DeviceName` |
+
+## RTSP Streams
+
+URL format: `rtsp://user:pass@host:port/cam/realmonitor?channel=N&subtype=S`
+
+- Subtype 0 = Main stream
+- Subtype 1 = Sub stream
+- Subtype 3 = Direct RTSP (no path)

--- a/.agents/summary/review_notes.md
+++ b/.agents/summary/review_notes.md
@@ -1,0 +1,42 @@
+# Review Notes
+
+## Consistency Check
+
+### Issues Found
+
+1. **VTO vs IP camera event key casing**: VTO events use capitalized keys (`Action`, `Data`, `Index`) while IP camera events use lowercase (`action`, `data`, `index`). The coordinator's `on_receive_vto_event` and `on_receive` methods handle this differently. This is documented in data_models.md but could be a source of bugs.
+
+2. **`supports_ptz_position()` method has wrong implementation**: In `__init__.py`, `supports_ptz_position()` checks `table.Lighting_V2` data instead of PTZ-related data — it's a copy-paste of `supports_illuminator()`. The actual PTZ support flag `_supports_ptz_position` is set correctly during initialization but the public method doesn't use it.
+
+3. **`button.py` is a placeholder**: Registered as a platform but `async_setup_entry` does nothing. No button entities are created.
+
+4. **`rpc2.py` appears unused**: `DahuaRpc2Client` is defined but not imported or used by the coordinator or any entity. It may be intended for future use or specific device types.
+
+5. **`models.py` appears unused in main flow**: `CoaxialControlIOStatus` is only imported by `rpc2.py`, which itself appears unused.
+
+## Completeness Check
+
+### Gaps Identified
+
+1. **Test coverage is minimal**: Only `test_api.py` and `conftest.py` exist with minimal content. No tests for coordinator, entities, event parsing, or VTO protocol.
+
+2. **No error handling documentation**: The codebase has extensive try/except patterns for feature detection but no documentation on error recovery strategies or known failure modes beyond the README's "Known Issues" section.
+
+3. **NVR multi-channel behavior**: The code has comments about NVR channel handling (creating one thread per channel, all getting same events) but the workaround (filtering by channel index) and its limitations aren't well documented.
+
+4. **Amcrest/Lorex/IMOU device differences**: The code has many model-specific branches (e.g., `is_amcrest_doorbell()`, `is_flood_light()`, NVR-specific night mode switching) but there's no consolidated guide on which features work with which device families.
+
+5. **Profile mode semantics**: Profile mode values (0=day, 1=night, 2=scene) are scattered across comments but not centrally documented.
+
+6. **SSL handling**: Both `__init__.py` and `config_flow.py` create SSL contexts that disable certificate verification. The security implications aren't documented.
+
+7. **`button.py` platform**: Listed in `PLATFORMS` but has no implementation. Could confuse contributors.
+
+## Recommendations
+
+1. **Fix `supports_ptz_position()`** — It currently returns illuminator support status instead of PTZ support.
+2. **Remove or implement `button.py`** — Either add button entities or remove from PLATFORMS to avoid confusion.
+3. **Add integration tests** — Especially for event parsing (`parse_event`), VTO protocol parsing, and coordinator initialization.
+4. **Consolidate device-specific logic** — Create a device capabilities matrix or registry instead of scattered model string checks.
+5. **Document the RPC2 client** — Clarify if it's actively used, planned for future use, or deprecated.
+6. **Standardize event key casing** — Consider normalizing VTO events to match IP camera event format in the coordinator.

--- a/.agents/summary/workflows.md
+++ b/.agents/summary/workflows.md
@@ -1,0 +1,150 @@
+# Workflows
+
+## Integration Setup Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ConfigFlow
+    participant DahuaClient
+    participant Camera
+
+    User->>ConfigFlow: Enter credentials + address
+    ConfigFlow->>DahuaClient: get_machine_name()
+    DahuaClient->>Camera: GET /magicBox.cgi?action=getMachineName
+    Camera-->>DahuaClient: name=FrontDoor
+    DahuaClient->>Camera: GET /magicBox.cgi?action=getSystemInfo
+    Camera-->>DahuaClient: serialNumber=ABC123
+    ConfigFlow-->>User: Show name confirmation step
+    User->>ConfigFlow: Confirm name
+    ConfigFlow->>ConfigFlow: Create config entry
+    ConfigFlow->>ConfigFlow: async_setup_entry()
+```
+
+## Device Initialization
+
+```mermaid
+flowchart TD
+    A[async_setup_entry] --> B[Create DahuaDataUpdateCoordinator]
+    B --> C[First data refresh]
+    C --> D{Initialized?}
+    D -->|No| E[Probe device capabilities]
+    E --> F[Get machine name, system info, version]
+    F --> G[Detect model and device type]
+    G --> H[Check channel numbering]
+    H --> I[Probe: coaxial control]
+    I --> J[Probe: disarming linkage]
+    J --> K[Probe: smart motion]
+    K --> L[Probe: PTZ]
+    L --> M[Probe: lighting V1 + V2]
+    M --> N{Is doorbell?}
+    N -->|Yes| O[Start VTO event listener<br/>TCP port 5000]
+    N -->|No| P[Start HTTP event listener<br/>eventManager.cgi]
+    P --> Q[Probe: profile mode support]
+    O --> R[Mark initialized]
+    Q --> R
+    D -->|Yes| S[Poll: motion, lighting, disarming, etc.]
+    R --> S
+```
+
+## Event Processing (IP Camera)
+
+```mermaid
+sequenceDiagram
+    participant Camera
+    participant Client
+    participant Coordinator
+    participant EventBus
+    participant BinarySensor
+
+    Camera->>Client: HTTP chunked response<br/>Code=VideoMotion;action=Start;index=0;data={...}
+    Client->>Coordinator: on_receive(data_bytes, channel)
+    Coordinator->>Coordinator: parse_event(data)
+    Coordinator->>Coordinator: Filter by channel
+    Coordinator->>Coordinator: translate_event_code()
+    Coordinator->>EventBus: fire("dahua_event_received", event)
+    Coordinator->>Coordinator: Update _dahua_event_timestamp
+    Coordinator->>BinarySensor: Call registered listener
+    BinarySensor->>BinarySensor: schedule_update_ha_state()
+```
+
+## Event Processing (VTO Doorbell)
+
+```mermaid
+sequenceDiagram
+    participant Doorbell
+    participant VTOClient
+    participant Coordinator
+    participant EventBus
+
+    Doorbell->>VTOClient: Binary frame + JSON event
+    VTOClient->>VTOClient: parse_response()
+    VTOClient->>VTOClient: handle_notify_event_stream()
+    VTOClient->>Coordinator: on_receive_vto_event(event)
+    Coordinator->>EventBus: fire("dahua_event_received", event)
+    Coordinator->>Coordinator: translate_event_code()<br/>BackKeyLight → DoorbellPressed
+    Coordinator->>Coordinator: Handle Start/Stop/Pulse actions
+    Coordinator->>Coordinator: Update timestamps + call listeners
+```
+
+## Periodic State Polling
+
+```mermaid
+flowchart TD
+    A[Every 30 seconds] --> B{Profile mode supported?}
+    B -->|Yes| C[Get VideoInMode]
+    B -->|No| D[Skip]
+    C --> E{PTZ supported?}
+    D --> E
+    E -->|Yes| F[Get PTZ status]
+    E -->|No| G[Skip]
+    F --> H[Fan out parallel API calls]
+    G --> H
+    H --> I[Get motion detection config]
+    H --> J[Get lighting config<br/>if IR supported]
+    H --> K[Get disarming linkage<br/>if supported]
+    H --> L[Get coaxial status<br/>if supported]
+    H --> M[Get smart motion<br/>if supported]
+    H --> N[Get Lighting_V2<br/>if supported]
+    I & J & K & L & M & N --> O[Gather results]
+    O --> P[Update coordinator.data]
+    P --> Q[Entities read updated state]
+```
+
+## Event Stream Reconnection
+
+```mermaid
+flowchart TD
+    A[Start event stream] --> B[Connect to camera]
+    B --> C[Stream events]
+    C --> D{Connection lost?}
+    D -->|No| C
+    D -->|Yes| E{Failed quickly<br/>< 10 seconds?}
+    E -->|Yes| F[Wait 60 seconds]
+    E -->|No| G[Reconnect immediately]
+    F --> B
+    G --> B
+```
+
+VTO reconnection uses a simpler 5s delay on disconnect, 30s on connection failure.
+
+## Service Call Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant HA
+    participant CameraEntity
+    participant Coordinator
+    participant Client
+    participant Device
+
+    User->>HA: Call dahua.set_infrared_mode
+    HA->>CameraEntity: async_set_infrared_mode(mode, brightness)
+    CameraEntity->>Coordinator: get_channel()
+    CameraEntity->>Client: async_set_lighting_v1_mode(channel, mode, brightness)
+    Client->>Device: GET /configManager.cgi?action=setConfig&Lighting[ch][0].Mode=mode
+    Device-->>Client: OK
+    CameraEntity->>Coordinator: async_refresh()
+    Coordinator->>Coordinator: _async_update_data()
+```

--- a/.kiro/settings/lsp.json
+++ b/.kiro/settings/lsp.json
@@ -1,0 +1,198 @@
+{
+  "languages": {
+    "go": {
+      "name": "gopls",
+      "command": "gopls",
+      "args": [],
+      "file_extensions": [
+        "go"
+      ],
+      "project_patterns": [
+        "go.mod",
+        "go.sum"
+      ],
+      "exclude_patterns": [
+        "**/vendor/**"
+      ],
+      "multi_workspace": false,
+      "initialization_options": {
+        "usePlaceholders": true,
+        "completeUnimported": true
+      },
+      "request_timeout_secs": 60
+    },
+    "python": {
+      "name": "pyright",
+      "command": "pyright-langserver",
+      "args": [
+        "--stdio"
+      ],
+      "file_extensions": [
+        "py"
+      ],
+      "project_patterns": [
+        "pyproject.toml",
+        "setup.py",
+        "requirements.txt",
+        "pyrightconfig.json"
+      ],
+      "exclude_patterns": [
+        "**/__pycache__/**",
+        "**/venv/**",
+        "**/.venv/**",
+        "**/.pytest_cache/**"
+      ],
+      "multi_workspace": false,
+      "initialization_options": {},
+      "request_timeout_secs": 60
+    },
+    "typescript": {
+      "name": "typescript-language-server",
+      "command": "typescript-language-server",
+      "args": [
+        "--stdio"
+      ],
+      "file_extensions": [
+        "ts",
+        "js",
+        "tsx",
+        "jsx"
+      ],
+      "project_patterns": [
+        "package.json",
+        "tsconfig.json"
+      ],
+      "exclude_patterns": [
+        "**/node_modules/**",
+        "**/dist/**"
+      ],
+      "multi_workspace": false,
+      "initialization_options": {
+        "preferences": {
+          "disableSuggestions": false
+        }
+      },
+      "request_timeout_secs": 60
+    },
+    "ruby": {
+      "name": "solargraph",
+      "command": "solargraph",
+      "args": [
+        "stdio"
+      ],
+      "file_extensions": [
+        "rb"
+      ],
+      "project_patterns": [
+        "Gemfile",
+        "Rakefile"
+      ],
+      "exclude_patterns": [
+        "**/vendor/**",
+        "**/tmp/**"
+      ],
+      "multi_workspace": false,
+      "initialization_options": {},
+      "request_timeout_secs": 60
+    },
+    "java": {
+      "name": "jdtls",
+      "command": "jdtls",
+      "args": [],
+      "file_extensions": [
+        "java"
+      ],
+      "project_patterns": [
+        "pom.xml",
+        "build.gradle",
+        "build.gradle.kts",
+        ".project"
+      ],
+      "exclude_patterns": [
+        "**/target/**",
+        "**/build/**",
+        "**/.gradle/**"
+      ],
+      "multi_workspace": false,
+      "initialization_options": {
+        "settings": {
+          "java": {
+            "compile": {
+              "nullAnalysis": {
+                "mode": "automatic"
+              }
+            },
+            "configuration": {
+              "annotationProcessing": {
+                "enabled": true
+              }
+            }
+          }
+        }
+      },
+      "request_timeout_secs": 60
+    },
+    "cpp": {
+      "name": "clangd",
+      "command": "clangd",
+      "args": [
+        "--background-index"
+      ],
+      "file_extensions": [
+        "cpp",
+        "cc",
+        "cxx",
+        "c",
+        "h",
+        "hpp",
+        "hxx"
+      ],
+      "project_patterns": [
+        "CMakeLists.txt",
+        "compile_commands.json",
+        "Makefile"
+      ],
+      "exclude_patterns": [
+        "**/build/**",
+        "**/cmake-build-**/**"
+      ],
+      "multi_workspace": false,
+      "initialization_options": {},
+      "request_timeout_secs": 60
+    },
+    "rust": {
+      "name": "rust-analyzer",
+      "command": "rust-analyzer",
+      "args": [],
+      "file_extensions": [
+        "rs"
+      ],
+      "project_patterns": [
+        "Cargo.toml"
+      ],
+      "exclude_patterns": [
+        "**/target/**"
+      ],
+      "multi_workspace": false,
+      "initialization_options": {
+        "cargo": {
+          "buildScripts": {
+            "enable": true
+          }
+        },
+        "diagnostics": {
+          "enable": true,
+          "enableExperimental": true
+        },
+        "workspace": {
+          "symbol": {
+            "search": {
+              "scope": "workspace"
+            }
+          }
+        }
+      },
+      "request_timeout_secs": 60
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,169 @@
+# AGENTS.md — Dahua Home Assistant Integration
+
+<!-- tags: ai-context, codebase-navigation, dahua, home-assistant, custom-integration -->
+
+Custom Home Assistant integration for Dahua IP cameras, doorbells (VTO), NVRs, and DVRs. Also supports Amcrest, Lorex, IMOU, EmpireTech, and Avaloid Goliath rebranded devices. Version 0.9.81, HACS-installable.
+
+## Table of Contents
+
+- [Directory Map](#directory-map) — Where to find things
+- [Architecture Overview](#architecture-overview) — How the system fits together
+- [Key Entry Points](#key-entry-points) — Where to start reading
+- [Device-Specific Branching](#device-specific-branching) — Model detection patterns
+- [Event System](#event-system) — Dual event streaming architecture
+- [API Layer](#api-layer) — Three distinct API clients
+- [Config and CI](#config-and-ci) — Tooling discoverable from config files
+- [Known Quirks](#known-quirks) — Non-obvious behaviors
+- [Detailed Documentation](#detailed-documentation) — Deep-dive reference files
+- [Custom Instructions](#custom-instructions) — Human/agent-maintained conventions
+
+## Directory Map
+
+<!-- tags: navigation, directory-structure -->
+
+```
+custom_components/dahua/
+├── __init__.py          # Coordinator (central hub): setup, polling, event streams, feature detection
+├── client.py            # HTTP API client: all CGI endpoint calls, Digest Auth, RTSP URLs
+├── camera.py            # Camera entity + 18 service registrations (infrared, overlays, IVS, PTZ, reboot)
+├── binary_sensor.py     # Event-driven binary sensors (motion, tripwire, doorbell press)
+├── switch.py            # Toggles: motion detection, siren, smart motion, disarming
+├── light.py             # IR light, illuminator, flood light, security light, ring light
+├── select.py            # Dropdowns: doorbell light mode, PTZ preset position
+├── config_flow.py       # UI setup flow: credentials → name → config entry
+├── entity.py            # Base entity: device info, unique ID from serial number
+├── vto.py               # VTO doorbell binary TCP client (port 5000, DHIP protocol)
+├── rpc2.py              # Alternative RPC2 JSON API client (currently unused by main flow)
+├── digest.py            # Custom aiohttp Digest Auth (aiohttp lacks native support)
+├── dahua_utils.py       # Brightness conversion, event stream text parser
+├── const.py             # Domain, platform list, config keys, icons
+├── models.py            # CoaxialControlIOStatus dataclass (used by rpc2.py only)
+├── services.yaml        # HA service definitions for all 18 camera services
+└── translations/        # UI strings: en, es, fr, it, bg, ca, nl, pt, pt-BR
+```
+
+Other directories: `tests/` (minimal), `scripts/` (develop, lint, setup), `.github/workflows/` (CI).
+
+## Architecture Overview
+
+<!-- tags: architecture, design-patterns -->
+
+```mermaid
+graph LR
+    CF[Config Flow] -->|creates| COORD[Coordinator<br/>__init__.py]
+    COORD -->|polls via| CLIENT[DahuaClient<br/>client.py]
+    COORD -->|streams via| CLIENT
+    COORD -->|VTO events via| VTO[VTOClient<br/>vto.py]
+    COORD -->|manages| ENT[Entities<br/>camera, sensor, switch, light, select]
+    CLIENT -->|HTTP+DigestAuth| DEV[Camera CGI API]
+    VTO -->|TCP:5000 binary| DEV2[Doorbell DHIP]
+```
+
+**Coordinator pattern**: `DahuaDataUpdateCoordinator` (extends HA's `DataUpdateCoordinator`) is the single source of truth. It initializes by probing device capabilities, polls state every 30s, and maintains persistent event stream connections.
+
+**Entity hierarchy**: All entities extend `DahuaBaseEntity` → `CoordinatorEntity`. Device info (model, serial, firmware) comes from the coordinator.
+
+## Key Entry Points
+
+<!-- tags: entry-points, getting-started -->
+
+| Task | Start Here |
+|------|-----------|
+| Understand the integration | `__init__.py` → `DahuaDataUpdateCoordinator` |
+| Add a new API call | `client.py` → `DahuaClient` |
+| Add a new entity | Create in appropriate platform file, register in `__init__.py` PLATFORMS |
+| Add a new service | `camera.py` → `async_setup_entry()` service registrations + `services.yaml` |
+| Add a new event type | `config_flow.py` → `ALL_EVENTS` list |
+| Modify VTO/doorbell behavior | `vto.py` → `DahuaVTOClient` |
+| Change feature detection | `__init__.py` → `_async_update_data()` initialization block |
+
+## Device-Specific Branching
+
+<!-- tags: device-detection, model-checks -->
+
+The coordinator uses model string matching to determine device capabilities. Key methods:
+
+| Method | Detection Logic |
+|--------|----------------|
+| `is_doorbell()` | Model starts with VTO, DH-VTO, DHI, AD, DB6, DB2X, AV-V |
+| `is_amcrest_doorbell()` | Model starts with AD or DB6 |
+| `supports_siren()` | Model contains -AS-PV, L46N, or starts with W452ASD |
+| `supports_security_light()` | Model contains -AS-PV, or is AD410, DB61i, IP8M-2796E |
+| `is_flood_light()` | Model starts with ASH26, V261LC, W452ASD, or contains L26N, L46N |
+| `supports_infrared_light()` | Lighting supported AND model doesn't contain -AS-PV, -AS-NI, LED-S2 |
+
+Adding support for a new device model typically means updating these string checks.
+
+## Event System
+
+<!-- tags: events, event-streaming -->
+
+Two parallel event streaming mechanisms:
+
+1. **IP cameras**: HTTP long-poll to `eventManager.cgi?action=attach`. Response is `--myboundary`-delimited text: `Code=X;action=Y;index=Z;data={json}`. Parsed by `dahua_utils.parse_event()`.
+
+2. **VTO doorbells**: Binary TCP on port 5000. DHIP protocol (32-byte header + JSON). Handled by `DahuaVTOClient` (asyncio.Protocol).
+
+**Event translation**: `BackKeyLight`/`PhoneCallDetect` → `DoorbellPressed`. `CrossLineDetection` with `ObjectType=human` → also fires `SmartMotionHuman`.
+
+**Reconnection**: IP camera streams retry after 60s if connection fails quickly (<10s), otherwise reconnect immediately. VTO retries after 5s on disconnect, 30s on connection failure.
+
+All events fire on HA event bus as `dahua_event_received`.
+
+## API Layer
+
+<!-- tags: api, http, protocols -->
+
+Three API clients exist (only two are actively used):
+
+| Client | Protocol | Used For |
+|--------|----------|----------|
+| `DahuaClient` | HTTP GET + Digest Auth | All camera control and polling (primary) |
+| `DahuaVTOClient` | TCP binary (DHIP) | Doorbell event streaming |
+| `DahuaRpc2Client` | HTTP POST JSON-RPC | Currently unused in main flow |
+
+API responses are `key=value` text parsed into flat dicts. All values are strings — boolean checks compare against `"true"`/`"false"`.
+
+**Channel numbering quirk**: Channel index is 0-based, channel number is index+1. Some older firmwares use the same value for both. The coordinator auto-detects this during init by attempting a snapshot with channel 0.
+
+## Config and CI
+
+<!-- tags: ci, tooling, configuration -->
+
+- **CI** (`.github/workflows/`): HACS validation, Hassfest validation, Black formatting check, pytest on push/PR
+- **Linting**: flake8 config in `setup.cfg`, Black for formatting, isort for imports
+- **Testing**: `pytest-homeassistant-custom-component` — test coverage is currently minimal
+- **HACS**: `hacs.json` requires HACS >=1.6.0, HA >=2025.1.2
+- **Dev environment**: VS Code devcontainer (`.devcontainer.json`), scripts in `scripts/`
+
+## Known Quirks
+
+<!-- tags: gotchas, quirks -->
+
+- `supports_ptz_position()` method has a **copy-paste bug** — it checks Lighting_V2 data instead of PTZ data. The `_supports_ptz_position` flag is correct but the public method doesn't use it.
+- `button.py` is in PLATFORMS but has no implementation (empty `async_setup_entry`).
+- `rpc2.py` and `models.py` are defined but not used in the main integration flow.
+- SSL certificate verification is disabled in both `__init__.py` and `config_flow.py` (self-signed certs on cameras).
+- VTO events use capitalized keys (`Action`, `Data`) while IP camera events use lowercase (`action`, `data`).
+- The siren auto-turns off after 10-15 seconds (hardware behavior, not a bug).
+
+## Detailed Documentation
+
+For deep-dive reference, see `.agents/summary/`:
+
+| File | Contents |
+|------|----------|
+| `index.md` | Documentation index with query routing guide |
+| `architecture.md` | System design, patterns, component diagrams |
+| `components.md` | Detailed module-by-module descriptions |
+| `interfaces.md` | Complete API reference (CGI, VTO, RPC2, services) |
+| `data_models.md` | Data structures, event payloads, protocol framing |
+| `workflows.md` | Sequence diagrams for setup, events, polling, services |
+| `dependencies.md` | All dependencies and external services |
+| `review_notes.md` | Known issues, gaps, and recommendations |
+
+## Custom Instructions
+
+<!-- This section is maintained by developers and agents during day-to-day work.
+     It is NOT auto-generated by codebase-summary and MUST be preserved during refreshes.
+     Add project-specific conventions, gotchas, and workflow requirements here. -->

--- a/custom_components/dahua/dahua_utils.py
+++ b/custom_components/dahua/dahua_utils.py
@@ -68,7 +68,7 @@ def parse_event(data: str) -> list[dict[str, any]]:
         # And we want to put each key/value pair into a dictionary...
         event = dict()
         for key_value in event_block.split(';'):
-            key, value = key_value.split('=')
+            key, value = key_value.split('=', 1)
             event[key] = value
 
         # data is a json string, convert it to real json and add it back to the output dic

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+python = "3.13"

--- a/tests/dahua/test_dahua_utils.py
+++ b/tests/dahua/test_dahua_utils.py
@@ -1,0 +1,79 @@
+"""Tests for custom_components.dahua.dahua_utils."""
+from custom_components.dahua.dahua_utils import parse_event
+
+
+def _wrap_event(event_body: str) -> str:
+    """Wrap a raw event body in the --myboundary framing that parse_event expects."""
+    return (
+        "--myboundary\n"
+        "Content-Type: text/plain\n"
+        "Content-Length: 999\n"
+        "\n"
+        f"{event_body}\n"
+    )
+
+
+class TestParseEvent:
+    """Tests for parse_event."""
+
+    def test_simple_event_without_data(self):
+        """Events with no data payload parse correctly."""
+        raw = _wrap_event("Code=VideoMotion;action=Start;index=0")
+        events = parse_event(raw)
+
+        assert len(events) == 1
+        assert events[0]["Code"] == "VideoMotion"
+        assert events[0]["action"] == "Start"
+        assert events[0]["index"] == "0"
+
+    def test_event_with_json_data(self):
+        """Events with a JSON data payload parse data into a dict."""
+        event_body = (
+            'Code=VideoMotion;action=Start;index=0;data={\n'
+            '   "Id" : [ 0 ],\n'
+            '   "RegionName" : [ "Region1" ],\n'
+            '   "SmartMotionEnable" : true\n'
+            '}'
+        )
+        raw = _wrap_event(event_body)
+        events = parse_event(raw)
+
+        assert len(events) == 1
+        assert events[0]["Code"] == "VideoMotion"
+        assert isinstance(events[0]["data"], dict)
+        assert events[0]["data"]["RegionName"] == ["Region1"]
+
+    def test_unparseable_data_stays_as_string(self):
+        """When data is not valid JSON, it remains as a string."""
+        raw = _wrap_event("Code=VideoMotion;action=Start;index=0;data=notjson")
+        events = parse_event(raw)
+
+        assert len(events) == 1
+        assert events[0]["data"] == "notjson"
+
+    def test_empty_input_returns_no_events(self):
+        """Empty or non-event input returns an empty list."""
+        assert parse_event("") == []
+        assert parse_event("some random text") == []
+
+    def test_equals_in_data_value_does_not_crash(self):
+        """Bug #477: values containing '=' must not crash parse_event."""
+        event_body = (
+            'Code=CrossRegionDetection;action=Start;index=0;data={\n'
+            '   "Name" : "Rule1",\n'
+            '   "Encoded" : "dGVzdA=="\n'
+            '}'
+        )
+        raw = _wrap_event(event_body)
+        events = parse_event(raw)
+
+        assert len(events) == 1
+        assert events[0]["Code"] == "CrossRegionDetection"
+
+    def test_equals_in_non_json_data_preserved(self):
+        """Bug #477: non-JSON data containing '=' is preserved intact."""
+        raw = _wrap_event("Code=VideoMotion;action=Start;index=0;data=key=value")
+        events = parse_event(raw)
+
+        assert len(events) == 1
+        assert events[0]["data"] == "key=value"


### PR DESCRIPTION
Fix for #477: parse_event crashes with ValueError when event data contains '=' characters (e.g. base64-encoded values). The split('=') call produces more than 2 parts, causing 'too many values to unpack'.

Fix: use split('=', 1) to split on the first '=' only, preserving any '=' characters in the value portion.

Adds unit tests for parse_event covering the bug and happy paths.