### PR TITLE
Let the event subscription be changed after setup

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -55,6 +55,15 @@ SSL_CONTEXT.verify_mode = ssl.CERT_NONE
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
+def get_configured_events(entry: ConfigEntry) -> list:
+    """Returns the events this entry subscribes to.
+
+    Options win when present, so the subscription can be changed after setup.
+    Entries created before the option existed only carry the setup-time value.
+    """
+    return entry.options.get(CONF_EVENTS, entry.data.get(CONF_EVENTS))
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up this integration using UI."""
     if hass.data.get(DOMAIN) is None:
@@ -66,7 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     address = entry.data.get(CONF_ADDRESS)
     port = int(entry.data.get(CONF_PORT))
     rtsp_port = int(entry.data.get(CONF_RTSP_PORT))
-    events = entry.data.get(CONF_EVENTS)
+    events = get_configured_events(entry)
     name = entry.data.get(CONF_NAME)
     channel = entry.data.get(CONF_CHANNEL, 0)
 

--- a/custom_components/dahua/config_flow.py
+++ b/custom_components/dahua/config_flow.py
@@ -267,6 +267,14 @@ class DahuaOptionsFlowHandler(config_entries.OptionsFlow):
                 default=self.options.get(CONF_AUTO_DETECT_CHANNEL, True),
             )
         ] = bool
+        schema[
+            vol.Optional(
+                CONF_EVENTS,
+                default=self.options.get(
+                    CONF_EVENTS, self.config_entry.data.get(CONF_EVENTS, DEFAULT_EVENTS)
+                ),
+            )
+        ] = cv.multi_select(ALL_EVENTS)
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(schema),

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -49,7 +49,8 @@
                     "light": "Light enabled",
                     "select": "Select enabled",
                     "camera": "Camera enabled",
-                    "auto_detect_channel": "Auto-detect channel index (disable if HTTP snapshot at channel=0 works but RTSP only streams on channel=1)"
+                    "auto_detect_channel": "Auto-detect channel index (disable if HTTP snapshot at channel=0 works but RTSP only streams on channel=1)",
+                    "events": "Events to subscribe to"
                 }
             }
         }

--- a/tests/dahua/test_options_events.py
+++ b/tests/dahua/test_options_events.py
@@ -1,0 +1,77 @@
+"""The event subscription must be changeable after setup, not only at setup."""
+
+from types import SimpleNamespace
+
+from custom_components.dahua import get_configured_events
+from custom_components.dahua.config_flow import DahuaOptionsFlowHandler
+
+SETUP_EVENTS = ["VideoMotion", "CrossLineDetection", "AudioMutation"]
+CHOSEN_EVENTS = ["VideoMotion"]
+
+
+def _entry(data_events=None, option_events=None):
+    data = {"events": data_events} if data_events is not None else {}
+    options = {"events": option_events} if option_events is not None else {}
+    return SimpleNamespace(data=data, options=options)
+
+
+def test_options_win_over_the_setup_value():
+    entry = _entry(data_events=SETUP_EVENTS, option_events=CHOSEN_EVENTS)
+    assert get_configured_events(entry) == CHOSEN_EVENTS
+
+
+def test_setup_value_is_used_when_the_option_was_never_set():
+    """Entries created before this option existed must keep working."""
+    entry = _entry(data_events=SETUP_EVENTS)
+    assert get_configured_events(entry) == SETUP_EVENTS
+
+
+def test_an_empty_selection_is_honoured_not_treated_as_unset():
+    """Deselecting every event means "none", not "fall back to setup"."""
+    entry = _entry(data_events=SETUP_EVENTS, option_events=[])
+    assert get_configured_events(entry) == []
+
+
+def _schema_defaults(result):
+    """Maps field name -> resolved default from a shown form."""
+    out = {}
+    for marker in result["data_schema"].schema:
+        default = getattr(marker, "default", None)
+        out[str(marker.schema)] = default() if callable(default) else default
+    return out
+
+
+async def _shown_options_form(hass, entry):
+    handler = DahuaOptionsFlowHandler()
+    handler.hass = hass
+    # Assigning config_entry is deprecated and raises under the test harness;
+    # set the attribute Home Assistant's own flow manager populates.
+    handler._config_entry = entry
+    handler.options = dict(entry.options)
+    return await handler.async_step_user()
+
+
+async def test_options_form_offers_events_defaulted_to_the_setup_value(hass):
+    entry = _entry(data_events=SETUP_EVENTS)
+
+    defaults = _schema_defaults(await _shown_options_form(hass, entry))
+
+    assert "events" in defaults, "the options screen does not expose events"
+    assert defaults["events"] == SETUP_EVENTS
+
+
+async def test_options_form_defaults_to_the_previously_chosen_events(hass):
+    entry = _entry(data_events=SETUP_EVENTS, option_events=CHOSEN_EVENTS)
+
+    defaults = _schema_defaults(await _shown_options_form(hass, entry))
+
+    assert defaults["events"] == CHOSEN_EVENTS
+
+
+async def test_platform_toggles_are_still_offered(hass):
+    """Adding events must not displace what the screen already had."""
+    defaults = _schema_defaults(await _shown_options_form(hass, _entry(SETUP_EVENTS)))
+
+    for field in ("camera", "light", "switch", "binary_sensor", "select"):
+        assert field in defaults, f"lost the {field} toggle"
+    assert "auto_detect_channel" in defaults


### PR DESCRIPTION
The events an entry subscribes to are read from `entry.data`:

```python
# __init__.py
events = entry.data.get(CONF_EVENTS)
```

`entry.data` is written once by the config flow and never offered again — `CONF_EVENTS` appears in the setup schema and nowhere in the options flow. So changing which events a camera subscribes to means **deleting the entry and adding it back**, which loses the entity IDs, their history, and every automation that refers to them.

### What this does

Adds the multi-select the setup form already uses to the options screen, and reads the value from `entry.options` with `entry.data` as the fallback:

```python
def get_configured_events(entry: ConfigEntry) -> list:
    return entry.options.get(CONF_EVENTS, entry.data.get(CONF_EVENTS))
```

- Entries created before this option existed keep working untouched.
- An empty selection is honoured as "no events", not silently treated as unset.
- The entry already reloads on an options update via the existing `entry.add_update_listener(async_reload_entry)`, so there is no extra plumbing.
- The platform toggles and `auto_detect_channel` are unchanged; a test asserts they are still offered.

### Why it matters most on an NVR

One NVR host carries one entry per channel. On the 11-entry setup this was written against, each entry subscribes to nine or ten codes:

```
VideoMotion, CrossLineDetection, AlarmLocal, VideoLoss, VideoBlind,
AudioMutation, CrossRegionDetection, SmartMotionHuman, SmartMotionVehicle, FaceDetection
```

That produces roughly **4,800 `dahua_event_received` events per day**. Dropping the codes you do not automate on is an obvious win, and today it is not reachable without rebuilding all eleven entries by hand.

### Verification

In a `python:3.13` container matching CI:

```
options screen reverted, tests kept : 2 failed, 4 passed  (KeyError: 'events')
with this change                    : 6 passed
full suite with #599 merged         : 24 passed
```

These tests import only `custom_components.dahua` and `custom_components.dahua.config_flow`, neither of which pulls in `homeassistant.components.camera`. So unlike #600 they collect and run on CI as it stands, without needing #599 first.

Only `translations/en.json` is updated for the new label; Home Assistant falls back to English for the other locales.