### PR TITLE
Turn lights on at full when no brightness is given

### DIFF
--- a/custom_components/dahua/dahua_utils.py
+++ b/custom_components/dahua/dahua_utils.py
@@ -23,7 +23,9 @@ def hass_brightness_to_dahua_brightness(hass_brightness: int) -> int:
     Converts a HASS brightness (which is 0 to 255 inclusive) to a Dahua brightness (which is 0 to 100 inclusive)
     """
     if hass_brightness is None:
-        hass_brightness = 100
+        # No brightness asked for means full. Full on the HASS scale is 255;
+        # 100 here is a Dahua-scale value and came out as 39% instead.
+        hass_brightness = 255
     return int((hass_brightness / 255) * 100)
 
 

--- a/tests/dahua/test_light.py
+++ b/tests/dahua/test_light.py
@@ -1,0 +1,194 @@
+"""light.py had no tests at all, and day/night handling has regressed before."""
+
+import pytest
+
+from custom_components.dahua import dahua_utils
+from custom_components.dahua.light import DahuaIlluminator, DahuaInfraredLight
+
+ATTR_BRIGHTNESS = "brightness"
+
+
+class _Client:
+    def __init__(self):
+        self.v1 = []
+        self.v2 = []
+
+    async def async_set_lighting_v1(self, channel, enabled, brightness):
+        self.v1.append((channel, enabled, brightness))
+
+    async def async_set_lighting_v2(self, channel, enabled, brightness, profile_mode):
+        self.v2.append((channel, enabled, brightness, profile_mode))
+
+
+class _Coordinator:
+    def __init__(self, channel=3, profile_mode="1"):
+        self.client = _Client()
+        self._channel = channel
+        self._profile_mode = profile_mode
+        self.refreshed = 0
+        self.infrared_on = True
+        self.infrared_brightness = 128
+        self.illuminator_on = False
+        self.illuminator_brightness = 64
+
+    def get_channel(self):
+        return self._channel
+
+    def get_profile_mode(self):
+        return self._profile_mode
+
+    def get_serial_number(self):
+        return "SERIAL1"
+
+    def get_device_name(self):
+        return "Front Door"
+
+    def is_infrared_light_on(self):
+        return self.infrared_on
+
+    def get_infrared_brightness(self):
+        return self.infrared_brightness
+
+    def is_illuminator_on(self):
+        return self.illuminator_on
+
+    def get_illuminator_brightness(self):
+        return self.illuminator_brightness
+
+    async def async_refresh(self):
+        self.refreshed += 1
+
+
+def _light(cls, coordinator, name="Infrared"):
+    """Build the entity without Home Assistant's entity plumbing."""
+    entity = object.__new__(cls)
+    entity._coordinator = coordinator
+    entity.coordinator = coordinator
+    entity._name = name
+    return entity
+
+
+# --- brightness conversion -------------------------------------------------
+
+@pytest.mark.parametrize("hass_value,expected", [
+    (0, 0),
+    (255, 100),
+    (128, 50),
+    (None, 100),   # no brightness given means full, not off
+])
+def test_hass_brightness_maps_to_dahua_scale(hass_value, expected):
+    assert dahua_utils.hass_brightness_to_dahua_brightness(hass_value) == expected
+
+
+@pytest.mark.parametrize("dahua_value,expected", [
+    ("0", 0),
+    ("100", 255),
+    ("50", 127),
+    ("", 255),     # blank means full
+    (None, 255),
+])
+def test_dahua_brightness_maps_back_to_hass_scale(dahua_value, expected):
+    assert dahua_utils.dahua_brightness_to_hass_brightness(dahua_value) == expected
+
+
+def test_the_two_conversions_agree_on_what_no_value_means():
+    """Both default to "full", but they work on different scales.
+
+    Full is 100 on the Dahua scale and 255 on the HASS scale. Using 100 for
+    both made an unspecified brightness mean 39%, so a plain toggle-on lit
+    the light dimly.
+    """
+    no_value_hass = dahua_utils.dahua_brightness_to_hass_brightness(None)
+    no_value_dahua = dahua_utils.hass_brightness_to_dahua_brightness(None)
+
+    assert no_value_hass == 255, "full on the HASS scale"
+    assert no_value_dahua == 100, "full on the Dahua scale"
+    assert dahua_utils.dahua_brightness_to_hass_brightness(str(no_value_dahua)) == no_value_hass
+
+
+def test_full_and_off_survive_a_round_trip():
+    for hass_value in (0, 255):
+        dahua = dahua_utils.hass_brightness_to_dahua_brightness(hass_value)
+        assert dahua_utils.dahua_brightness_to_hass_brightness(str(dahua)) == hass_value
+
+
+# --- infrared light (v1 API) ----------------------------------------------
+
+async def test_infrared_turn_on_sends_the_channel_and_brightness():
+    c = _Coordinator(channel=3)
+    await _light(DahuaInfraredLight, c).async_turn_on(**{ATTR_BRIGHTNESS: 255})
+
+    assert c.client.v1 == [(3, True, 100)]
+    assert c.client.v2 == [], "the infrared light must not use the v2 API"
+    assert c.refreshed == 1
+
+
+async def test_infrared_turn_off_sends_enabled_false():
+    c = _Coordinator(channel=3)
+    await _light(DahuaInfraredLight, c).async_turn_off()
+
+    assert len(c.client.v1) == 1
+    channel, enabled, _ = c.client.v1[0]
+    assert (channel, enabled) == (3, False)
+
+
+async def test_infrared_turn_on_without_brightness_uses_full():
+    c = _Coordinator()
+    await _light(DahuaInfraredLight, c).async_turn_on()
+
+    assert c.client.v1[0][2] == 100
+
+
+def test_infrared_reads_state_from_the_coordinator():
+    c = _Coordinator()
+    light = _light(DahuaInfraredLight, c)
+
+    assert light.is_on is True
+    assert light.brightness == 128
+    c.infrared_on = False
+    assert light.is_on is False
+
+
+# --- illuminator (v2 API, carries the profile mode) ------------------------
+
+async def test_illuminator_passes_the_profile_mode_through():
+    """Day/night handling rides on this argument and has regressed before."""
+    c = _Coordinator(channel=2, profile_mode="1")
+
+    await _light(DahuaIlluminator, c, "Illuminator").async_turn_on(**{ATTR_BRIGHTNESS: 255})
+
+    assert c.client.v2 == [(2, True, 100, "1")]
+    assert c.client.v1 == [], "the illuminator must not use the v1 API"
+
+
+async def test_illuminator_turn_off_keeps_the_profile_mode():
+    c = _Coordinator(channel=2, profile_mode="0")
+
+    await _light(DahuaIlluminator, c, "Illuminator").async_turn_off()
+
+    channel, enabled, _, profile_mode = c.client.v2[0]
+    assert (channel, enabled, profile_mode) == (2, False, "0")
+
+
+async def test_illuminator_uses_whatever_profile_mode_is_current():
+    c = _Coordinator(profile_mode="2")
+    await _light(DahuaIlluminator, c, "Illuminator").async_turn_on()
+    assert c.client.v2[0][3] == "2"
+
+
+# --- identity --------------------------------------------------------------
+
+def test_the_two_lights_do_not_share_a_unique_id():
+    """A collision would merge two different lights into one entity."""
+    c = _Coordinator()
+    infrared = _light(DahuaInfraredLight, c).unique_id
+    illuminator = _light(DahuaIlluminator, c, "Illuminator").unique_id
+
+    assert infrared == "SERIAL1_infrared"
+    assert illuminator == "SERIAL1_illuminator"
+    assert infrared != illuminator
+
+
+def test_name_is_prefixed_with_the_device_name():
+    c = _Coordinator()
+    assert _light(DahuaInfraredLight, c, "Infrared").name == "Front Door Infrared"


