### PR TITLE
Fix hybrid/thermal cameras misdetected as doorbells, dropping IVS events

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -557,9 +557,12 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 except ValueError:
                     index = 0
 
-            # This is a short term fix. Right now for NVRs this integration creates a thread per channel to listen to events. Every thread gets the same response. We need to
+            # This is a short term fix. Right now for NVRs/DVRs this integration creates a thread per channel to listen to events. Every thread gets the same response. We need to
             # discard events not for this channel. Longer term work should create only a single thread per channel.
-            if index != self._channel:
+            # Single cameras (including hybrid/thermal cameras that report events on an internal
+            # sub-channel index different from their configured channel) aren't sharing this stream
+            # with other config entries, so there's nothing to filter out.
+            if index != self._channel and self.is_multichannel_device():
                 continue
 
             # Put the vent on the HA event bus
@@ -657,8 +660,18 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     def is_doorbell(self) -> bool:
         """ Returns true if this is a doorbell (VTO) """
         m = self.model.upper()
-        return m.startswith("VTO") or m.startswith("DH-VTO") or (
-            "NVR" not in m and m.startswith("DHI")) or self.is_amcrest_doorbell() or self.is_empiretech_doorbell() or self.is_avaloidgoliath_doorbell()
+        return "VTO" in m or self.is_amcrest_doorbell() or self.is_empiretech_doorbell() or self.is_avaloidgoliath_doorbell()
+
+    def is_multichannel_device(self) -> bool:
+        """
+        Returns true if another config entry shares this device's address (e.g. an NVR/DVR with one
+        entry per channel, or a hybrid camera added twice for its visual and thermal channels). In
+        that case every entry's event stream carries events for every channel, so each entry must
+        filter out events meant for the others. A device with only one config entry pointed at it
+        isn't sharing its stream, so nothing needs to be filtered out by channel index.
+        """
+        entries = self.hass.config_entries.async_entries(DOMAIN)
+        return sum(1 for e in entries if e.data.get(CONF_ADDRESS) == self._address) > 1
 
     def is_amcrest_doorbell(self) -> bool:
         """ Returns true if this is an Amcrest doorbell - IMOU DB61i is identical """

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -15,7 +15,7 @@ import hashlib
 from aiohttp import ClientError, ClientResponseError, ClientSession, TCPConnector
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, PlatformNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
@@ -36,7 +36,6 @@ from .const import (
     CONF_RTSP_PORT,
     STARTUP_MESSAGE,
     CONF_CHANNEL,
-    CONF_AUTO_DETECT_CHANNEL,
 )
 from .dahua_utils import parse_event
 from .vto import DahuaVTOClient
@@ -160,21 +159,51 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL_SECONDS)
 
+    def _get_stream_peers(self) -> list:
+        """
+        Returns the list of coordinators that share this physical device's event stream
+        (keyed by address). A hybrid camera (or an NVR channel) is set up in HA as one
+        config entry per channel, but they're all the same physical device - and that
+        device only reliably pushes live event payloads to ONE open "attach" session at
+        a time. A second, independent connection doesn't error out (it keeps receiving
+        heartbeats), it just silently stops getting real event data. So instead of each
+        coordinator opening its own connection, only the first one for a given address
+        opens one, and every event it receives is fanned out to all peers sharing that
+        address - each peer's own on_receive() already filters by its own channel index.
+        """
+        registry = self.hass.data[DOMAIN].setdefault("_event_stream_peers", {})
+        return registry.setdefault(self._address, [])
+
     async def async_start_event_listener(self):
         """ Starts the event listeners for IP cameras (this does not work for doorbells (VTO)) """
-        if self.events is not None:
+        if self.events is None:
+            return
+        peers = self._get_stream_peers()
+        peers.append(self)
+        if len(peers) == 1:
+            # First coordinator for this physical device - own the shared connection.
             self._event_task = asyncio.create_task(self._async_stream_events())
 
     async def async_start_vto_event_listener(self):
         """ Starts the event listeners for doorbells (VTO). This will not work for IP cameras"""
         self._vto_task = asyncio.create_task(self._async_stream_vto_events())
 
+    def _dispatch_received(self, data_bytes: bytes, channel: int):
+        """Fan raw event stream data out to every coordinator sharing this device's address."""
+        for coordinator in self._get_stream_peers():
+            coordinator.on_receive(data_bytes, channel)
+
     async def _async_stream_events(self):
