### PR TITLE
Reuse the digest challenge instead of re-authenticating on every request

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -35,6 +35,9 @@ class DahuaClient:
     ) -> None:
         self._username = username
         self._password = password
+        # One digest challenge shared by every request this client makes, so a
+        # call doesn't have to take a 401 before it can authenticate.
+        self._digest_state = {}
         # Strip trailing slashes from address to prevent malformed URLs like http://host/:80
         self._address = address.rstrip('/')
         self._session = session
@@ -773,7 +776,7 @@ class DahuaClient:
             response = None
 
             try:
-                auth = DigestAuth(self._username, self._password, self._session)
+                auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
                 response = await auth.request("GET", url)
                 response.raise_for_status()
 
@@ -814,7 +817,7 @@ class DahuaClient:
         async with async_timeout.timeout(TIMEOUT_SECONDS):
             response = None
             try:
-                auth = DigestAuth(self._username, self._password, self._session)
+                auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
                 response = await auth.request("GET", self._base + url)
                 response.raise_for_status()
 
@@ -830,7 +833,7 @@ class DahuaClient:
             async with async_timeout.timeout(TIMEOUT_SECONDS):
                 response = None
                 try:
-                    auth = DigestAuth(self._username, self._password, self._session)
+                    auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
                     response = await auth.request("GET", url)
                     response.raise_for_status()
                     data = await response.text()

--- a/custom_components/dahua/digest.py
+++ b/custom_components/dahua/digest.py
@@ -12,6 +12,9 @@ from yarl import URL
 # Copied and then modified from https://github.com/aio-libs/aiohttp/pull/2213
 # I really wish this was baked into aiohttp :-(
 