### PR DESCRIPTION
`light.py` had no tests at all — 211 statements at 0% coverage. Writing the first ones turned up a bug that has been there since the initial commit.

**Builds on #606, #607 and #608** and shares their branch, so the diff currently shows those commits too. It collapses to its own change once they merge.

### The bug

The two brightness conversions both default to `100`, but they work on different scales. Full is **100** on the Dahua scale and **255** on the HASS scale:

```python
def dahua_brightness_to_hass_brightness(bri_str):   # Dahua -> HASS
    bri = 100                                       # -> 255, full, correct

def hass_brightness_to_dahua_brightness(hass_brightness):   # HASS -> Dahua
    if hass_brightness is None:
        hass_brightness = 100                       # -> 39, meant to be full
```

Home Assistant omits `ATTR_BRIGHTNESS` when a light is simply toggled on, so **every plain turn-on of an infrared light or an illuminator asked the camera for 39% brightness rather than full.** All four call sites in `light.py` pass `kwargs.get(ATTR_BRIGHTNESS)`, so they all reach it.

Defaulting to `255` gives `int((255/255)*100) == 100` — full on the scale this function returns, and consistent with its sibling.

### The tests

Aimed at the parts most likely to regress rather than at a coverage number:

- **The illuminator passes `profile_mode` through** to `async_set_lighting_v2` on both on and off, and reflects whatever the coordinator currently reports. Day/night handling rides on that argument, and it is what #582 got wrong badly enough to be reverted.
- **The two APIs never cross** — the infrared light must use v1 and the illuminator v2. Each test asserts the other was not called, so a copy-paste between the two classes fails loudly.
- **Unique IDs stay distinct** (`_infrared` vs `_illuminator`); a collision would silently merge two lights into one entity.
- **Conversion boundaries** — 0, 255, and the `None` case above, plus a round-trip check.

They construct the entities with `object.__new__` and a fake coordinator, so no `hass` fixture is needed. The same approach would work for `switch.py` (128 statements) and `binary_sensor.py` (55), which are also at zero.

### Verification

In a `python:3.13` container matching CI:

```
suite: 99 passed
light.py       0%  -> 59%
dahua_utils.py 74% -> 97%
TOTAL          36% -> 41%
```

Reintroducing the old default fails three tests.

### Note

This changes observable behaviour: lights that came on dim will now come on at full. That is the intent of the code as documented, but it is a visible change and worth calling out.