### PR TITLE
Send the channel number, not the channel index, to ptz.cgi

### DIFF
--- a/custom_components/dahua/camera.py
+++ b/custom_components/dahua/camera.py
@@ -350,7 +350,7 @@ class DahuaCamera(DahuaBaseEntity, Camera):
 
     async def async_goto_preset_position(self, position: int):
         """Go to a preset, using RPC2 only for the SDT4E425."""
-        channel = self._logical_channel
+        channel = self._channel_number
         if is_sdt4e425(self._coordinator.get_model()):
             await self._coordinator.client.async_goto_preset_rpc2(1, position)
         else:

--- a/custom_components/dahua/select.py
+++ b/custom_components/dahua/select.py
@@ -111,7 +111,7 @@ class DahuaCameraPresetPositionSelect(DahuaBaseEntity, SelectEntity):
                 self._rpc2_channel, int(option)
             )
         else:
-            channel = self._coordinator.get_channel()
+            channel = self._coordinator.get_channel_number()
             await self._coordinator.client.async_goto_preset_position(channel, int(option))
         await self._coordinator.async_refresh()
 

--- a/tests/dahua/test_ptz_channel.py
+++ b/tests/dahua/test_ptz_channel.py
@@ -1,0 +1,100 @@
+"""ptz.cgi takes the channel number, not the 0-based channel index."""
+
+from types import SimpleNamespace
+
+from custom_components.dahua.camera import DahuaCamera
+from custom_components.dahua.select import DahuaCameraPresetPositionSelect
+
+
+class _CapturingClient:
+    """Records the channel handed to the PTZ CGI call."""
+
+    def __init__(self):
+        self.channel = None
+        self.position = None
+
+    async def async_goto_preset_position(self, channel, position):
+        self.channel = channel
+        self.position = position
+        return {}
+
+
+class _FakeCoordinator:
+    def __init__(self, channel_index, channel_number, model="OTHER"):
+        self.client = _CapturingClient()
+        self._channel_index = channel_index
+        self._channel_number = channel_number
+        self._model = model
+        self.data = {}
+
+    def get_channel(self):
+        return self._channel_index
+
+    def get_channel_number(self):
+        return self._channel_number
+
+    def get_model(self):
+        return self._model
+
+    async def async_refresh(self):
+        return None
+
+
+def _select_for(coordinator):
+    """Build the entity without running Home Assistant's entity plumbing."""
+    entity = object.__new__(DahuaCameraPresetPositionSelect)
+    entity._coordinator = coordinator
+    entity._rpc2_channel = None
+    return entity
+
+
+def _camera_for(coordinator):
+    entity = object.__new__(DahuaCamera)
+    entity._coordinator = coordinator
+    entity._logical_channel = coordinator.get_channel()
+    entity._channel_number = coordinator.get_channel_number()
+    return entity
+
+
+async def test_select_sends_the_channel_number_not_the_index():
+    """On an NVR the index and the number differ; ptz.cgi wants the number."""
+    coordinator = _FakeCoordinator(channel_index=2, channel_number=3)
+
+    await _select_for(coordinator).async_select_option("4")
+
+    assert coordinator.client.channel == 3, "sent the 0-based index to ptz.cgi"
+    assert coordinator.client.position == 4
+
+
+async def test_goto_preset_service_sends_the_channel_number_not_the_index():
+    """The goto_preset_position service had the same defect as the select."""
+    coordinator = _FakeCoordinator(channel_index=2, channel_number=3)
+
+    await _camera_for(coordinator).async_goto_preset_position(4)
+
+    assert coordinator.client.channel == 3, "sent the 0-based index to ptz.cgi"
+    assert coordinator.client.position == 4
+
+
+async def test_channel_number_equal_to_index_is_respected():
+    """Older firmware reports number == index; the coordinator detects that.
+
+    Reading get_channel_number() keeps that correction. Deriving the channel as
+    index + 1 would silently undo it.
+    """
+    coordinator = _FakeCoordinator(channel_index=2, channel_number=2)
+
+    await _select_for(coordinator).async_select_option("1")
+    assert coordinator.client.channel == 2
+
+    await _camera_for(coordinator).async_goto_preset_position(1)
+    assert coordinator.client.channel == 2
+
+
+async def test_select_manual_is_a_no_op():
+    """Manual is a readback placeholder, not a position to command."""
+    coordinator = _FakeCoordinator(channel_index=2, channel_number=3)
+
+    await _select_for(coordinator).async_select_option("Manual")
+
+    assert coordinator.client.channel is None


### PR DESCRIPTION
Fixes #592. Very likely also fixes #522.

`get_channel()` is documented as *"the channel index of this camera. 0 based"*, but `ptz.cgi` expects the channel **number**. `camera.py` already uses `get_channel_number()` for the RTSP URL — the two PTZ preset paths did not.

On an NVR that means a preset moves the camera on the wrong channel, or returns `400 Bad Request` when the channel list has gaps.

### Two call sites, not one

#592 reports the select entity (`select.py`). The `goto_preset_position` **service** in `camera.py` has the identical defect and isn't mentioned there — it takes `self._logical_channel`, which is `get_channel()`. That is the likely cause of #522, where a preset called from an automation or Node-RED does nothing. Both are fixed here.

### Why `get_channel_number()` and not `index + 1`

The coordinator defaults the number to `channel + 1`, but auto-detects older firmware that numbers channels from zero and resets the number back to the index:

```python
# __init__.py
self._channel_number = channel + 1
...
    if not self.is_doorbell():
        self._channel_number = self._channel
```

Computing `index + 1` at the call site would silently undo that correction. Reading `get_channel_number()` keeps it. `test_channel_number_equal_to_index_is_respected` guards this.

### Verification

In a `python:3.13` container matching the CI job, running the new tests against unmodified code and then against this change:

```
without the fix: 2 failed, 2 passed   (channel 2 sent where 3 was required)
with the fix:    4 passed
```

### Note on CI

`Run tests` will be red on this branch for reasons unrelated to it — `tests/dahua/test_issue589.py` fails at collection on `ModuleNotFoundError: turbojpeg`, and the resulting event-loop damage cascades into other tests. #599 fixes that. With #599 merged in locally, the full suite including these new tests is **22 passed**.

`async_get_ptz_preset_ids` is deliberately left alone — it talks to RPC2, not `ptz.cgi`, and its parameter is correctly named `channel_index`.