+# How many times one request may answer a 401 before giving up.
+MAX_AUTH_ATTEMPTS = 3
+
 
 class DigestAuth:
     """HTTP digest authentication helper.
@@ -25,39 +28,102 @@ class DigestAuth:
 
         self.username = username
         self.password = password
-        self.last_nonce = previous.get("last_nonce", "")
-        self.nonce_count = previous.get("nonce_count", 0)
-        self.challenge = previous.get("challenge")
-        self.args = {}
+        # Held by reference, so a challenge accepted by one request is reused by
+        # the next. Callers passing nothing keep the old per-request behaviour.
+        self._state = previous
         self.session = session
 
+    # Challenge and nonce count live in the shared state, exposed as attributes.
+    @property
+    def challenge(self):
+        return self._state.get("challenge")
+
+    @challenge.setter
+    def challenge(self, value):
+        self._state["challenge"] = value
+
+    @property
+    def last_nonce(self):
+        return self._state.get("last_nonce", "")
+
+    @last_nonce.setter
+    def last_nonce(self, value):
+        self._state["last_nonce"] = value
+
+    @property
+    def nonce_count(self):
+        return self._state.get("nonce_count", 0)
+
+    @nonce_count.setter
+    def nonce_count(self, value):
+        self._state["nonce_count"] = value
+
     async def request(self, method, url, *, headers=None, **kwargs):
-        """Makes a request"""
+        """Makes a request, absorbing digest challenges up to a fixed budget."""
         if headers is None:
             headers = {}
 
-        # Save the args so we can re-run the request
-        self.args = {"method": method, "url": url, "headers": headers, "kwargs": kwargs}
+        refused = 0
+        response = None
 
-        if self.challenge:
-            authorization = self._build_digest_header(method.upper(), url)
-            headers["AUTHORIZATION"] = authorization
+        for _ in range(MAX_AUTH_ATTEMPTS):
+            attempt_headers = dict(headers)
+            sent_nonce = None
 
-        response = await self.session.request(method, url, headers=headers, **kwargs)
+            if self.challenge:
+                authorization = self._build_digest_header(method.upper(), url)
+                if authorization:
+                    attempt_headers["AUTHORIZATION"] = authorization
+                    sent_nonce = self.challenge.get("nonce")
+                else:
+                    # A challenge we cannot build a header from would otherwise
+                    # fail every later request too. Drop it and probe instead.
+                    self.challenge = None
 
-        # Only try performing digest authentication if the response status is from 401
-        if response.status == 401:
-            return await self._handle_401(response)
+            response = await self.session.request(method, url, headers=attempt_headers, **kwargs)
+
+            if response.status != 401:
+                return response
+
+            challenge = self._parse_401(response)
+            if challenge is None:
+                return response
+
+            if sent_nonce is not None:
+                stale = str(challenge.get("stale", "")).lower() == "true"
+                if challenge.get("nonce") == sent_nonce and not stale:
+                    # Same nonce, not flagged stale: either the credentials are
+                    # wrong or our nonce count arrived out of order. One retry
+                    # covers the count; a second failure means it is the password.
+                    refused += 1
+                    if refused > 1:
+                        self.challenge = None
+                        return response
+
+            response.close()
+            self.challenge = challenge
 
         return response
+
+    def _parse_401(self, response: ClientResponse):
+        """Returns the digest challenge carried by a 401, or None."""
+        parts = response.headers.get("www-authenticate", "").split(" ", 1)
+        if "digest" == parts[0].lower() and len(parts) > 1:
+            try:
+                return parse_key_value_list(parts[1])
+            except (IndexError, ValueError):
+                return None
+        return None
 
     def _build_digest_header(self, method, url):
         """
         :rtype: str
         """
 
-        realm = self.challenge["realm"]
-        nonce = self.challenge["nonce"]
+        realm = self.challenge.get("realm")
+        nonce = self.challenge.get("nonce")
+        if realm is None or nonce is None:
+            return ""
         qop = self.challenge.get("qop")
         algorithm = self.challenge.get("algorithm", "MD5").upper()
         opaque = self.challenge.get("opaque")
@@ -133,29 +199,6 @@ class DigestAuth:
             base += ', qop="auth", nc=%s, cnonce="%s"' % (ncvalue, cnonce)
 
         return "Digest %s" % base
-
-    async def _handle_401(self, response: ClientResponse):
-        """
-        Takes the given response and tries digest-auth, if needed.
-        :rtype: ClientResponse
-        """
-        auth_header = response.headers.get("www-authenticate", "")
-
-        parts = auth_header.split(" ", 1)
-        if "digest" == parts[0].lower() and len(parts) > 1:
-            # Close the initial response since we are going making another request and return that response
-            response.close()
-
-            self.challenge = parse_key_value_list(parts[1])
-
-            return await self.request(
-                self.args["method"],
-                self.args["url"],
-                headers=self.args["headers"],
-                **self.args["kwargs"],
-            )
-
-        return response
 
 
 def parse_pair(pair):

--- a/tests/dahua/test_digest.py
+++ b/tests/dahua/test_digest.py
@@ -1,0 +1,220 @@
+"""Tests for custom_components.dahua.digest."""
+import asyncio
+import hashlib
+import re
+
+from custom_components.dahua.client import DahuaClient
+from custom_components.dahua.digest import DigestAuth
+
+REALM = "DahuaRpc"
+USER = "admin"
+PASSWORD = "secret"
+
+
+def _params(header: str) -> dict:
+    """Parse the parameters out of an Authorization header."""
+    body = header.partition(" ")[2]
+    return {m[0]: (m[1] or m[2])
+            for m in re.findall(r'(\w+)=(?:"([^"]*)"|([^,\s]+))', body)}
+
+
+def _expected_response(method: str, params: dict, password: str) -> str:
+    """Recompute the digest the client should have sent."""
+    def h(value):
+        return hashlib.md5(value.encode()).hexdigest()
+
+    ha1 = h("%s:%s:%s" % (params.get("username", ""), REALM, password))
+    ha2 = h("%s:%s" % (method, params.get("uri", "")))
+    if params.get("qop"):
+        return h(":".join([ha1, params.get("nonce", ""), params.get("nc", ""),
+                           params.get("cnonce", ""), "auth", ha2]))
+    return h("%s:%s:%s" % (ha1, params.get("nonce", ""), ha2))
+
+
+class FakeResponse:
+    def __init__(self, status, headers=None, body=""):
+        self.status = status
+        self.headers = headers or {}
+        self.closed = False
+        self._body = body
+
+    def close(self):
+        self.closed = True
+
+    async def text(self):
+        return self._body
+
+    async def read(self):
+        return self._body.encode()
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise AssertionError("unexpected %s in this test" % self.status)
+
+
+class FakeSession:
+    """A device that actually verifies the digest it is sent.
+
+    Requests suspend before replying so concurrent callers genuinely overlap
+    rather than each running to completion in one scheduler step.
+    """
+
+    def __init__(self, password=PASSWORD, nonce="nonce-1", strict_nc=False, body="ok=1"):
+        self.requests = []
+        self.password = password
+        self.nonce = nonce
+        self.strict_nc = strict_nc
+        self.body = body
+        self.seen_nc = set()
+
+    def _challenge(self, stale=False):
+        header = 'Digest realm="%s", nonce="%s", qop="auth"' % (REALM, self.nonce)
+        if stale:
+            header += ', stale="true"'
+        return {"www-authenticate": header}
+
+    async def request(self, method, url, headers=None, **kwargs):
+        headers = headers or {}
+        self.requests.append({"method": method, "url": url, "headers": dict(headers)})
+        await asyncio.sleep(0)  # let siblings interleave
+
+        auth = headers.get("AUTHORIZATION")
+        if not auth:
+            return FakeResponse(401, self._challenge())
+
+        params = _params(auth)
+        if params.get("nonce") != self.nonce:
+            return FakeResponse(401, self._challenge(stale=True))
+        if params.get("response") != _expected_response(method.upper(), params, self.password):
+            return FakeResponse(401, self._challenge())
+        if self.strict_nc:
+            nc = params.get("nc")
+            if nc in self.seen_nc:
+                # RFC 7616 5.5: a replayed count is refused with the same nonce.
+                return FakeResponse(401, self._challenge())
+            self.seen_nc.add(nc)
+
+        return FakeResponse(200, body=self.body)
+
+
+def nc_of(request):
+    match = re.search(r"nc=([0-9a-f]{8})", request["headers"].get("AUTHORIZATION", ""))
+    return match.group(1) if match else None
+
+
+async def test_challenge_is_reused_across_requests():
+    """The first call absorbs a 401; later calls authenticate up front."""
+    session = FakeSession()
+    state = {}
+
+    first = await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/one")
+    assert first.status == 200
+    assert len(session.requests) == 2  # probe, then authenticated retry
+
+    second = await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/two")
+    assert second.status == 200
+    assert len(session.requests) == 3  # no second probe
+    assert "AUTHORIZATION" in session.requests[2]["headers"]
+
+
+async def test_client_reuses_one_challenge_across_calls():
+    """The client must thread one challenge through every call site."""
+    session = FakeSession(body="deviceType=NVR")
+    client = DahuaClient(USER, PASSWORD, "d", 80, 554, session)
+
+    await client.get("/cgi-bin/magicBox.cgi?action=getSystemInfo")
+    await client.get("/cgi-bin/magicBox.cgi?action=getDeviceType")
+
+    # Four requests would mean each call re-challenged independently.
+    assert len(session.requests) == 3
+
+
+async def test_without_shared_state_every_request_rechallenges():
+    """Callers that pass no state keep the old behaviour."""
+    session = FakeSession()
+
+    for _ in range(3):
+        await DigestAuth(USER, PASSWORD, session).request("GET", "http://d/x")
+
+    assert len(session.requests) == 6  # two per call
+
+
+async def test_nonce_count_increments_across_requests():
+    """nc must advance per RFC 2617 while the nonce is unchanged."""
+    session = FakeSession()
+    state = {}
+
+    for _ in range(3):
+        await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/x")
+
+    assert [nc_of(r) for r in session.requests if nc_of(r)] == [
+        "00000001", "00000002", "00000003"]
+
+
+async def test_concurrent_requests_get_distinct_nonce_counts():
+    """Requests genuinely in flight together must not reuse a count."""
+    session = FakeSession()
+    state = {}
+
+    await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/prime")
+    before = len(session.requests)
+
+    results = await asyncio.gather(*[
+        DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/%d" % i)
+        for i in range(5)
+    ])
+
+    assert [r.status for r in results] == [200] * 5
+    counts = [nc_of(r) for r in session.requests[before:]]
+    assert len(set(counts)) == len(counts) == 5, "nonce counts collided: %s" % counts
+
+
+async def test_out_of_order_nonce_count_recovers():
+    """A device refusing a replayed count must not fail the call outright."""
+    session = FakeSession(strict_nc=True)
+    state = {}
+    await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/prime")
+
+    # Replay the count the priming call already burned.
+    state["last_nonce"] = ""
+    state["nonce_count"] = 0
+
+    response = await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/x")
+    assert response.status == 200
+
+
+async def test_rejected_credentials_stop_after_budget():
+    """A 401 that keeps its challenge header must not retry forever."""
+    session = FakeSession(password="something-else")
+
+    response = await DigestAuth(USER, "wrong", session, {}).request("GET", "http://d/x")
+
+    assert response.status == 401
+    assert len(session.requests) <= 3
+
+
+async def test_stale_challenge_is_refreshed_and_succeeds():
+    """A rotated nonce is re-learned and the call still succeeds."""
+    session = FakeSession(nonce="nonce-1")
+    state = {}
+    await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/x")
+    assert state["challenge"]["nonce"] == "nonce-1"
+
+    session.nonce = "nonce-2"
+    before = len(session.requests)
+
+    response = await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/y")
+    assert response.status == 200
+    assert state["challenge"]["nonce"] == "nonce-2"
+    assert len(session.requests) - before == 2  # stale attempt, then success
+
+
+async def test_unusable_cached_challenge_is_discarded():
+    """A cached challenge missing required fields must not poison later calls."""
+    session = FakeSession()
+    state = {"challenge": {"qop": "auth"}}  # no realm, no nonce
+
+    response = await DigestAuth(USER, PASSWORD, session, state).request("GET", "http://d/x")
+
+    assert response.status == 200
+    assert state["challenge"]["nonce"] == session.nonce


### PR DESCRIPTION
Fixes the "massive login/logout" behaviour reported in #577, and very likely the connection exhaustion in #511.

## The bug

`DigestAuth.__init__` takes a `previous=` argument so an accepted challenge can be carried into the next request. None of the three call sites in `client.py` ever passes it:

```python
auth = DigestAuth(self._username, self._password, self._session)
```

So `self.challenge` is always `None`, every API call goes out unauthenticated, takes a `401`, and is retried. **Two HTTP requests per logical call**, forever. The `previous` parameter has been dead code the whole time — nothing read it, nothing wrote back to it.

That is cheap on a device that supports keep-alive. It is not cheap here: my NVR answers `Connection: close` on every response, including the 401. Keep-alive is impossible, so each of those requests is its own TCP connection, TLS handshake, and **login**.

## Measurements

DHI-NVR5464-16P-EI, 12 channels configured, HTTPS on 443. Sampling the NVR's own `userManager.cgi?action=getActiveUserInfoAll` every 2 minutes:

```
mean 2.13 logins/sec  ->  7,654 logins/hour
concurrent sessions held by HA: 10-22
```

For a controlled comparison, I rebooted the NVR and caught an 8-minute window before this integration reconnected. Same device, same other clients:

| | logins/sec |
|---|---|
| everything except this integration | 0.18 – 0.24 |
| after it reconnected | **2.13** |

The device's CGI service degrades as this accumulates — response times went from ~130 ms to 3 s within 100 minutes of boot — and eventually stops answering HTTP entirely while still completing TCP connects. Only a reboot clears it. That matches #511's *"number of connections reached its limits"*, and it takes P2P/DMSS remote access down with it, since remote access is the client that must open a *new* session on demand.

@dawuhe's numbers in #577 line up: 114,300 logins in 24 h from 5 cameras is 1.32/s, against my 2.13/s from 12 channels. Same per-channel rate, different channel counts.

## What this changes

**1. The client keeps one challenge.** `DahuaClient` holds a single `_digest_state` dict and passes it at all three call sites. `DigestAuth` holds it by reference and exposes `challenge` / `last_nonce` / `nonce_count` as properties backed by it, so the rest of the class is untouched. Callers that pass nothing get their own private state and the previous behaviour, so this is not a breaking change for any other caller.

The nonce counter now advances across requests as RFC 2617 intends, rather than every request minting `nc=00000001` on its own private counter. The read-modify-write is synchronous with no `await` in it, so concurrent requests get distinct counts.

**2. The retry is bounded.** `_handle_401` recursed through `request()` with no limit. A device that rejects credentials returns 401 *with* a `www-authenticate` header, so the old code re-challenged forever. Against current `main`:

```
upstream HEAD  ->  RecursionError after 495 HTTP requests
this branch    ->  status 401 after 2
```

495 logins to the device for one API call. If any of the entries in #577 came from a config entry with stale credentials, that alone would account for a login count far above what 2x amplification explains.

The budget distinguishes the two causes of a 401 on a cached challenge: a rotated nonce or `stale=true` is retried, while the same nonce returned twice means the password is wrong and we stop. One same-nonce retry is allowed first, so a device that refuses an out-of-order `nc` per RFC 7616 §5.5 recovers instead of failing the call.

**3. A bad cached challenge no longer sticks.** `_build_digest_header` did `self.challenge["realm"]`. With a cached challenge that is now reused, one malformed 401 during a device reboot would raise `KeyError` on every subsequent request for the life of the config entry. It now returns `""`, and `request()` drops the challenge and re-probes.

## Tests

`tests/dahua/test_digest.py`, 9 tests. The fake device verifies the digest it is sent — realm, nonce, `nc`, and the MD5 response — rather than just checking a header exists, and it suspends before replying so gathered requests genuinely overlap instead of each running to completion in one scheduler step.

Covered: challenge reuse across calls; the client threading one challenge through all three call sites; unchanged behaviour when no state is passed; `nc` advancing; distinct `nc` under real concurrency; recovery from a refused out-of-order `nc`; bounded retry on bad credentials; nonce rotation refreshed *and* the retry succeeding; an unusable cached challenge being discarded.

I checked the client-level test actually pins the fix — dropping the fourth argument from the three call sites fails it.

## Effect

For a poll cycle that currently costs N connections, this costs N/2 in the steady state. It does not change how many API calls the coordinator makes per cycle, so it halves the connection and handshake load rather than eliminating it — on this device the remaining login rate is still driven by `SCAN_INTERVAL_SECONDS` (hardcoded to 30) multiplied by the number of configured channels, each of which gets its own coordinator, `ClientSession`, and permanently-open event stream. Those are worth looking at separately; I wanted to keep this PR to the auth path.

Happy to split the retry-bounding into its own PR if you'd rather take that first — it stands alone and is the smaller change.
