### PR TITLE
Replace PlatformNotReady with UpdateFailed to prevent coordinator tracebacks

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -15,7 +15,7 @@ import hashlib
 from aiohttp import ClientError, ClientResponseError, ClientSession, TCPConnector
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady, PlatformNotReady
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
@@ -366,10 +366,10 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     self.config_entry.async_start_reauth(self.hass)
                     raise UpdateFailed("Authentication failed") from exception
                 _LOGGER.error("Failed to initialize device at %s", self._address, exc_info=exception)
-                raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet")
+                raise UpdateFailed("Dahua device at " + self._address + " isn't fully initialized yet")
             except Exception as exception:
                 _LOGGER.error("Failed to initialize device at %s", self._address, exc_info=exception)
-                raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet")
+                raise UpdateFailed("Dahua device at " + self._address + " isn't fully initialized yet")
 
         # This is the event loop code that's called every n seconds
         try:


### PR DESCRIPTION
## Summary
- The `DataUpdateCoordinator` base class only handles `UpdateFailed` silently. `PlatformNotReady` falls through to the generic `except`, causing full 60-line tracebacks for every unreachable camera retry cycle.
- Replace `PlatformNotReady` with `UpdateFailed` in `_async_update_data` so retries are handled gracefully.
- Remove unused `PlatformNotReady` import.

## Test plan
- [ ] Verify camera startup with an unreachable camera — should see clean retry logs instead of full tracebacks
- [ ] Verify normal camera initialization still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)