### PR TITLE
Stop fetching what the integration does not use

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -277,6 +277,10 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _close_session(self) -> None:
         _LOGGER.debug("Closing Session")
+        try:
+            await self.client.close()
+        except Exception:
+            _LOGGER.debug("Failed to close the client's RPC2 session", exc_info=True)
         if self._session is not None:
             try:
                 await self._session.close()
@@ -329,7 +333,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 auto_detect = self.config_entry.options.get(CONF_AUTO_DETECT_CHANNEL, True)
                 if auto_detect:
                     try:
-                        await self.client.async_get_snapshot(0)
+                        await self.client.async_probe_snapshot(0)
                         # If able to take a snapshot with index 0 then most likely this cams channel needs to be reset
                         # but check if unit is not a doorbell first as channel 0 doesnt exist for VTOs
                         if not self.is_doorbell():
@@ -453,23 +457,23 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     _LOGGER.debug("Could not get profile mode", exc_info=exception)
                     pass
             
-            # We need the ptz status
-            if self._supports_ptz_position:
+            # The profile mode above has to be read first because the lighting
+            # call below needs it. The PTZ position does not, so it joins the
+            # fan-out rather than costing an extra round trip ahead of it.
+            async def _ptz_position():
                 try:
-                    ptz_data = await self.client.async_get_ptz_position()
-                    data.update(ptz_data)
-                    self._preset_position = ptz_data.get("status.PresetID", "0")
-                    if not self._preset_position:
-                        self._preset_position = "0"
+                    return await self.client.async_get_ptz_position()
                 except Exception as exception:
                     # I believe this API is missing on some cameras so we'll just ignore it and move on
                     _LOGGER.debug("Could not get preset position", exc_info=exception)
-                    pass
+                    return None
 
             # Figure out which APIs we need to call and then fan out and gather the results
             coros = [
                 asyncio.ensure_future(self.client.async_get_config_motion_detection()),
             ]
+            if self._supports_ptz_position:
+                coros.append(asyncio.ensure_future(_ptz_position()))
             if self.supports_infrared_light():
                 coros.append(
                     asyncio.ensure_future(self.client.async_get_config_lighting(self._channel, self._profile_mode)))
@@ -495,7 +499,13 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 if result is not None:
                     data.update(result)
 
-            if self.supports_security_light() or self.is_flood_light():
+            if self._supports_ptz_position:
+                self._preset_position = data.get("status.PresetID", "0") or "0"
+
+            # Only if it was not already fetched above: on a camera that both
+            # supports the v2 API and reports a security light, this was being
+            # requested twice on every poll.
+            if (self.supports_security_light() or self.is_flood_light()) and not self._supports_lighting_v2:
                 light_v2 = await self.client.async_get_lighting_v2()
                 if light_v2 is not None:
                     data.update(light_v2)

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -76,6 +76,7 @@ class DahuaClient:
         self._use_https = use_https
         # Keyed by address so every entry for one NVR shares a single budget.
         self._host_limit = _host_limiter(self._address)
+        self._rpc2_session_instance = None
         protocol = "https" if use_https else "http"
         self._base = "{0}://{1}:{2}".format(protocol, self._address, port)
 
@@ -379,49 +380,66 @@ class DahuaClient:
             cookie_jar=aiohttp.CookieJar(unsafe=True),
         )
 
+    def _rpc2_session(self) -> aiohttp.ClientSession:
+        """Returns this client's RPC2 session, building it on first use.
+
+        Sessions are meant to be long lived. Creating one per call also built a
+        connector and a connection pool each time, and threw them away again.
+        """
+        if self._rpc2_session_instance is None or self._rpc2_session_instance.closed:
+            self._rpc2_session_instance = self._new_rpc2_session()
+        return self._rpc2_session_instance
+
+    async def close(self) -> None:
+        """Releases anything this client owns. Safe to call more than once."""
+        session = self._rpc2_session_instance
+        self._rpc2_session_instance = None
+        if session is not None and not session.closed:
+            await session.close()
+
     async def async_get_ptz_preset_ids(self, channel_index: int) -> list[int]:
         """Read the real preset IDs exposed by Web5.0 RPC2."""
-        async with self._new_rpc2_session() as session:
-            rpc2 = DahuaRpc2Client(
-                self._username, self._password, self._address, self._port,
-                self._rtsp_port, session, self._use_https
-            )
+        session = self._rpc2_session()
+        rpc2 = DahuaRpc2Client(
+            self._username, self._password, self._address, self._port,
+            self._rtsp_port, session, self._use_https
+        )
+        try:
+            async with async_timeout.timeout(5):
+                presets = await rpc2.async_get_ptz_presets(channel_index)
+            ids = self.parse_ptz_preset_ids(presets)
+            if presets and not ids:
+                raise ValueError("Dahua RPC2 preset response contains no valid IDs")
+            return ids
+        finally:
             try:
