### PR TITLE
Add an HTTPS option and let connection settings be changed after setup

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -38,6 +38,7 @@ from .const import (
     STARTUP_MESSAGE,
     CONF_CHANNEL,
     CONF_AUTO_DETECT_CHANNEL,
+    CONF_USE_HTTPS,
 )
 from .dahua_utils import parse_event
 from .vto import DahuaVTOClient
@@ -64,6 +65,16 @@ def get_configured_events(entry: ConfigEntry) -> list:
     return entry.options.get(CONF_EVENTS, entry.data.get(CONF_EVENTS))
 
 
+def get_configured_use_https(entry: ConfigEntry):
+    """Whether this entry forces HTTPS.
+
+    None means "decide from the port", which is what the client did before the
+    option existed: HTTPS only on 443. An unticked box must keep that, so it
+    reads as None rather than False.
+    """
+    return True if entry.data.get(CONF_USE_HTTPS) else None
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up this integration using UI."""
     if hass.data.get(DOMAIN) is None:
@@ -78,10 +89,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     events = get_configured_events(entry)
     name = entry.data.get(CONF_NAME)
     channel = entry.data.get(CONF_CHANNEL, 0)
+    use_https = get_configured_use_https(entry)
 
     coordinator = DahuaDataUpdateCoordinator(hass, entry=entry, events=events, address=address, port=port,
                                              rtsp_port=rtsp_port, username=username, password=password, name=name,
-                                             channel=channel)
+                                             channel=channel, use_https=use_https)
     await coordinator.async_config_entry_first_refresh()
 
     if not coordinator.last_update_success:
@@ -109,14 +121,16 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry, events: list, address: str, port: int, rtsp_port: int,
-                 username: str, password: str, name: str, channel: int) -> None:
+                 username: str, password: str, name: str, channel: int,
+                 use_https: bool = None) -> None:
         """Initialize the coordinator."""
         # Self signed certs are used over HTTPS so we'll disable SSL verification
         connector = TCPConnector(enable_cleanup_closed=True, ssl=SSL_CONTEXT)
         self._session = ClientSession(connector=connector)
 
         # The client used to communicate with Dahua devices
-        self.client: DahuaClient = DahuaClient(username, password, address, port, rtsp_port, self._session)
+        self.client: DahuaClient = DahuaClient(username, password, address, port, rtsp_port, self._session,
+                                               use_https)
 
         # self.config_entry = entry
         self.platforms = []

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -38,7 +38,8 @@ class DahuaClient:
             address: str,
             port: int,
             rtsp_port: int,
-            session: aiohttp.ClientSession
+            session: aiohttp.ClientSession,
+            use_https: bool = None
     ) -> None:
         self._username = username
         self._password = password
@@ -51,7 +52,11 @@ class DahuaClient:
         self._port = port
         self._rtsp_port = rtsp_port
 
-        protocol = "https" if int(port) == 443 else "http"
+        # Callers that do not say keep the old behaviour: HTTPS only on 443.
+        if use_https is None:
+            use_https = int(port) == 443
+        self._use_https = use_https
+        protocol = "https" if use_https else "http"
         self._base = "{0}://{1}:{2}".format(protocol, self._address, port)
 
     def get_rtsp_stream_url(self, channel: int, subtype: int) -> str:
@@ -359,7 +364,7 @@ class DahuaClient:
         async with self._new_rpc2_session() as session:
             rpc2 = DahuaRpc2Client(
                 self._username, self._password, self._address, self._port,
-                self._rtsp_port, session
+                self._rtsp_port, session, self._use_https
             )
             try:
                 async with async_timeout.timeout(5):
@@ -384,7 +389,7 @@ class DahuaClient:
         async with self._new_rpc2_session() as session:
             rpc2 = DahuaRpc2Client(
                 self._username, self._password, self._address, self._port,
-                self._rtsp_port, session
+                self._rtsp_port, session, self._use_https
             )
             try:
                 async with async_timeout.timeout(5):

--- a/custom_components/dahua/config_flow.py
+++ b/custom_components/dahua/config_flow.py
@@ -24,6 +24,7 @@ from .const import (
     PLATFORMS,
     CONF_CHANNEL,
     CONF_AUTO_DETECT_CHANNEL,
+    CONF_USE_HTTPS,
 )
 
 """
