### PR TITLE
Fixed illuminator state/control on dual illuminator camera (IL series)

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -362,6 +362,15 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     except ClientError:
                         _LOGGER.debug("Cam does not support profile mode. Will use mode 0")
                         self._supports_profile_mode = False
+                    if not self._supports_profile_mode:
+                        # The legacy Lighting[0][2] probe is empty on some cams (e.g. white-light/dual
+                        # illuminator models). Fall back to the VideoInMode API, which is the canonical
+                        # source for the active day/night profile.
+                        try:
+                            mode_data = await self.client.async_get_video_in_mode()
+                            self._supports_profile_mode = "table.VideoInMode[0].Config[0]" in mode_data
+                        except ClientError:
+                            self._supports_profile_mode = False
                     _LOGGER.debug("Device supports profile mode=%s", self._supports_profile_mode)
                 else:
                     # Start the event listeners for doorbells (VTO)
@@ -766,11 +775,28 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         bri = self.data.get("table.Lighting[{0}][0].MiddleLight[0].Light".format(self._channel))
         return dahua_utils.dahua_brightness_to_hass_brightness(bri)
 
+    def get_illuminator_index(self, profile_mode) -> int:
+        """
+        Return the Lighting_V2 array index of the white-light illuminator for the given profile.
+
+        On single-illuminator cameras the white light is at index 0, but on dual-illuminator
+        models (e.g. the -IL series) index 0 is the InfraredLight and the white light lives at a
+        later index. We locate it by LightType so the right light is read/controlled regardless of
+        layout. Falls back to 0 when no WhiteLight entry is present (legacy behaviour).
+        """
+        for index in range(0, 3):
+            light_type = self.data.get(
+                "table.Lighting_V2[{0}][{1}][{2}].LightType".format(self._channel, profile_mode, index))
+            if light_type == "WhiteLight":
+                return index
+        return 0
+
     def is_illuminator_on(self) -> bool:
         """Return true if the illuminator light is on"""
         # profile_mode 0=day, 1=night, 2=scene
-        profile_mode = self.get_profile_mode()       
-        return self.data.get("table.Lighting_V2[{0}][{1}][0].Mode".format(self._channel, profile_mode), "") == "Manual"
+        profile_mode = self.get_profile_mode()
+        index = self.get_illuminator_index(profile_mode)
+        return self.data.get("table.Lighting_V2[{0}][{1}][{2}].Mode".format(self._channel, profile_mode, index), "") == "Manual"
 
     def is_flood_light_on(self) -> bool:
 
@@ -789,8 +815,10 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
     def get_illuminator_brightness(self) -> int:
         """Return the brightness of the illuminator light, as reported by the camera itself, between 0..255 inclusive"""
-
-        bri = self.data.get("table.Lighting_V2[{0}][0][0].MiddleLight[0].Light".format(self._channel))
+        # profile_mode 0=day, 1=night, 2=scene
+        profile_mode = self.get_profile_mode()
+        index = self.get_illuminator_index(profile_mode)
+        bri = self.data.get("table.Lighting_V2[{0}][{1}][{2}].MiddleLight[0].Light".format(self._channel, profile_mode, index))
         return dahua_utils.dahua_brightness_to_hass_brightness(bri)
 
     def is_security_light_on(self) -> bool:

--- a/custom_components/dahua/camera.py
+++ b/custom_components/dahua/camera.py
@@ -335,6 +335,10 @@ class DahuaCamera(DahuaBaseEntity, Camera):
             await self._coordinator.client.async_set_night_switch_mode(channel, mode)
         else:
             await self._coordinator.client.async_set_video_profile_mode(channel, mode)
+        # Refresh immediately so dependent entities (e.g. the illuminator light, whose state is
+        # derived from the active day/night profile) update right away instead of waiting for the
+        # next ~30s poll. The camera reflects the new profile in its config immediately.
+        await self._coordinator.async_refresh()
 
     async def async_adjustfocus(self, focus: str, zoom: str):
         """ Handles the service call from SERVICE_SET_INFRARED_MODE to set zoom and focus """

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -495,21 +495,23 @@ class DahuaClient:
         if "OK" not in value and "ok" not in value:
             raise Exception("Could not set text")
 
