### PR TITLE
Use current profile to get brightness, default to 100

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -789,8 +789,8 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
     def get_illuminator_brightness(self) -> int:
         """Return the brightness of the illuminator light, as reported by the camera itself, between 0..255 inclusive"""
-
-        bri = self.data.get("table.Lighting_V2[{0}][0][0].MiddleLight[0].Light".format(self._channel))
+        profile_mode = self.get_profile_mode()
+        bri = self.data.get("table.Lighting_V2[{0}][{1}][0].MiddleLight[0].Light".format(self._channel, profile_mode))
         return dahua_utils.dahua_brightness_to_hass_brightness(bri)
 
     def is_security_light_on(self) -> bool:

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -341,18 +341,18 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
 #Checking lighting_v2 support
                 try:
-                    await self.client.async_get_lighting_v2()
+                    lighting_v2_data = await self.client.async_get_lighting_v2()
                     self._supports_lighting_v2 = True
                     # Detect which light type(s) this camera uses for illuminator brightness.
                     # MiddleLight is mutually exclusive with FarLight/NearLight.
                     channel = self._channel
                     middle_key = "table.Lighting_V2[{0}][0][0].MiddleLight[0].Light".format(channel)
-                    if middle_key in self.data:
+                    if middle_key in lighting_v2_data:
                         self._illuminator_brightness_keys = ["MiddleLight"]
                     else:
                         for light_type in ["FarLight", "NearLight"]:
                             test_key = "table.Lighting_V2[{0}][0][0].{1}[0].Light".format(channel, light_type)
-                            if test_key in self.data:
+                            if test_key in lighting_v2_data:
                                 self._illuminator_brightness_keys.append(light_type)
                     if self._illuminator_brightness_keys:
                         _LOGGER.debug("Illuminator uses %s for brightness", ",".join(self._illuminator_brightness_keys))

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -126,6 +126,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         self._max_streams = 3  # 1 main stream + 2 sub-streams by default
 
         self._supports_lighting_v2 = False
+        self._illuminator_brightness_keys = []
 
         # channel_number is not the channel_index. channel_number is the index + 1.
         # So channel index 0 is channel number 1. Except for some older firmwares where channel
@@ -342,6 +343,21 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 try:
                     await self.client.async_get_lighting_v2()
                     self._supports_lighting_v2 = True
+                    # Detect which light type(s) this camera uses for illuminator brightness.
+                    # MiddleLight is mutually exclusive with FarLight/NearLight.
+                    channel = self._channel
+                    middle_key = "table.Lighting_V2[{0}][0][0].MiddleLight[0].Light".format(channel)
+                    if middle_key in self.data:
+                        self._illuminator_brightness_keys = ["MiddleLight"]
+                    else:
+                        for light_type in ["FarLight", "NearLight"]:
+                            test_key = "table.Lighting_V2[{0}][0][0].{1}[0].Light".format(channel, light_type)
+                            if test_key in self.data:
+                                self._illuminator_brightness_keys.append(light_type)
+                    if self._illuminator_brightness_keys:
+                        _LOGGER.debug("Illuminator uses %s for brightness", ",".join(self._illuminator_brightness_keys))
+                    else:
+                        _LOGGER.debug("Could not detect illuminator brightness light type")
                 except ClientError:
                     self._supports_lighting_v2 = False
                     pass
@@ -790,8 +806,20 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     def get_illuminator_brightness(self) -> int:
         """Return the brightness of the illuminator light, as reported by the camera itself, between 0..255 inclusive"""
         profile_mode = self.get_profile_mode()