@@ -113,6 +114,7 @@ class DahuaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input[CONF_PORT],
                 user_input[CONF_RTSP_PORT],
                 user_input[CONF_CHANNEL],
+                True if user_input.get(CONF_USE_HTTPS) else None,
             )
             if data is not None:
                 # Only allow a camera to be setup once
@@ -194,6 +196,43 @@ class DahuaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry):
         return DahuaOptionsFlowHandler()
 
+    async def async_step_reconfigure(self, user_input=None):
+        """Change an existing entry's connection settings.
+
+        Credentials are left alone - those are what async_step_reauth is for.
+        """
+        self._errors = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            data = await self._test_credentials(
+                entry.data[CONF_USERNAME],
+                entry.data[CONF_PASSWORD],
+                user_input[CONF_ADDRESS],
+                user_input[CONF_PORT],
+                user_input[CONF_RTSP_PORT],
+                user_input[CONF_CHANNEL],
+                True if user_input.get(CONF_USE_HTTPS) else None,
+            )
+            if data is not None:
+                return self.async_update_reload_and_abort(entry, data_updates=user_input)
+            self._errors["base"] = "auth"
+
+        current = {**entry.data, **(user_input or {})}
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_ADDRESS, default=current.get(CONF_ADDRESS, "")): str,
+                    vol.Required(CONF_PORT, default=str(current.get(CONF_PORT, "80"))): str,
+                    vol.Required(CONF_RTSP_PORT, default=str(current.get(CONF_RTSP_PORT, "554"))): str,
+                    vol.Required(CONF_CHANNEL, default=int(current.get(CONF_CHANNEL, 0))): int,
+                    vol.Optional(CONF_USE_HTTPS, default=bool(current.get(CONF_USE_HTTPS, False))): bool,
+                }
+            ),
+            errors=self._errors,
+        )
+
     async def _show_config_form_user(self, user_input):  # pylint: disable=unused-argument
         """Show the configuration form to edit camera name."""
         return self.async_show_form(
@@ -206,6 +245,7 @@ class DahuaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_PORT, default="80"): str,
                     vol.Required(CONF_RTSP_PORT, default="554"): str,
                     vol.Required(CONF_CHANNEL, default=0): int,
+                    vol.Optional(CONF_USE_HTTPS, default=False): bool,
                     vol.Optional(CONF_EVENTS, default=DEFAULT_EVENTS): cv.multi_select(ALL_EVENTS),
                 }
             ),
@@ -224,13 +264,13 @@ class DahuaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def _test_credentials(self, username, password, address, port, rtsp_port, channel):
+    async def _test_credentials(self, username, password, address, port, rtsp_port, channel, use_https=None):
         """Return name and serialNumber if credentials is valid."""
         # Self signed certs are used over HTTPS so we'll disable SSL verification
         connector = TCPConnector(enable_cleanup_closed=True, ssl=SSL_CONTEXT)
         session = ClientSession(connector=connector)
         try:
-            client = DahuaClient(username, password, address, port, rtsp_port, session)
+            client = DahuaClient(username, password, address, port, rtsp_port, session, use_https)
             data = await client.get_machine_name()
             serial = await client.async_get_system_info()
             data.update(serial)

--- a/custom_components/dahua/const.py
+++ b/custom_components/dahua/const.py
@@ -44,6 +44,7 @@ CONF_EVENTS = "events"
 CONF_NAME = "name"
 CONF_CHANNEL = "channel"
 CONF_AUTO_DETECT_CHANNEL = "auto_detect_channel"
+CONF_USE_HTTPS = "use_https"
 
 # Defaults
 DEFAULT_NAME = "Dahua"

--- a/custom_components/dahua/rpc2.py
+++ b/custom_components/dahua/rpc2.py
@@ -26,7 +26,8 @@ class DahuaRpc2Client:
             address: str,
             port: int,
             rtsp_port: int,
-            session: aiohttp.ClientSession
+            session: aiohttp.ClientSession,
+            use_https: bool = None
     ) -> None:
         self._username = username
         self._password = password
@@ -35,7 +36,10 @@ class DahuaRpc2Client:
         self._session_id = None
         self._ptz_objects: dict[int, int] = {}
         self._id = 0
-        protocol = "https" if int(port) == 443 else "http"
+        if use_https is None:
+            use_https = int(port) == 443
+        self._use_https = use_https
+        protocol = "https" if use_https else "http"
         self._base = "{0}://{1}:{2}".format(protocol, address, port)
 
     async def request(self, method, params=_PARAMS_UNSET, object_id=None, extra=None, url=None, verify_result=True):

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -10,6 +10,7 @@
                     "address": "Address",
                     "port": "Port",
                     "rtsp_port": "RTSP Port",