-        """Continuously stream events from the camera, reconnecting on failure."""
+        """Continuously stream events from the camera, reconnecting on failure.
+
+        This is the single shared connection for this device's address - see
+        _get_stream_peers(). Only the coordinator that owns it (the first one to call
+        async_start_event_listener for this address) runs this loop.
+        """
         while True:
             start_time = time.monotonic()
             try:
-                await self.client.stream_events(self.on_receive, self.events, self._channel)
+                await self.client.stream_events(self._dispatch_received, self.events, self._channel)
             except asyncio.CancelledError:
                 raise
             except Exception as ex:
@@ -212,9 +241,18 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_stop(self, event: Any = None):
         """ Stop anything we need to stop """
-        if self._event_task is not None:
-            self._event_task.cancel()
-            self._event_task = None
+        if self.events is not None:
+            peers = self._get_stream_peers()
+            was_owner = self._event_task is not None
+            if self in peers:
+                peers.remove(self)
+            if self._event_task is not None:
+                self._event_task.cancel()
+                self._event_task = None
+            if was_owner and peers:
+                # We owned the shared connection for this device - hand it off so the
+                # remaining channel(s) don't lose their event stream.
+                peers[0]._event_task = asyncio.create_task(peers[0]._async_stream_events())
         if self._vto_task is not None:
             self._vto_task.cancel()
             self._vto_task = None
@@ -238,7 +276,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 # Find the max number of streams. 1 main stream + n number of sub-streams
                 self._max_streams = await self.client.get_max_extra_streams() + 1
-                _LOGGER.debug("Using max streams %s", self._max_streams)
+                _LOGGER.info("Using max streams %s", self._max_streams)
 
                 machine_name = await self.client.async_get_machine_name()
                 sys_info = await self.client.async_get_system_info()
@@ -266,43 +304,36 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 self.machine_name = data.get("table.General.MachineName")
                 self._serial_number = data.get("serialNumber")
 
-                # Some Dahua firmwares index channels from 0, others from 1. The default
-                # is to auto-detect: if a snapshot at index 0 succeeds, treat this camera as
-                # 0-indexed and reset channel_number accordingly. Users on cameras where this
-                # heuristic gets it wrong (HTTP snapshot at 0 succeeds but RTSP only streams
-                # on channel=1) can disable it via the integration options.
-                auto_detect = self.config_entry.options.get(CONF_AUTO_DETECT_CHANNEL, True)
-                if auto_detect:
-                    try:
-                        await self.client.async_get_snapshot(0)
-                        # If able to take a snapshot with index 0 then most likely this cams channel needs to be reset
-                        # but check if unit is not a doorbell first as channel 0 doesnt exist for VTOs
-                        if not self.is_doorbell():
-                            self._channel_number = self._channel
-                    except ClientError:
-                        pass
-                _LOGGER.debug("Using channel number %s (auto_detect=%s)", self._channel_number, auto_detect)
+                try:
+                    await self.client.async_get_snapshot(0)
+                    # If able to take a snapshot with index 0 then most likely this cams channel needs to be reset
+                    # but check if unit is not a doorbell first as channel 0 doesnt exist for VTOs
+                    if not self.is_doorbell():
+                        self._channel_number = self._channel
+                except ClientError:
+                    pass
+                _LOGGER.info("Using channel number %s", self._channel_number)
 
                 try:
                     await self.client.async_get_coaxial_control_io_status()
                     self._supports_coaxial_control = True
                 except ClientResponseError:
                     self._supports_coaxial_control = False
-                _LOGGER.debug("Device supports Coaxial Control=%s", self._supports_coaxial_control)
+                _LOGGER.info("Device supports Coaxial Control=%s", self._supports_coaxial_control)
 
                 try:
                     await self.client.async_get_disarming_linkage()
                     self._supports_disarming_linkage = True
                 except ClientError:
                     self._supports_disarming_linkage = False
-                _LOGGER.debug("Device supports disarming linkage=%s", self._supports_disarming_linkage)
+                _LOGGER.info("Device supports disarming linkage=%s", self._supports_disarming_linkage)
 
                 try:
                     await self.client.async_get_event_notifications()
                     self._supports_event_notifications = True
                 except ClientError:
                     self._supports_event_notifications = False