-                async with async_timeout.timeout(5):
-                    presets = await rpc2.async_get_ptz_presets(channel_index)
-                ids = self.parse_ptz_preset_ids(presets)
-                if presets and not ids:
-                    raise ValueError("Dahua RPC2 preset response contains no valid IDs")
-                return ids
-            finally:
-                try:
-                    async with async_timeout.timeout(3):
-                        logout_ok = await rpc2.logout()
-                    if not logout_ok:
-                        _LOGGER.debug(
-                            "RPC2 logout reported failure after preset discovery"
-                        )
-                except Exception:
-                    _LOGGER.debug("RPC2 logout failed after preset discovery", exc_info=True)
+                async with async_timeout.timeout(3):
+                    logout_ok = await rpc2.logout()
+                if not logout_ok:
+                    _LOGGER.debug(
+                        "RPC2 logout reported failure after preset discovery"
+                    )
+            except Exception:
+                _LOGGER.debug("RPC2 logout failed after preset discovery", exc_info=True)
 
     async def async_goto_preset_rpc2(self, channel: int, position: int) -> dict:
         """Go to a real preset through the hardware-validated RPC2 contract."""
-        async with self._new_rpc2_session() as session:
-            rpc2 = DahuaRpc2Client(
-                self._username, self._password, self._address, self._port,
-                self._rtsp_port, session, self._use_https
-            )
+        session = self._rpc2_session()
+        rpc2 = DahuaRpc2Client(
+            self._username, self._password, self._address, self._port,
+            self._rtsp_port, session, self._use_https
+        )
+        try:
+            async with async_timeout.timeout(5):
+                return await rpc2.async_goto_preset_position(channel, position)
+        finally:
             try:
-                async with async_timeout.timeout(5):
-                    return await rpc2.async_goto_preset_position(channel, position)
-            finally:
-                try:
-                    async with async_timeout.timeout(3):
-                        logout_ok = await rpc2.logout()
-                    if not logout_ok:
-                        _LOGGER.debug("RPC2 logout reported failure after GotoPreset")
-                except Exception:
-                    _LOGGER.debug("RPC2 logout failed after GotoPreset", exc_info=True)
+                async with async_timeout.timeout(3):
+                    logout_ok = await rpc2.logout()
+                if not logout_ok:
+                    _LOGGER.debug("RPC2 logout reported failure after GotoPreset")
+            except Exception:
+                _LOGGER.debug("RPC2 logout failed after GotoPreset", exc_info=True)
 
     async def async_get_light_global_enabled(self) -> dict:
         """
@@ -922,6 +940,26 @@ class DahuaClient:
                 # We didn't get a key=value. We just got a key. Just stick it in the dictionary and move on
                 data_dict[parts[0]] = line
         return data_dict
+
+    async def async_probe_snapshot(self, channel_number: int) -> None:
+        """Checks the snapshot endpoint answers for a channel, without fetching the image.
+
+        Used only to work out how this device numbers its channels, so the JPEG
+        body is never needed. Reading it would pull a full-resolution image per
+        entry at setup, which is the worst possible moment on a busy NVR.
+        Raises the same errors async_get_snapshot would.
+        """
+        url = self._base + "/cgi-bin/snapshot.cgi?channel={0}".format(channel_number)
+        async with async_timeout.timeout(TIMEOUT_SECONDS), self._host_limit:
+            response = None
+            try:
+                auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
+                response = await auth.request("GET", url)
+                response.raise_for_status()
+            finally:
+                if response is not None:
+                    # close() rather than read(): drops the body without transferring it
+                    response.close()
 
     async def get_bytes(self, url: str) -> bytes:
         """Get information from the API. This will return the raw response and not process it"""

--- a/tests/dahua/test_client_efficiency.py
+++ b/tests/dahua/test_client_efficiency.py
@@ -1,0 +1,112 @@
+"""The client should not fetch what it does not need, or rebuild what it has."""
+
+import pytest
+
+from custom_components.dahua import client as client_module
+from custom_components.dahua.client import DahuaClient
+
+
+@pytest.fixture(autouse=True)
+def _clean_limiters():
+    client_module._HOST_LIMITS.clear()
+    yield
+    client_module._HOST_LIMITS.clear()
+
+
+class _Resp:
+    def __init__(self, recorder):
+        self._recorder = recorder
+        self.status = 200
+        self.headers = {}
+
+    def raise_for_status(self):
+        return None
+
+    async def read(self):
+        self._recorder["read"] = True
+        return b"\xff\xd8" + b"x" * 500_000  # a JPEG we should never pull
+
+    async def text(self):
+        self._recorder["read"] = True
+        return "key=value"
+
+    def close(self):
+        self._recorder["closed"] = True
+
+
+class _Session:
+    def __init__(self, recorder):
+        self._recorder = recorder
+        self.urls = []
+
+    async def request(self, method, url, headers=None, **kwargs):
+        self.urls.append(url)
+        return _Resp(self._recorder)
+
+
+def _client(session):
+    return DahuaClient("u", "p", "10.0.0.1", 80, 554, session)
+
+
+async def test_channel_probe_does_not_download_the_image():
+    """It only needs to know the endpoint answers, not what it returns."""
+    rec = {}
+    session = _Session(rec)
+
+    await _client(session).async_probe_snapshot(0)
+
+    assert session.urls == ["http://10.0.0.1:80/cgi-bin/snapshot.cgi?channel=0"]
+    assert rec.get("read") is not True, "the probe pulled the JPEG body"
+    assert rec.get("closed") is True, "the response must be released"
+
+
+async def test_get_bytes_still_reads_the_body():
+    """The real snapshot path must be unaffected by the probe's shortcut."""
+    rec = {}
+    data = await _client(_Session(rec)).get_bytes("/cgi-bin/snapshot.cgi?channel=1")
+
+    assert rec.get("read") is True
+    assert data.startswith(b"\xff\xd8")
+
+
+async def test_rpc2_session_is_built_once_and_reused():
+    c = _client(_Session({}))
+
+    first = c._rpc2_session()
+    second = c._rpc2_session()
+
+    assert first is second, "a new session per call rebuilds the connection pool"
+    await c.close()
+
+
+async def test_close_releases_the_rpc2_session():
+    c = _client(_Session({}))
+    session = c._rpc2_session()
+    assert not session.closed
+
+    await c.close()
+
+    assert session.closed
+    assert c._rpc2_session_instance is None
+
+
+async def test_close_is_safe_to_call_twice_and_without_use():
+    c = _client(_Session({}))
+    await c.close()          # never used a session
+    await c.close()          # and again
+
+    session = c._rpc2_session()
+    await c.close()
+    await c.close()
+    assert session.closed
+
+
+async def test_a_closed_session_is_replaced_rather_than_reused():
+    c = _client(_Session({}))
+    first = c._rpc2_session()
+    await c.close()
+
+    second = c._rpc2_session()
+    assert second is not first
+    assert not second.closed
+    await c.close()


