### PR TITLE
Cap concurrent requests per host

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -19,6 +19,24 @@ TIMEOUT_SECONDS = 20
 EVENT_STREAM_HEARTBEAT_SECONDS = 5
 EVENT_STREAM_READ_TIMEOUT_SECONDS = 60
 
+# One NVR carries a config entry per channel, and every entry sets itself up at
+# the same moment. Dahua's HTTP server is small: a dozen simultaneous CGI calls
+# can wedge it, and because the entries then fail together they retry together,
+# so the burst repeats and the device never recovers. Cap concurrent requests
+# per host, shared across every client for that address.
+MAX_CONCURRENT_REQUESTS_PER_HOST = 2
+_HOST_LIMITS: dict = {}
+
+
+def _host_limiter(address: str) -> asyncio.Semaphore:
+    """Returns the semaphore shared by every client talking to this address."""
+    limiter = _HOST_LIMITS.get(address)
+    if limiter is None:
+        limiter = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS_PER_HOST)
+        _HOST_LIMITS[address] = limiter
+    return limiter
+
+
 SECURITY_LIGHT_TYPE = 1
 SIREN_TYPE = 2
 
@@ -56,6 +74,8 @@ class DahuaClient:
         if use_https is None:
             use_https = int(port) == 443
         self._use_https = use_https
+        # Keyed by address so every entry for one NVR shares a single budget.
+        self._host_limit = _host_limiter(self._address)
         protocol = "https" if use_https else "http"
         self._base = "{0}://{1}:{2}".format(protocol, self._address, port)
 
@@ -905,7 +925,9 @@ class DahuaClient:
 
     async def get_bytes(self, url: str) -> bytes:
         """Get information from the API. This will return the raw response and not process it"""
-        async with async_timeout.timeout(TIMEOUT_SECONDS):
+        # The timeout covers the wait for a slot as well as the request, so a
+        # busy host sheds load instead of building an unbounded queue.
+        async with async_timeout.timeout(TIMEOUT_SECONDS), self._host_limit:
             response = None
             try:
                 auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
@@ -921,7 +943,7 @@ class DahuaClient:
         """Get information from the API."""
         url = self._base + url
         try:
-            async with async_timeout.timeout(TIMEOUT_SECONDS):
+            async with async_timeout.timeout(TIMEOUT_SECONDS), self._host_limit:
                 response = None
                 try:
                     auth = DigestAuth(self._username, self._password, self._session, self._digest_state)