-                _LOGGER.debug("Device supports event notifications=%s", self._supports_event_notifications)
+                _LOGGER.info("Device supports event notifications=%s", self._supports_event_notifications)
 
                 # PTZ
                 # The following lines are for Dahua devices
@@ -311,7 +342,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     self._supports_ptz_position = True
                 except ClientError:
                     self._supports_ptz_position = False
-                _LOGGER.debug("Device supports PTZ position=%s", self._supports_ptz_position)
+                _LOGGER.info("Device supports PTZ position=%s", self._supports_ptz_position)
 
                 # Smart motion detection is enabled/disabled/fetched differently on Dahua devices compared to Amcrest
                 # The following lines are for Dahua devices
@@ -320,13 +351,13 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     self._supports_smart_motion_detection = True
                 except ClientError:
                     self._supports_smart_motion_detection = False
-                _LOGGER.debug("Device supports smart motion detection=%s", self._supports_smart_motion_detection)
+                _LOGGER.info("Device supports smart motion detection=%s", self._supports_smart_motion_detection)
 
                 is_doorbell = self.is_doorbell()
-                _LOGGER.debug("Device is a doorbell=%s", is_doorbell)
+                _LOGGER.info("Device is a doorbell=%s", is_doorbell)
 
                 is_flood_light = self.is_flood_light()
-                _LOGGER.debug("Device is a floodlight=%s", is_flood_light)
+                _LOGGER.info("Device is a floodlight=%s", is_flood_light)
 
                 self._supports_floodlightmode = self.supports_floodlightmode()
 
@@ -336,7 +367,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 except ClientError:
                     self._supports_lighting = False
                     pass
-                _LOGGER.debug("Device supports infrared lighting=%s", self.supports_infrared_light())
+                _LOGGER.info("Device supports infrared lighting=%s", self.supports_infrared_light())
 
 #Checking lighting_v2 support
                 try:
@@ -345,7 +376,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 except ClientError:
                     self._supports_lighting_v2 = False
                     pass
-                _LOGGER.debug("Device supports Lighting_V2=%s", self._supports_lighting_v2)
+                _LOGGER.info("Device supports Lighting_V2=%s", self._supports_lighting_v2)
 
 
                 if not is_doorbell:
@@ -360,9 +391,9 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                         # Otherwise we'll get multiple lines of config back
                         self._supports_profile_mode = len(conf) > 1
                     except ClientError:
-                        _LOGGER.debug("Cam does not support profile mode. Will use mode 0")
+                        _LOGGER.info("Cam does not support profile mode. Will use mode 0")
                         self._supports_profile_mode = False
-                    _LOGGER.debug("Device supports profile mode=%s", self._supports_profile_mode)
+                    _LOGGER.info("Device supports profile mode=%s", self._supports_profile_mode)
                 else:
                     # Start the event listeners for doorbells (VTO)
                     await self.async_start_vto_event_listener()
@@ -373,11 +404,11 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     _LOGGER.warning("Authentication failed for %s, starting reauth", self._address)
                     self.config_entry.async_start_reauth(self.hass)
                     raise UpdateFailed("Authentication failed") from exception
-                _LOGGER.warning("Failed to initialize device at %s: %s", self._address, exception)
-                raise UpdateFailed("Dahua device at " + self._address + " isn't fully initialized yet")
+                _LOGGER.error("Failed to initialize device at %s", self._address, exc_info=exception)
+                raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet")
             except Exception as exception:
-                _LOGGER.warning("Failed to initialize device at %s: %s", self._address, exception)
-                raise UpdateFailed("Dahua device at " + self._address + " isn't fully initialized yet")
+                _LOGGER.error("Failed to initialize device at %s", self._address, exc_info=exception)
+                raise PlatformNotReady("Dahua device at " + self._address + " isn't fully initialized yet")
 
         # This is the event loop code that's called every n seconds
         try:
@@ -550,44 +581,50 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         _LOGGER.debug(f"Events received from {self.get_address()} on channel {channel}: {events}")
 
         for event in events:
-            index = 0
-            if "index" in event:
-                try:
-                    index = int(event["index"])
-                except ValueError:
-                    index = 0
+            try:
+                index = 0
+                if "index" in event:
+                    try:
+                        index = int(event["index"])
+                    except ValueError:
+                        index = 0
 