### PR DESCRIPTION
Four wasted requests, found while looking at why a busy NVR struggles. All are independent of each other.

**Builds on #606** — it shares that branch, so the diff currently shows its commit too. Once #606 merges this collapses to its own change.

### 1. A full JPEG downloaded per entry, to answer a yes/no question

```python
await self.client.async_get_snapshot(0)   # → get_bytes → await response.read()
```

This runs at every entry setup when `auto_detect_channel` is on, purely to see whether the endpoint answers. The image is discarded. On an NVR with one entry per channel that is a simultaneous full-resolution download per entry, at the moment the device is already handling one CGI call per entry.

`async_probe_snapshot` issues the same request against the same endpoint — so the heuristic is unchanged — and releases the response with `close()` instead of `read()`, which drops the body rather than transferring it.

### 2. A new `ClientSession` for every PTZ call

`_new_rpc2_session()` was called per request, building a session, a connector and a connection pool each time and discarding them. Sessions are meant to be long lived. It is now built once per client and closed alongside the existing session teardown in `_close_session`.

### 3. `async_get_lighting_v2` requested twice per poll

Once in the fan-out when `_supports_lighting_v2` (set at runtime when the API answers), and again afterwards for `supports_security_light() or is_flood_light()` (decided by model name). Those overlap — an `-AS-PV` camera hits both — so the same call went out twice on every single poll. The trailing call now runs only when it was not already in the fan-out.

### 4. One avoidable serial round trip per poll

`async_get_ptz_position` was awaited on its own ahead of the fan-out, though nothing in the batch depends on it. It joins the batch, keeping the same swallow-and-log behaviour via a small wrapper.

`async_get_video_in_mode` above it is **not** moved: it sets `self._profile_mode`, which `async_get_config_lighting` then consumes, so it is a real dependency.

### Verification

In a `python:3.13` container matching CI:

```
suite: 73 passed
probe test with the body download reintroduced: 1 failed
```

The new tests cover the probe not reading the body, `get_bytes` still reading it, and the RPC2 session being built once, released on close, replaced if closed, and safe to close twice.