### PR TITLE
Make the device poll interval configurable

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -38,11 +38,13 @@ from .const import (
     STARTUP_MESSAGE,
     CONF_CHANNEL,
     CONF_AUTO_DETECT_CHANNEL,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
 )
 from .dahua_utils import parse_event
 from .vto import DahuaVTOClient
 
-SCAN_INTERVAL_SECONDS = timedelta(seconds=30)
 
 # A stream that keeps heartbeating but has stopped reporting events looks
 # healthy to a read timeout, so recycle it periodically as well.
@@ -54,6 +56,20 @@ SSL_CONTEXT.check_hostname = False
 SSL_CONTEXT.verify_mode = ssl.CERT_NONE
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
+
+def get_configured_scan_interval(entry: ConfigEntry) -> timedelta:
+    """Returns how often this entry polls its device.
+
+    Options win when present. Values below MIN_SCAN_INTERVAL are raised to it,
+    so a hand-edited entry cannot hammer the device.
+    """
+    seconds = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    try:
+        seconds = int(seconds)
+    except (TypeError, ValueError):
+        seconds = DEFAULT_SCAN_INTERVAL
+    return timedelta(seconds=max(seconds, MIN_SCAN_INTERVAL))
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up this integration using UI."""
@@ -171,7 +187,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER,
             config_entry=entry,
             name=DOMAIN,
-            update_interval=SCAN_INTERVAL_SECONDS,
+            update_interval=get_configured_scan_interval(entry),
         )
 
     async def async_start_event_listener(self):

--- a/custom_components/dahua/config_flow.py
+++ b/custom_components/dahua/config_flow.py
@@ -24,6 +24,9 @@ from .const import (
     PLATFORMS,
     CONF_CHANNEL,
     CONF_AUTO_DETECT_CHANNEL,
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
 )
 
 """
@@ -267,6 +270,12 @@ class DahuaOptionsFlowHandler(config_entries.OptionsFlow):
                 default=self.options.get(CONF_AUTO_DETECT_CHANNEL, True),
             )
         ] = bool
+        schema[
+            vol.Required(
+                CONF_SCAN_INTERVAL,
+                default=self.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+            )
+        ] = vol.All(vol.Coerce(int), vol.Range(min=MIN_SCAN_INTERVAL))
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(schema),

--- a/custom_components/dahua/const.py
+++ b/custom_components/dahua/const.py
@@ -44,9 +44,17 @@ CONF_EVENTS = "events"
 CONF_NAME = "name"
 CONF_CHANNEL = "channel"
 CONF_AUTO_DETECT_CHANNEL = "auto_detect_channel"
+CONF_SCAN_INTERVAL = "scan_interval"
 
 # Defaults
 DEFAULT_NAME = "Dahua"
+# How often the coordinator polls each device for its settings. Events do not
+# come from polling - they arrive on the event stream - so this only paces the
+# configuration read-back.
+DEFAULT_SCAN_INTERVAL = 30
+# Below this the polling costs more than it tells you, especially on an NVR
+# where every channel is a separate entry against the same host.
+MIN_SCAN_INTERVAL = 10
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -49,7 +49,8 @@
                     "light": "Light enabled",
                     "select": "Select enabled",
                     "camera": "Camera enabled",
-                    "auto_detect_channel": "Auto-detect channel index (disable if HTTP snapshot at channel=0 works but RTSP only streams on channel=1)"
+                    "auto_detect_channel": "Auto-detect channel index (disable if HTTP snapshot at channel=0 works but RTSP only streams on channel=1)",
+                    "scan_interval": "Seconds between device polls (events are not affected)"
                 }
             }
         }