+                    "use_https": "Use HTTPS (otherwise HTTPS is used only on port 443)",
                     "streams": "RTSP Streams",
                     "events": "Events",
                     "channel": "Channel (single cameras are 0, NVRs are the 0 based index)"
@@ -28,6 +29,17 @@
                     "username": "Username",
                     "password": "Password"
                 }
+            },
+            "reconfigure": {
+                "title": "Dahua Camera Connection",
+                "description": "Update how Home Assistant reaches this device. Credentials are unchanged; use re-authentication for those.",
+                "data": {
+                    "address": "Address",
+                    "port": "Port",
+                    "rtsp_port": "RTSP Port",
+                    "channel": "Channel (single cameras are 0, NVRs are the 0 based index)",
+                    "use_https": "Use HTTPS (otherwise HTTPS is used only on port 443)"
+                }
             }
         },
         "error": {
@@ -36,7 +48,8 @@
         "abort": {
             "single_instance_allowed": "Only a single instance is allowed.",
             "already_configured": "Only a single instance of a device is allowed.",
-            "reauth_successful": "Re-authentication was successful."
+            "reauth_successful": "Re-authentication was successful.",
+            "reconfigure_successful": "Connection settings updated"
         }
     },
     "options": {

--- a/tests/dahua/test_connection_settings.py
+++ b/tests/dahua/test_connection_settings.py
@@ -1,0 +1,139 @@
+"""HTTPS must be selectable, and connection settings changeable after setup."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.dahua import get_configured_use_https
+from custom_components.dahua import client as client_module
+from custom_components.dahua.client import DahuaClient
+from custom_components.dahua.config_flow import DahuaFlowHandler
+from custom_components.dahua.rpc2 import DahuaRpc2Client
+
+
+def _client(port, use_https=None):
+    return DahuaClient("u", "p", "1.2.3.4", port, 554, session=None, use_https=use_https)
+
+
+def _rpc2(port, use_https=None):
+    return DahuaRpc2Client("u", "p", "1.2.3.4", port, 554, session=None, use_https=use_https)
+
+
+@pytest.mark.parametrize(
+    "port,use_https,expected",
+    [
+        # Unspecified keeps the behaviour that shipped before the option.
+        (80, None, "http://1.2.3.4:80"),
+        (443, None, "https://1.2.3.4:443"),
+        (8443, None, "http://1.2.3.4:8443"),
+        # Explicitly asked for, on any port. This is the point of the option.
+        (8443, True, "https://1.2.3.4:8443"),
+        (80, True, "https://1.2.3.4:80"),
+        # Explicitly declined, even on 443.
+        (443, False, "http://1.2.3.4:443"),
+    ],
+)
+def test_client_base_url(port, use_https, expected):
+    assert _client(port, use_https)._base == expected
+
+
+@pytest.mark.parametrize(
+    "port,use_https,expected",
+    [
+        (80, None, "http://1.2.3.4:80"),
+        (443, None, "https://1.2.3.4:443"),
+        (8443, True, "https://1.2.3.4:8443"),
+        (443, False, "http://1.2.3.4:443"),
+    ],
+)
+def test_rpc2_base_url(port, use_https, expected):
+    assert _rpc2(port, use_https)._base == expected
+
+
+async def test_internally_built_rpc2_client_inherits_the_flag(monkeypatch):
+    """client.py builds its own RPC2 client; it must not fall back to the port."""
+    captured = {}
+
+    class _CapturingRpc2:
+        def __init__(self, username, password, address, port, rtsp_port, session, use_https=None):
+            captured["use_https"] = use_https
+
+        async def async_get_ptz_presets(self, channel):
+            return []
+
+        async def logout(self):
+            return True
+
+    class _NullSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(client_module, "DahuaRpc2Client", _CapturingRpc2)
+    monkeypatch.setattr(client_module.DahuaClient, "_new_rpc2_session", staticmethod(_NullSession))
+
+    # HTTPS on a non-443 port is exactly where deriving from the port is wrong.
+    await _client(8443, True).async_get_ptz_preset_ids(1)
+
+    assert captured["use_https"] is True
+
+
+def test_unticked_means_derive_from_the_port_not_force_http():
+    """False must not force HTTP on 443, or existing entries would break."""
+    assert get_configured_use_https(SimpleNamespace(data={}, options={})) is None
+    assert get_configured_use_https(SimpleNamespace(data={"use_https": False}, options={})) is None
+    assert get_configured_use_https(SimpleNamespace(data={"use_https": True}, options={}) ) is True
+
+
+def _schema_defaults(result):
+    out = {}
+    for marker in result["data_schema"].schema:
+        default = getattr(marker, "default", None)
+        out[str(marker.schema)] = default() if callable(default) else default
+    return out
+
+
+async def _shown_reconfigure_form(hass, entry):
+    handler = DahuaFlowHandler()
+    handler.hass = hass
+    handler._get_reconfigure_entry = lambda: entry
+    return await handler.async_step_reconfigure()
+
+
+async def test_reconfigure_form_is_prefilled_from_the_entry(hass):
+    entry = SimpleNamespace(
+        data={
+            "address": "192.168.0.210",
+            "port": "8443",
+            "rtsp_port": "554",
+            "channel": 2,
+            "use_https": True,
+            "username": "u",
+            "password": "p",
+        },
+        options={},
+    )
+
+    defaults = _schema_defaults(await _shown_reconfigure_form(hass, entry))
+
+    assert defaults["address"] == "192.168.0.210"
+    assert defaults["port"] == "8443"
+    assert defaults["rtsp_port"] == "554"
+    assert defaults["channel"] == 2
+    assert defaults["use_https"] is True
+
+
+async def test_reconfigure_form_does_not_offer_credentials(hass):
+    """Credentials belong to the reauth step, not here."""
+    entry = SimpleNamespace(
+        data={"address": "1.2.3.4", "port": "80", "rtsp_port": "554",
+              "channel": 0, "username": "u", "password": "p"},
+        options={},
+    )
+
+    defaults = _schema_defaults(await _shown_reconfigure_form(hass, entry))
+
+    assert "username" not in defaults
+    assert "password" not in defaults


### PR DESCRIPTION
Fixes #537.

Two related gaps in how an entry reaches its device.

**HTTPS was decided by the port.** Any port other than 443 was addressed over plain HTTP, so a custom HTTPS port was impossible. Both clients made that decision independently:

```python
protocol = "https" if int(port) == 443 else "http"   # client.py and rpc2.py
```

**Address, port, RTSP port and channel were write-once.** Changing any of them — after a DHCP lease moves a camera, say — meant deleting the entry and adding it back, losing the entity IDs, their history, and every automation that referred to them.

### What this does

Adds a "use HTTPS" flag threaded through `DahuaClient` and `DahuaRpc2Client`, and an `async_step_reconfigure` for the connection settings.

**The back-compat default lives in the constructors, not the call sites:**

```python
if use_https is None:
    use_https = int(port) == 443
```

So every existing construction path keeps today's behaviour without needing to be correct about it — including the two `DahuaRpc2Client`s that `client.py` builds internally inside `_new_rpc2_session`, and the validation client in the config flow. A test covers the internal one specifically, since that is the path a future refactor would quietly break.

**An unticked box reads as `None`, not `False`:**

```python
return True if entry.data.get(CONF_USE_HTTPS) else None
```

If it read as `False` it would force HTTP onto entries that work on 443 today. `None` means "decide from the port", which is the pre-existing rule.

**No entry migration and no `VERSION` bump** — this adds an optional key with a derived default rather than changing the shape of stored data.

**Credentials stay out of the reconfigure form**; that is what the existing reauth step is for.

### Verification

In a `python:3.13` container matching CI — 14 new tests covering the protocol matrix for both clients, the internally-built RPC2 client inheriting the flag, and the reconfigure form's prefill:

```
suite: 51 passed
```

Every pre-existing test still constructs both clients without the new parameter, which is the back-compat proof.

`_new_rpc2_session` already uses `ssl=False`, which skips certificate validation rather than disabling TLS, so self-signed certs work on the RPC2 path as well as the CGI one.

### Note

This branches off `main` as it stands, so it does not include #602. Both add a constant after `CONF_AUTO_DETECT_CHANNEL` in `const.py`, so whichever merges second will want a one-hunk resolution — happy to do that as soon as the other lands.

Only `translations/en.json` carries the new labels; Home Assistant falls back to English for the other locales.