-    async def async_set_lighting_v2(self, channel: int, enabled: bool, brightness: int, profile_mode: str) -> dict:
+    async def async_set_lighting_v2(self, channel: int, enabled: bool, brightness: int, profile_mode: str, index: int = 0) -> dict:
         """
         async_set_lighting_v2 will turn on or off the white light on the camera. If turning on, the brightness will be used.
         brightness is in the range of 0 to 100 inclusive where 100 is the brightest.
         NOTE: this is not the same as the infrared (IR) light. This is the white visible light on the camera
 
         profile_mode: 0=day, 1=night, 2=scene
+        index: the Lighting_V2 light index. White light is index 0 on single-illuminator cams but a
+               later index on dual-illuminator (-IL) models, so the caller passes the resolved index.
         """
 
         # on = Manual, off = Off
         mode = "Manual"
         if not enabled:
             mode = "Off"
-        url = "/cgi-bin/configManager.cgi?action=setConfig&Lighting_V2[{channel}][{profile_mode}][0].Mode={mode}&Lighting_V2[{channel}][{profile_mode}][0].MiddleLight[0].Light={brightness}".format(
-            channel=channel, profile_mode=profile_mode, mode=mode, brightness=brightness
+        url = "/cgi-bin/configManager.cgi?action=setConfig&Lighting_V2[{channel}][{profile_mode}][{index}].Mode={mode}&Lighting_V2[{channel}][{profile_mode}][{index}].MiddleLight[0].Light={brightness}".format(
+            channel=channel, profile_mode=profile_mode, index=index, mode=mode, brightness=brightness
         )
         _LOGGER.debug("Turning light on: %s", url)
         return await self.get(url)

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -166,7 +166,8 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         dahua_brightness = dahua_utils.hass_brightness_to_dahua_brightness(hass_brightness)
         channel = self._coordinator.get_channel()
         profile_mode = self._coordinator.get_profile_mode()
-        await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode)
+        index = self._coordinator.get_illuminator_index(profile_mode)
+        await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode, index)
         await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):
@@ -175,7 +176,8 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         dahua_brightness = dahua_utils.hass_brightness_to_dahua_brightness(hass_brightness)
         channel = self._coordinator.get_channel()
         profile_mode = self._coordinator.get_profile_mode()
-        await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode)
+        index = self._coordinator.get_illuminator_index(profile_mode)
+        await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode, index)
         await self._coordinator.async_refresh()
 
 


### PR DESCRIPTION
✨ Fix: Dynamic illuminator indexing for Dahua dual smart light cameras (IL Series)

### 🚨 The Problem
On modern Dahua dual smart light cameras (IL series), the illuminator state and functionality were bugged. Previously, the white light was implicitly assumed to be at `index 0`. While this works for single-illuminator cameras, on dual-illuminator models, `index 0` is assigned to the **Infrared (IR) light**, which breaks white light controls.

### 🛠️ The Solution
* **Introduced `get_illuminator_index`:** A new function to dynamically identify the correct light index regardless of the camera's hardware layout, cleanly preserving legacy behavior.
* **Refactored `async_set_lighting_v2`:** Parameterized the index within the function call, ensuring the dynamically identified light index is resolved *before* execution.

### ✅ Impact
* 💡 Successfully restores **turn on/off** and **brightness** controls for the white light on IL series cameras.
* 🛡️ Ensures strict backward compatibility for single-illuminator models.

### 📝 Documentation & Usage Note
To control the illuminator via the Home Assistant entity, the camera's illuminator mode **must** be set to `manual`. 
*(Tip: Setting the night profile to "manual illuminator" allows for consistent manual control directly from the HA entity).*