--- a/tests/dahua/test_options_scan_interval.py
+++ b/tests/dahua/test_options_scan_interval.py
@@ -1,0 +1,98 @@
+"""How often an entry polls its device must be configurable after setup."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+from custom_components.dahua import get_configured_scan_interval
+from custom_components.dahua.config_flow import DahuaOptionsFlowHandler
+from custom_components.dahua.const import DEFAULT_SCAN_INTERVAL, MIN_SCAN_INTERVAL
+
+
+def _entry(**options):
+    return SimpleNamespace(data={}, options=dict(options))
+
+
+def test_defaults_to_the_previous_hardcoded_interval():
+    """Entries that never set the option keep the behaviour they had."""
+    assert get_configured_scan_interval(_entry()) == timedelta(seconds=DEFAULT_SCAN_INTERVAL)
+
+
+def test_uses_the_configured_interval():
+    assert get_configured_scan_interval(_entry(scan_interval=300)) == timedelta(seconds=300)
+
+
+def test_values_below_the_minimum_are_raised_to_it():
+    """A hand-edited entry must not be able to hammer the device."""
+    assert get_configured_scan_interval(_entry(scan_interval=1)) == timedelta(
+        seconds=MIN_SCAN_INTERVAL
+    )
+
+
+def test_a_nonsense_value_falls_back_to_the_default():
+    for bad in ("", None, "abc", []):
+        assert get_configured_scan_interval(_entry(scan_interval=bad)) == timedelta(
+            seconds=DEFAULT_SCAN_INTERVAL
+        ), f"{bad!r} did not fall back"
+
+
+def test_a_numeric_string_is_accepted():
+    """Home Assistant can hand back a string from a number field."""
+    assert get_configured_scan_interval(_entry(scan_interval="120")) == timedelta(seconds=120)
+
+
+def _schema_defaults(result):
+    out = {}
+    for marker in result["data_schema"].schema:
+        default = getattr(marker, "default", None)
+        out[str(marker.schema)] = default() if callable(default) else default
+    return out
+
+
+def _validators(result):
+    return {str(m.schema): v for m, v in result["data_schema"].schema.items()}
+
+
+async def _shown_options_form(hass, entry):
+    handler = DahuaOptionsFlowHandler()
+    handler.hass = hass
+    # Assigning config_entry is deprecated and raises under the test harness;
+    # set the attribute Home Assistant's own flow manager populates.
+    handler._config_entry = entry
+    handler.options = dict(entry.options)
+    return await handler.async_step_user()
+
+
+async def test_options_form_offers_the_interval(hass):
+    defaults = _schema_defaults(await _shown_options_form(hass, _entry()))
+
+    assert "scan_interval" in defaults, "the options screen does not expose the interval"
+    assert defaults["scan_interval"] == DEFAULT_SCAN_INTERVAL
+
+
+async def test_options_form_defaults_to_the_chosen_interval(hass):
+    defaults = _schema_defaults(await _shown_options_form(hass, _entry(scan_interval=600)))
+
+    assert defaults["scan_interval"] == 600
+
+
+async def test_options_form_rejects_an_interval_below_the_minimum(hass):
+    """The screen should refuse it rather than relying on the read-side clamp."""
+    import voluptuous as vol
+
+    validate = _validators(await _shown_options_form(hass, _entry()))["scan_interval"]
+
+    assert validate(MIN_SCAN_INTERVAL) == MIN_SCAN_INTERVAL
+    try:
+        validate(MIN_SCAN_INTERVAL - 1)
+    except vol.Invalid:
+        pass
+    else:
+        raise AssertionError("accepted an interval below the minimum")
+
+
+async def test_platform_toggles_are_still_offered(hass):
+    defaults = _schema_defaults(await _shown_options_form(hass, _entry()))
+
+    for field in ("camera", "light", "switch", "binary_sensor", "select"):
+        assert field in defaults, f"lost the {field} toggle"
+    assert "auto_detect_channel" in defaults


### PR DESCRIPTION
The coordinator polls every 30 seconds, hardcoded:

```python
SCAN_INTERVAL_SECONDS = timedelta(seconds=30)
...
update_interval=SCAN_INTERVAL_SECONDS,
```

Each cycle fans out to one unconditional CGI call plus up to eight capability-dependent ones (`async_get_config_lighting`, `async_get_disarming_linkage`, `async_get_event_notifications`, `async_get_coaxial_control_io_status`, `async_get_smart_motion_detection`, …), plus `async_get_video_in_mode` and `async_get_ptz_position` — **per entry**.

That is a lot of traffic for what it actually reads. Events do not come from polling; they arrive on the event stream. The poll only refreshes configuration state — motion detection settings, disarming linkage, event notification settings, lighting mode — and those change rarely.

It compounds on an NVR, where each channel is a separate config entry against the same host. On an eleven-entry setup, 30-second polling is on the order of a hundred thousand requests a day, and there is currently no way to slow it down short of editing the source. It is likely a contributor to #577.

### What this does

Adds the interval to the options screen:

```python
def get_configured_scan_interval(entry: ConfigEntry) -> timedelta:
    seconds = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
    ...
    return timedelta(seconds=max(seconds, MIN_SCAN_INTERVAL))
```

- Defaults to the previous 30 seconds, so nothing changes for existing entries.
- The form refuses anything below `MIN_SCAN_INTERVAL` (10s), and the read side clamps as well, so a hand-edited entry cannot hammer the device.
- A non-numeric value falls back to the default rather than raising during setup.
- The entry already reloads on an options update via the existing update listener.
- `SCAN_INTERVAL_SECONDS` is removed as it had no remaining references.

### Verification

In a `python:3.13` container matching CI:

```
options screen reverted, tests kept : 3 failed, 6 passed  (KeyError: 'scan_interval')
with this change                    : 9 passed
full suite with #599 merged         : 27 passed
```

These tests import only `custom_components.dahua`, its `const`, and `config_flow` — none of which pull in `homeassistant.components.camera` — so they collect and run on CI without needing #599 first.

Note the `Run tests` check will still be red here, from the two failures that pre-exist on `main` and that #599 fixes. This PR's own tests pass within that run.