### PR TITLE
Add option to disable channel-number auto-detection

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_RTSP_PORT,
     STARTUP_MESSAGE,
     CONF_CHANNEL,
+    CONF_AUTO_DETECT_CHANNEL,
 )
 from .dahua_utils import parse_event
 from .vto import DahuaVTOClient
@@ -265,15 +266,22 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 self.machine_name = data.get("table.General.MachineName")
                 self._serial_number = data.get("serialNumber")
 
-                try:
-                    await self.client.async_get_snapshot(0)
-                    # If able to take a snapshot with index 0 then most likely this cams channel needs to be reset
-                    # but check if unit is not a doorbell first as channel 0 doesnt exist for VTOs
-                    if not self.is_doorbell():
-                        self._channel_number = self._channel
-                except ClientError:
-                    pass
-                _LOGGER.debug("Using channel number %s", self._channel_number)
+                # Some Dahua firmwares index channels from 0, others from 1. The default
+                # is to auto-detect: if a snapshot at index 0 succeeds, treat this camera as
+                # 0-indexed and reset channel_number accordingly. Users on cameras where this
+                # heuristic gets it wrong (HTTP snapshot at 0 succeeds but RTSP only streams
+                # on channel=1) can disable it via the integration options.
+                auto_detect = self.config_entry.options.get(CONF_AUTO_DETECT_CHANNEL, True)
+                if auto_detect:
+                    try:
+                        await self.client.async_get_snapshot(0)
+                        # If able to take a snapshot with index 0 then most likely this cams channel needs to be reset
+                        # but check if unit is not a doorbell first as channel 0 doesnt exist for VTOs
+                        if not self.is_doorbell():
+                            self._channel_number = self._channel
+                    except ClientError:
+                        pass
+                _LOGGER.debug("Using channel number %s (auto_detect=%s)", self._channel_number, auto_detect)
 
                 try:
                     await self.client.async_get_coaxial_control_io_status()

--- a/custom_components/dahua/config_flow.py
+++ b/custom_components/dahua/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
     CONF_CHANNEL,
+    CONF_AUTO_DETECT_CHANNEL,
 )
 
 """
@@ -256,14 +257,19 @@ class DahuaOptionsFlowHandler(config_entries.OptionsFlow):
             self.options.update(user_input)
             return await self._update_options()
 
+        schema = {
+            vol.Required(x, default=self.options.get(x, True)): bool
+            for x in sorted(PLATFORMS)
+        }
+        schema[
+            vol.Required(
+                CONF_AUTO_DETECT_CHANNEL,
+                default=self.options.get(CONF_AUTO_DETECT_CHANNEL, True),
+            )
+        ] = bool
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(x, default=self.options.get(x, True)): bool
-                    for x in sorted(PLATFORMS)
-                }
-            ),
+            data_schema=vol.Schema(schema),
         )
 
     async def _update_options(self):

--- a/custom_components/dahua/const.py
+++ b/custom_components/dahua/const.py
@@ -43,6 +43,7 @@ CONF_STREAMS = "streams"
 CONF_EVENTS = "events"
 CONF_NAME = "name"
 CONF_CHANNEL = "channel"
+CONF_AUTO_DETECT_CHANNEL = "auto_detect_channel"
 
 # Defaults
 DEFAULT_NAME = "Dahua"

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -48,7 +48,8 @@
                     "switch": "Switch enabled",
                     "light": "Light enabled",
                     "select": "Select enabled",
-                    "camera": "Camera enabled"
+                    "camera": "Camera enabled",
+                    "auto_detect_channel": "Auto-detect channel index (disable if HTTP snapshot at channel=0 works but RTSP only streams on channel=1)"
                 }
             }
         }


### PR DESCRIPTION
# Add option to disable channel-number auto-detection

Closes #578.

## Problem

The coordinator's `_async_update_data` probes `async_get_snapshot(0)` and, on success, resets `self._channel_number = self._channel` (line ~272 in `__init__.py`). The heuristic exists because some Dahua firmwares index channels from 0 instead of 1, and the camera's HTTP CGI endpoint reveals which family it belongs to.

On some cameras (full details in the linked issue) the HTTP snapshot endpoint cheerfully returns a JPEG at index 0 even though RTSP only streams on `channel=1`. The heuristic then mis-classifies the camera as 0-indexed and the resulting `rtsp://.../cam/realmonitor?channel=0&subtype=0` returns HTTP 404 forever after.

There's currently no way for affected users to opt out.

## Change

Add an `auto_detect_channel` option to the integration's OptionsFlow (default `True`, identical to current behavior). When disabled, the snapshot probe and channel reset are skipped, and `_channel_number` stays at `channel + 1`.

Existing installs are not affected — the new key isn't present in their `options` dict, so `options.get(CONF_AUTO_DETECT_CHANNEL, True)` returns the default `True` and the original code path runs.

## Files

- `const.py` — new `CONF_AUTO_DETECT_CHANNEL` constant.
- `__init__.py` — gate the snapshot reset on the new option, mention the toggle in the DEBUG log.
- `config_flow.py` — surface the toggle in the existing `DahuaOptionsFlowHandler` schema alongside the platform booleans.

## How to use

After updating, **Settings → Devices & services → Dahua (the affected camera) → Configure → uncheck "auto_detect_channel"**. The change takes effect on the next coordinator refresh (or immediately if the entry is reloaded).

## Testing

Verified on a real install: with the toggle off, `_channel_number` stays at 1, RTSP stream comes up, `camera.record` produces a valid MP4. Other cameras in the same install (which rely on the heuristic) keep the option on and are unaffected. `python -c "import ast; ast.parse(open(f).read())"` clean on the three changed files.