-        bri = self.data.get("table.Lighting_V2[{0}][{1}][0].MiddleLight[0].Light".format(self._channel, profile_mode))
-        return dahua_utils.dahua_brightness_to_hass_brightness(bri)
+        if not self._illuminator_brightness_keys:
+            return dahua_utils.dahua_brightness_to_hass_brightness(None)
+        # Average the brightness across all light types the camera uses (e.g. FarLight + NearLight)
+        total = 0
+        count = 0
+        for light_type in self._illuminator_brightness_keys:
+            bri = self.data.get("table.Lighting_V2[{0}][{1}][0].{2}[0].Light".format(
+                self._channel, profile_mode, light_type))
+            if bri is not None:
+                total += int(bri)
+                count += 1
+        if count == 0:
+            return dahua_utils.dahua_brightness_to_hass_brightness(None)
+        return dahua_utils.dahua_brightness_to_hass_brightness(str(total // count))
 
     def is_security_light_on(self) -> bool:
         """Return true if the security light is on. This is the red/blue flashing light"""
@@ -800,6 +828,10 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     def get_profile_mode(self) -> str:
         # profile_mode 0=day, 1=night, 2=scene
         return self._profile_mode
+
+    def get_illuminator_brightness_keys(self) -> list:
+        """Return the list of light type keys used for illuminator brightness (e.g. ['FarLight', 'NearLight'])"""
+        return self._illuminator_brightness_keys if self._illuminator_brightness_keys else ["MiddleLight"]
 
     def get_channel(self) -> int:
         """returns the channel index of this camera. 0 based. Channel index 0 is channel number 1"""

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -495,22 +495,29 @@ class DahuaClient:
         if "OK" not in value and "ok" not in value:
             raise Exception("Could not set text")
 
-    async def async_set_lighting_v2(self, channel: int, enabled: bool, brightness: int, profile_mode: str) -> dict:
+    async def async_set_lighting_v2(self, channel: int, enabled: bool, brightness: int, profile_mode: str, light_types: list = None) -> dict:
         """
         async_set_lighting_v2 will turn on or off the white light on the camera. If turning on, the brightness will be used.
         brightness is in the range of 0 to 100 inclusive where 100 is the brightest.
         NOTE: this is not the same as the infrared (IR) light. This is the white visible light on the camera
 
         profile_mode: 0=day, 1=night, 2=scene
+        light_types: list of brightness field names (e.g. ['MiddleLight'], ['FarLight', 'NearLight'])
         """
 
+        if light_types is None:
+            light_types = ["MiddleLight"]
         # on = Manual, off = Off
         mode = "Manual"
         if not enabled:
             mode = "Off"
-        url = "/cgi-bin/configManager.cgi?action=setConfig&Lighting_V2[{channel}][{profile_mode}][0].Mode={mode}&Lighting_V2[{channel}][{profile_mode}][0].MiddleLight[0].Light={brightness}".format(
-            channel=channel, profile_mode=profile_mode, mode=mode, brightness=brightness
+        url = "/cgi-bin/configManager.cgi?action=setConfig&Lighting_V2[{channel}][{profile_mode}][0].Mode={mode}".format(
+            channel=channel, profile_mode=profile_mode, mode=mode
         )
+        for lt in light_types:
+            url += "&Lighting_V2[{channel}][{profile_mode}][0].{lt}[0].Light={brightness}".format(
+                channel=channel, profile_mode=profile_mode, lt=lt, brightness=brightness
+            )
         _LOGGER.debug("Turning light on: %s", url)
         return await self.get(url)
 

--- a/custom_components/dahua/dahua_utils.py
+++ b/custom_components/dahua/dahua_utils.py
@@ -23,7 +23,7 @@ def hass_brightness_to_dahua_brightness(hass_brightness: int) -> int:
     Converts a HASS brightness (which is 0 to 255 inclusive) to a Dahua brightness (which is 0 to 100 inclusive)
     """
     if hass_brightness is None:
-        hass_brightness = 100
+        return 100
     return int((hass_brightness / 255) * 100)
 
 

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -166,7 +166,8 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         dahua_brightness = dahua_utils.hass_brightness_to_dahua_brightness(hass_brightness)
         channel = self._coordinator.get_channel()
         profile_mode = self._coordinator.get_profile_mode()
-        await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode)
+        light_types = self._coordinator.get_illuminator_brightness_keys()
+        await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode, light_types)
         await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):
@@ -175,7 +176,8 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         dahua_brightness = dahua_utils.hass_brightness_to_dahua_brightness(hass_brightness)
         channel = self._coordinator.get_channel()
         profile_mode = self._coordinator.get_profile_mode()
-        await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode)
+        light_types = self._coordinator.get_illuminator_brightness_keys()
+        await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode, light_types)
         await self._coordinator.async_refresh()
 
 


### PR DESCRIPTION
This does 2 things:
1. Uses current profile to get current brightness instead of pulling from profile 0. 
2. If no brightness found, returns 100 instead of 100/255*100 = 39, discard if this was intentional. I believe this approach is much more automation friendly.

 Disclaimer:
1. cline shell with model openrouter/owl_alpha (AI) help diagnose and repair issues. 
2. I fully understand the changes I made.
3. This shouldn't change any other behaviors.
4. I do not fully understand the entire codebase why the old code was the way it was.

Testing:
This works for white light cameras N45EJ62 (IPC-HDW5442TP-S-LED) 