--- a/tests/dahua/test_host_request_limit.py
+++ b/tests/dahua/test_host_request_limit.py
@@ -1,0 +1,141 @@
+"""One NVR must not be hit by every channel's config entry at once."""
+
+import asyncio
+
+import pytest
+
+from custom_components.dahua import client as client_module
+from custom_components.dahua.client import (
+    MAX_CONCURRENT_REQUESTS_PER_HOST,
+    DahuaClient,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_limiters():
+    """The limiter registry is module state; keep tests independent."""
+    client_module._HOST_LIMITS.clear()
+    yield
+    client_module._HOST_LIMITS.clear()
+
+
+class _ConcurrencyProbe:
+    """Stands in for the session and records how many calls overlap."""
+
+    def __init__(self, hold=0.02):
+        self.hold = hold
+        self.current = 0
+        self.peak = 0
+        self.calls = 0
+
+    async def request(self, method, url, headers=None, **kwargs):
+        self.calls += 1
+        self.current += 1
+        self.peak = max(self.peak, self.current)
+        try:
+            await asyncio.sleep(self.hold)
+        finally:
+            self.current -= 1
+        return _Resp()
+
+
+class _Resp:
+    status = 200
+    headers = {}
+
+    def raise_for_status(self):
+        return None
+
+    async def text(self):
+        return "key=value"
+
+    async def read(self):
+        return b"bytes"
+
+    def close(self):
+        return None
+
+
+def _client(address, session):
+    return DahuaClient("u", "p", address, 80, 554, session)
+
+
+async def test_requests_to_one_host_are_capped():
+    probe = _ConcurrencyProbe()
+    c = _client("10.0.0.1", probe)
+
+    await asyncio.gather(*(c.get("/cgi-bin/x") for _ in range(20)))
+
+    assert probe.calls == 20, "every request must still be made"
+    assert probe.peak <= MAX_CONCURRENT_REQUESTS_PER_HOST, (
+        "peak concurrency %d exceeded the cap of %d"
+        % (probe.peak, MAX_CONCURRENT_REQUESTS_PER_HOST)
+    )
+
+
+async def test_separate_entries_for_the_same_nvr_share_one_budget():
+    """This is the case that wedges the device: one host, many config entries."""
+    probe = _ConcurrencyProbe()
+    clients = [_client("10.0.0.1", probe) for _ in range(11)]
+
+    await asyncio.gather(*(c.get("/cgi-bin/x") for c in clients for _ in range(3)))
+
+    assert probe.calls == 33
+    assert probe.peak <= MAX_CONCURRENT_REQUESTS_PER_HOST
+
+
+async def test_different_hosts_do_not_share_a_budget():
+    """A slow NVR must not throttle an unrelated doorbell."""
+    a, b = _ConcurrencyProbe(), _ConcurrencyProbe()
+    ca, cb = _client("10.0.0.1", a), _client("10.0.0.2", b)
+
+    assert ca._host_limit is not cb._host_limit
+
+    await asyncio.gather(
+        *(ca.get("/cgi-bin/x") for _ in range(6)),
+        *(cb.get("/cgi-bin/x") for _ in range(6)),
+    )
+    assert a.peak <= MAX_CONCURRENT_REQUESTS_PER_HOST
+    assert b.peak <= MAX_CONCURRENT_REQUESTS_PER_HOST
+
+
+async def test_two_clients_same_address_reuse_the_same_semaphore():
+    probe = _ConcurrencyProbe()
+    assert _client("10.0.0.1", probe)._host_limit is _client("10.0.0.1", probe)._host_limit
+
+
+async def test_get_bytes_is_capped_too():
+    probe = _ConcurrencyProbe()
+    c = _client("10.0.0.1", probe)
+
+    await asyncio.gather(*(c.get_bytes("/cgi-bin/snapshot") for _ in range(10)))
+
+    assert probe.calls == 10
+    assert probe.peak <= MAX_CONCURRENT_REQUESTS_PER_HOST
+
+
+async def test_the_event_stream_does_not_hold_a_slot():
+    """A long poll under the limiter would starve every other request forever."""
+    import inspect
+
+    src = inspect.getsource(DahuaClient.stream_events)
+    assert "_host_limit" not in src, "the event stream must not take a request slot"
+
+
+async def test_waiting_for_a_slot_counts_against_the_timeout():
+    """A wedged host should shed load rather than build an unbounded queue."""
+    probe = _ConcurrencyProbe(hold=30)
+    c = _client("10.0.0.1", probe)
+
+    blockers = [asyncio.create_task(c.get("/cgi-bin/slow"))
+                for _ in range(MAX_CONCURRENT_REQUESTS_PER_HOST)]
+    await asyncio.sleep(0.05)
+
+    # The queued call must not wait forever; it is bounded by the same timeout.
+    queued = asyncio.create_task(c.get("/cgi-bin/queued"))
+    await asyncio.sleep(0.05)
+    assert not queued.done(), "should still be waiting for a slot"
+
+    for t in blockers + [queued]:
+        t.cancel()
+    await asyncio.gather(*blockers, queued, return_exceptions=True)


### PR DESCRIPTION
An NVR carries one config entry per channel, and every entry sets itself up at the same moment. The first thing each one does is a CGI call:

```python
self._max_streams = await self.client.get_max_extra_streams() + 1
```

So a ten-channel NVR receives ten simultaneous requests before anything paces them. Dahua's HTTP server is small and can wedge under that load.

It then gets worse rather than better: the entries all fail at the same instant, so `ConfigEntryNotReady` puts them on the same backoff schedule and every retry is another synchronised burst. The device is held down rather than allowed to recover.

### Observed

On an eleven-entry NVR, after the entries reloaded together the web server stopped accepting connections outright:

```
TCP connect 192.168.0.213:80   545s before failing   (SYN retries exhausted)
ICMP                            0% loss, 1.2 ms
RTSP :554                       connects in 0.00s — recording unaffected
```

The log shows ten identical failures, repeating in lockstep every 20–30 seconds:

```
16:05:16 TimeoutError fetching information from
         http://192.168.0.213/cgi-bin/magicBox.cgi?action=getProductDefinition&name=MaxExtraStream
16:05:16 Failed to initialize device at 192.168.0.213
… ×10, then again at 16:05:39, then 16:06:09
```

Only the CGI interface was affected; ICMP and RTSP stayed healthy throughout, which is what points at the HTTP server rather than the unit.

### The change

A semaphore keyed by address, shared by every `DahuaClient` for that host, around the two request paths:

```python
MAX_CONCURRENT_REQUESTS_PER_HOST = 2
_HOST_LIMITS: dict = {}
```

- **Keyed by host, not per entry** — that is what makes the channels of one NVR cooperate rather than compete. Different devices keep independent budgets, so a slow NVR cannot throttle a doorbell.
- **The timeout wraps the wait for a slot as well as the request**, so a busy host sheds load instead of building an unbounded queue.
- **`stream_events` is deliberately outside the limiter.** It is a long poll, and holding a slot for its lifetime would starve every other request. A test asserts it stays outside.

Note that the scan interval added in #602 does not help here: it paces the coordinator *after* setup succeeds, while setup itself is unthrottled.

This is also plausibly relevant to #577, where a five-camera NVR logs ~114,000 logins a day — same root cause of many entries against one host.

### Verification

In a `python:3.13` container matching CI:

```
enforcement removed, tests kept : 4 failed, 3 passed
with this change                : 7 passed
full suite                      : 67 passed
```

The four failures are the peak-concurrency assertions, which observe 20 overlapping requests where 2 are allowed.