### PR TITLE
Bound the event stream on socket read instead of total time (fixes #596)

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -43,6 +43,10 @@ from .vto import DahuaVTOClient
 
 SCAN_INTERVAL_SECONDS = timedelta(seconds=30)
 
+# A stream that keeps heartbeating but has stopped reporting events looks
+# healthy to a read timeout, so recycle it periodically as well.
+EVENT_STREAM_MAX_LIFETIME_SECONDS = 3600
+
 SSL_CONTEXT = ssl.create_default_context()
 SSL_CONTEXT.set_ciphers("DEFAULT")
 SSL_CONTEXT.check_hostname = False
@@ -174,9 +178,14 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         while True:
             start_time = time.monotonic()
             try:
-                await self.client.stream_events(self.on_receive, self.events, self._channel)
+                await asyncio.wait_for(
+                    self.client.stream_events(self.on_receive, self.events, self._channel),
+                    timeout=EVENT_STREAM_MAX_LIFETIME_SECONDS,
+                )
             except asyncio.CancelledError:
                 raise
+            except asyncio.TimeoutError:
+                _LOGGER.debug("Recycling event stream for %s", self._address)
             except Exception as ex:
                 _LOGGER.warning("Event stream for %s ended unexpectedly: %s", self._address, ex)
 

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -12,6 +12,12 @@ from urllib.parse import quote
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 TIMEOUT_SECONDS = 20
+
+# The event stream asks the device to heartbeat at this interval, so a socket
+# that has delivered nothing for a comfortable multiple of it has stalled.
+EVENT_STREAM_HEARTBEAT_SECONDS = 5
+EVENT_STREAM_READ_TIMEOUT_SECONDS = 60
+
 SECURITY_LIGHT_TYPE = 1
 SIREN_TYPE = 2
 
@@ -768,13 +774,20 @@ class DahuaClient:
         """
         # Use codes=[All] for all codes
         codes = ",".join(events)
-        url = "{0}/cgi-bin/eventManager.cgi?action=attach&codes=[{1}]&heartbeat=5".format(self._base, codes)
+        url = "{0}/cgi-bin/eventManager.cgi?action=attach&codes=[{1}]&heartbeat={2}".format(
+            self._base, codes, EVENT_STREAM_HEARTBEAT_SECONDS)
         if self._username is not None and self._password is not None:
             response = None
 
             try:
+                # A long poll must not inherit the session's default total
+                # timeout, which tears a healthy stream down every 5 minutes.
+                # Bound it on read instead, so a socket that stops delivering
+                # is detected but one that keeps heartbeating is left alone.
+                timeout = aiohttp.ClientTimeout(
+                    total=None, sock_read=EVENT_STREAM_READ_TIMEOUT_SECONDS)
                 auth = DigestAuth(self._username, self._password, self._session)
-                response = await auth.request("GET", url)
+                response = await auth.request("GET", url, timeout=timeout)
                 response.raise_for_status()
 
                 # https://docs.aiohttp.org/en/stable/streams.html

--- a/tests/dahua/test_event_stream.py
+++ b/tests/dahua/test_event_stream.py
@@ -1,0 +1,78 @@
+"""Tests for the event stream's timeout behaviour."""
+import asyncio
+
+import aiohttp
+from aiohttp import web
+import pytest
+
+from custom_components.dahua import client as client_module
+from custom_components.dahua.client import DahuaClient
+
+
+class CapturingSession:
+    """Records the kwargs a request was issued with."""
+
+    def __init__(self):
+        self.kwargs = None
+
+    async def request(self, method, url, headers=None, **kwargs):
+        self.kwargs = kwargs
+        raise RuntimeError("stop here, we only want the arguments")
+
+
+async def test_stream_request_is_bounded_on_read_not_total():
+    """The long poll must not inherit the session's default total timeout."""
+    session = CapturingSession()
+    client = DahuaClient("u", "p", "d", 80, 554, session)
+
+    # stream_events swallows its own exceptions, so this returns normally.
+    await client.stream_events(lambda data, channel: None, ["All"], 0)
+
+    timeout = session.kwargs["timeout"]
+    assert isinstance(timeout, aiohttp.ClientTimeout)
+    # A total timeout would tear down a healthy stream on a fixed cycle.
+    assert timeout.total is None
+    assert timeout.sock_read == client_module.EVENT_STREAM_READ_TIMEOUT_SECONDS
+
+
+async def test_heartbeat_interval_matches_the_read_timeout():
+    """The read timeout is only meaningful if it exceeds the heartbeat."""
+    assert (client_module.EVENT_STREAM_READ_TIMEOUT_SECONDS
+            > client_module.EVENT_STREAM_HEARTBEAT_SECONDS * 2)
+
+
+async def test_stalled_stream_ends_so_the_caller_can_reconnect(monkeypatch):
+    """A socket that goes quiet must not hold the stream open forever."""
+    monkeypatch.setattr(client_module, "EVENT_STREAM_READ_TIMEOUT_SECONDS", 1)
+
+    async def handler(request):
+        response = web.StreamResponse(status=200)
+        await response.prepare(request)
+        await response.write(b"Heartbeat")
+        await asyncio.sleep(5)  # connection stays open, nothing more arrives
+        return response
+
+    app = web.Application()
+    app.router.add_get("/cgi-bin/eventManager.cgi", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = list(runner.addresses)[0][1]
+
+    session = aiohttp.ClientSession()
+    client = DahuaClient("u", "p", "127.0.0.1", port, 554, session)
+    received = []
+
+    try:
+        await asyncio.wait_for(
+            client.stream_events(lambda data, channel: received.append(data), ["All"], 0),
+            timeout=10,
+        )
+    except asyncio.TimeoutError:
+        pytest.fail("stream did not end after the socket went quiet")
+    finally:
+        await session.close()
+        await runner.cleanup()
+
+    assert received, "the heartbeat before the stall should have been delivered"


### PR DESCRIPTION
Fixes #596. Thanks @slash133 — the report was precise enough to reproduce directly, and the mock-server approach you described is what I used to measure it.

One correction to the diagnosis, and it changes the patch.

## The stream does not hang forever

`ClientSession(connector=connector)` inherits aiohttp's default `ClientTimeout(total=300)`, and that timeout **does** apply while iterating a streaming body. Measured against a mock `eventManager.cgi` that sends two heartbeats and then goes silent with the socket open:

```
socket goes quiet     ->  stream ended after 300.7s
```

`stream_events` swallows the resulting `TimeoutError` at debug level and returns, `_async_stream_events` sees a normal return and reconnects. So a stalled stream self-heals, worst case ~5 minutes — not indefinitely.

That doesn't make the report wrong; it makes it *cheaper to fix and more valuable than it looks*, because of what the same measurement turns up next.

## The same default is silently recycling healthy streams

Same mock server, but heartbeating normally the whole time:

```
healthy heartbeats    ->  stream ended after 300.3s (300 heartbeats delivered)
```

**Every event stream is being torn down and reconnected every five minutes**, per configured channel, with only a debug-level log to show for it. On an NVR that is one re-auth per channel per 5 minutes — on my 12-channel NVR, 144 event-stream reconnects an hour that nobody asked for. (Related: #577.)

## What this changes

**1. Bound the long poll on read, not total.**

```python
timeout = aiohttp.ClientTimeout(total=None, sock_read=EVENT_STREAM_READ_TIMEOUT_SECONDS)
response = await auth.request("GET", url, timeout=timeout)
```

```
                        before      after
socket goes quiet       300.7s      61.1s
healthy heartbeats      300.3s      not cut
```

To confirm the override rather than infer it, I shrank the *session* default to 10s and re-ran the healthy case: unpatched ended at 10.3s, patched was still streaming at 25s.

`sock_read` is 60s against a 5s heartbeat, so it cannot fire on a working stream. The heartbeat interval was hardcoded in the attach URL; it's now the constant the timeout is checked against, so the two can't drift apart.

**2. Recycle the stream once an hour.**

This is the part that isn't optional. `sock_read` only sees a socket that stops delivering *bytes*. A stream that keeps heartbeating while no longer reporting events is invisible to it — I reproduced that mode too, and it hangs just as thoroughly:

```
heartbeats but no events, unpatched  ->  ended at 300.3s (only because total fired)
```

Today that zombie is cleared by accident, by the very 5-minute teardown this PR removes. Dropping `total` without replacing it would turn a 5-minute recovery into a permanent one. So `_async_stream_events` now wraps the call in `asyncio.wait_for(..., 3600)` and treats the timeout as a normal recycle.

An hour is a deliberate trade: 12× fewer reconnects than the current accidental behaviour, while still bounding a zombie stream to an hour — which would have caught the "frozen for over an hour" case in the report. This is @slash133's own suggested safety net, with the interval chosen to be strictly cheaper than what the code already does.

## Tests

`tests/dahua/test_event_stream.py`, 3 tests, ~5s:

- the request is issued with `total=None` and `sock_read` set — the property that stops healthy streams being recycled;
- the read timeout comfortably exceeds the heartbeat interval, so it can't fire on a live stream;
- a real aiohttp server that goes quiet mid-stream causes `stream_events` to return, so the caller can reconnect (read timeout monkeypatched to 1s to keep it fast).

## Notes

- No change to the reconnect logic in `_async_stream_events` beyond the recycle branch; the existing "failed quickly, retry in 60s" backoff is untouched.
- VTO doorbell streaming (`vto.py`) is a raw TCP protocol on port 5000 and is unaffected.
- Independent of #597 — this branches from `main` and the two don't overlap.