-            # This is a short term fix. Right now for NVRs/DVRs this integration creates a thread per channel to listen to events. Every thread gets the same response. We need to
-            # discard events not for this channel. Longer term work should create only a single thread per channel.
-            # Single cameras (including hybrid/thermal cameras that report events on an internal
-            # sub-channel index different from their configured channel) aren't sharing this stream
-            # with other config entries, so there's nothing to filter out.
-            if index != self._channel and self.is_multichannel_device():
-                continue
+                # This is a short term fix. Right now for NVRs/DVRs this integration creates a thread per channel to listen to events. Every thread gets the same response. We need to
+                # discard events not for this channel. Longer term work should create only a single thread per channel.
+                # Single cameras (including hybrid/thermal cameras that report events on an internal
+                # sub-channel index different from their configured channel) aren't sharing this stream
+                # with other config entries, so there's nothing to filter out.
+                if index != self._channel and self.is_multichannel_device():
+                    continue
 
-            # Put the vent on the HA event bus
-            event["name"] = self.get_device_name()
-            event["DeviceName"] = self.get_device_name()
-            self.hass.bus.fire("dahua_event_received", event)
+                # Put the vent on the HA event bus
+                event["name"] = self.get_device_name()
+                event["DeviceName"] = self.get_device_name()
+                self.hass.bus.fire("dahua_event_received", event)
 
-            # When there's an event start we'll update the a map x to the current timestamp in seconds for the event.
-            # We'll reset it to 0 when the event stops.
-            # We'll use these timestamps in binary_sensor to know how long to trigger the sensor
+                # When there's an event start we'll update the a map x to the current timestamp in seconds for the event.
+                # We'll reset it to 0 when the event stops.
+                # We'll use these timestamps in binary_sensor to know how long to trigger the sensor
 
-            # This is the event code, example: VideoMotion, CrossLineDetection, etc
-            event_names = self.translate_event_code(event)
+                # This is the event code, example: VideoMotion, CrossLineDetection, etc
+                event_names = self.translate_event_code(event)
 
-            for event_name in event_names:
-                event_key = self.get_event_key(event_name)
-                listener = self._dahua_event_listeners.get(event_key)
-                if listener is not None:
-                    action = event["action"]
-                    if action == "Start":
-                        self._dahua_event_timestamp[event_key] = int(time.time())
-                        listener()
-                    elif action == "Stop":
-                        self._dahua_event_timestamp[event_key] = 0
-                        listener()
+                for event_name in event_names:
+                    event_key = self.get_event_key(event_name)
+                    listener = self._dahua_event_listeners.get(event_key)
+                    if listener is not None:
+                        action = event["action"]
+                        if action == "Start":
+                            self._dahua_event_timestamp[event_key] = int(time.time())
+                            listener()
+                        elif action == "Stop":
+                            self._dahua_event_timestamp[event_key] = 0
+                            listener()
+            except Exception:
+                # One malformed/unexpected event (e.g. an odd payload shape from a hybrid/thermal
+                # channel) must not take down the whole event stream connection - that would drop
+                # every event behind it until the next reconnect.
+                _LOGGER.exception("Failed to process event from %s: %s", self.get_address(), event)
 
     def translate_event_code(self, event: dict):
         """

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -772,14 +772,53 @@ class DahuaClient:
         if self._username is not None and self._password is not None:
             response = None
 
+            # The camera sends a multipart stream delimited by "--myboundary\n". TCP chunk
+            # boundaries (from iter_chunks) almost never line up with these event boundaries, so
+            # dispatching each raw chunk straight to on_receive regularly splits one event's JSON
+            # payload across two chunks. That either silently drops the event (truncated JSON
+            # fails to parse) or throws mid-parse and kills the whole connection - which can drop
+            # a paired "Stop" event and leave a binary_sensor stuck on. Buffer bytes here and only
+            # hand off blocks that are known-complete (bounded by two boundary markers).
+            buffer = b""
+            # Safety valve: if we somehow never see a boundary (e.g. camera sends something
+            # unexpected), don't let the buffer grow forever - drop it and let the stream error
+            # out so the caller reconnects.
+            max_buffer_size = 1_000_000
+            boundary_marker = b"--myboundary"
+            marker_len = len(boundary_marker)
+
             try:
                 auth = DigestAuth(self._username, self._password, self._session)
-                response = await auth.request("GET", url)
+                # sock_read: the camera sends a heartbeat every 5s (see heartbeat=5 above). If we
+                # go well beyond that without any bytes, the connection is dead but silently so
+                # (no FIN/RST) - without this the read can hang indefinitely instead of raising so
+                # _async_stream_events can reconnect.
+                timeout = aiohttp.ClientTimeout(total=None, sock_read=30, sock_connect=TIMEOUT_SECONDS)
+                response = await auth.request("GET", url, timeout=timeout)
                 response.raise_for_status()
 
                 # https://docs.aiohttp.org/en/stable/streams.html
                 async for data, _ in response.content.iter_chunks():
-                    on_receive(data, channel)
+                    buffer += data
+                    if len(buffer) > max_buffer_size:
+                        buffer = b""
+                        raise ValueError("Event stream buffer exceeded %d bytes without a boundary" % max_buffer_size)
+
+                    while True:
+                        idx = buffer.find(boundary_marker)
+                        if idx == -1:
+                            buffer = b""
+                            break
+                        if idx > 0:
+                            buffer = buffer[idx:]
+
+                        next_idx = buffer.find(boundary_marker, marker_len)
+                        if next_idx == -1:
+                            break
+
+                        complete_block = buffer[:next_idx]
+                        buffer = buffer[next_idx:]
+                        on_receive(complete_block, channel)
             except asyncio.CancelledError:
                 raise
             except Exception as exception:

--- a/custom_components/dahua/dahua_utils.py
+++ b/custom_components/dahua/dahua_utils.py
@@ -29,53 +29,35 @@ def hass_brightness_to_dahua_brightness(hass_brightness: int) -> int:
 
 # https://github.com/rroller/dahua/issues/166
 def parse_event(data: str) -> list[dict[str, any]]:
-    # This will turn the event stream data into a list of events, where each item in the list is a dictionary and where
-    # the key of the dictionary is the key is for example "Code" and the value is "VideoMotion", etc
-    # That's a little hard to explain... so look at this example...
-    # Code=VideoMotion;action=Start;index=0;data={
-    #    "Id" : [ 0 ],
-    #    "RegionName" : [ "Region1" ],
-    #    "SmartMotionEnable" : true
-    # }
-    # will be turned into
-    # [{
-    #   "Code":"VideoMotion",
-    #   "action":"Start",
-    #   "index":"0",
-    #   ...
-    # }]
-
-    # We will split on "--myboundary" and then skip the first 3 lines so we end up with a string that starts with Code=
-    event_blocks = re.split(r'--myboundary\n', data)
+    event_blocks = re.split(r'--myboundary\r?\n?', data)
 
     events = []
 
     for event_block in event_blocks:
-        # Skip the first 3 lines... the first line looks like: Content-Type: text/plain
-        s = event_block.split("\n", 3)
-        if len(s) < 3:
-            continue
-        event_block = s[3].strip()
-        if not event_block.startswith("Code="):
+        event_block = event_block.strip()
+        if not event_block:
             continue
 
-        # At this point we'll have something that looks like this...
-        # Code=VideoMotion;action=Start;index=0;data={
-        #    "Id" : [ 0 ],
-        #    "RegionName" : [ "Region1" ],
-        #    "SmartMotionEnable" : true
-        # }
-        # And we want to put each key/value pair into a dictionary...
+        # Look for Code= in the block regardless of how many header lines precede it
+        code_pos = event_block.find("Code=")
+        if code_pos == -1:
+            continue
+        event_content = event_block[code_pos:].strip()
+
+        # Extract key/value pairs safely
         event = dict()
-        for key_value in event_block.split(';'):
+        for key_value in event_content.split(';'):
+            key_value = key_value.strip()
+            if not key_value or '=' not in key_value:
+                continue
             key, value = key_value.split('=', 1)
             event[key] = value
 
-        # data is a json string, convert it to real json and add it back to the output dic
+        # data is a json string, convert it to real json and add it back to the output dict
         if "data" in event:
             try:
-                data = json.loads(event["data"])
-                event["data"] = data
+                data_json = json.loads(event["data"])
+                event["data"] = data_json
             except Exception:  # pylint: disable=broad-except
                 pass
         events.append(event)


### PR DESCRIPTION
## Problem

I have a DHI-TPC-BF1241 (hybrid visual+thermal camera) alongside several regular IPC-HFW3849T1-AS-PV cameras. The regular cameras receive line-crossing/region events fine, but the hybrid camera never received any events at all, not even `VideoMotion`.

## Root cause 1: `is_doorbell()` false positive

```python
def is_doorbell(self) -> bool:
    m = self.model.upper()
    return m.startswith("VTO") or m.startswith("DH-VTO") or (
        "NVR" not in m and m.startswith("DHI")) or ...
```

Any model starting with `DHI-` (and not containing `NVR`) is treated as a doorbell (VTO). That's too broad - it's meant to catch doorbell models like `DHI-VTO2211G-P`, but it also matches regular cameras that happen to use the common `DHI-` prefix, like `DHI-TPC-BF1241`. Once misclassified, the integration opens a VTO connection on port 5000 instead of the normal event stream, which the camera doesn't support, so it silently never receives any events.

Fix: match on the `VTO` substring instead, which still catches `VTO...`, `DH-VTO...`, `DHI-VTO...`, without matching unrelated `DHI-` prefixed models.

## Root cause 2: channel filter drops IVS events on hybrid cameras

After fixing `is_doorbell()`, the camera started connecting normally, but cross-line/cross-region events were still silently dropped:

```python
if index != self._channel:
    continue
```

This filter exists so NVRs/DVRs - where multiple config entries (one per channel) share one event stream - can discard events meant for other channels. But the DHI-TPC-BF1241 reports `CrossLineDetection`/`CrossRegionDetection` on an internal sub-channel index (`index: 1`) that differs from its configured video channel (`channel: 0`), so this filter dropped them too, even for a single standalone entry with no channel-sharing going on.

Fix: only apply the filter when it's actually needed - i.e. when more than one config entry points at the same device address. A standalone camera (including a hybrid one with only one entry) isn't sharing its event stream with anything else, so there's nothing to filter out.

## Update: further event loss found once split into two entries (visual + thermal)

Running this in production against a two-entry setup (visual on one channel, thermal on the other, both against the same device address) surfaced three more ways events were getting lost:

**Root cause 3: a second connection to the same device silently goes stale.** Once two config entries share a device address, each opened its own `attach` event-stream connection. The camera only pushes real event payloads to the *first* open session - a second, independent connection doesn't error, it just keeps receiving heartbeats and nothing else. Fix: one connection is now shared per physical device address; the coordinator that opens it fans every event out to all peer coordinators for that address (each peer still filters by its own channel per Root cause 2's fix), and ownership hands off to a peer if the owner disconnects.

**Root cause 4: TCP chunk boundaries don't line up with event boundaries.** Chunks from `response.content.iter_chunks()` were passed straight to `on_receive`, but the camera's multipart stream is delimited by `--myboundary`, not by TCP chunk boundaries - so a single event's JSON payload frequently got split across two chunks, either silently failing to parse or throwing mid-parse and killing the whole connection (dropping any paired Stop event behind it, leaving a `binary_sensor` stuck on). Fix: buffer bytes and only dispatch blocks bounded by two `--myboundary` markers.

**Root cause 5: `parse_event()` assumed a fixed number of header lines before `Code=`.** Events from the thermal channel don't always have the same header shape as the visual channel, so the fixed-offset split silently dropped them. Fix: search for `Code=` wherever it falls in the block instead of assuming its position.

Also added: exception isolation per individual event (so one malformed/unexpected payload doesn't take down the whole stream connection instead of just being skipped), and a `sock_read` timeout against the 5s heartbeat to detect a dead-but-silent connection (no FIN/RST) so it reconnects instead of hanging forever.

## Testing

- IPC-HFW3849T1-AS-PV (regular camera, unaffected by any of these bugs): confirmed still works and channel filtering still applies correctly.
- DHI-TPC-BF1241 added as a single entry: confirmed `is_doorbell()` now returns `False`, event stream connects normally, and `CrossRegionDetection`/`CrossLineDetection` events arrive in the debug log with `index: 1`.
- DHI-TPC-BF1241 split into two entries (visual on one channel, thermal on the other): confirmed via recorder history that a cross-region event correctly flips only the correct channel's sensor, and that both channels keep receiving live events over an extended run (no more silent stalls on the second entry, no truncated/dropped events at TCP chunk boundaries).
