### PR TITLE
Add tests for switch.py and binary_sensor.py

### DIFF
--- a/custom_components/dahua/dahua_utils.py
+++ b/custom_components/dahua/dahua_utils.py
@@ -23,7 +23,9 @@ def hass_brightness_to_dahua_brightness(hass_brightness: int) -> int:
     Converts a HASS brightness (which is 0 to 255 inclusive) to a Dahua brightness (which is 0 to 100 inclusive)
     """
     if hass_brightness is None:
-        hass_brightness = 100
+        # No brightness asked for means full. Full on the HASS scale is 255;
+        # 100 here is a Dahua-scale value and came out as 39% instead.
+        hass_brightness = 255
     return int((hass_brightness / 255) * 100)
 
 

--- a/tests/dahua/test_binary_sensor.py
+++ b/tests/dahua/test_binary_sensor.py
@@ -1,0 +1,145 @@
+"""binary_sensor.py had no tests. Its naming and IDs are derived, not declared."""
+
+import pytest
+
+from custom_components.dahua import binary_sensor as bs
+from custom_components.dahua.binary_sensor import DahuaEventSensor
+from custom_components.dahua.const import (
+    DOOR_DEVICE_CLASS,
+    MOTION_SENSOR_DEVICE_CLASS,
+    SAFETY_DEVICE_CLASS,
+    SOUND_DEVICE_CLASS,
+    VOLUME_HIGH_ICON,
+)
+
+
+class _Coordinator:
+    def __init__(self):
+        self.timestamps = {}
+        self.listeners = []
+
+    def get_serial_number(self):
+        return "SERIAL1"
+
+    def get_device_name(self):
+        return "Front Door"
+
+    def get_event_timestamp(self, event_name):
+        return self.timestamps.get(event_name, 0)
+
+    def add_dahua_event_listener(self, event_name, callback):
+        self.listeners.append((event_name, callback))
+
+
+@pytest.fixture
+def sensor(monkeypatch):
+    """Build real sensors, skipping only Home Assistant's entity plumbing."""
+    monkeypatch.setattr(bs.DahuaBaseEntity, "__init__", lambda self, c, e: None)
+    monkeypatch.setattr(bs.BinarySensorEntity, "__init__", lambda self: None)
+
+    def build(event_name, coordinator=None):
+        return DahuaEventSensor(coordinator or _Coordinator(), object(), event_name)
+
+    return build
+
+
+# --- names are derived from the event code ---------------------------------
+
+@pytest.mark.parametrize("event_name,expected", [
+    ("SmartMotionHuman", "Smart Motion Human"),
+    ("SmartMotionVehicle", "Smart Motion Vehicle"),
+    ("CrossRegionDetection", "Cross Region Detection"),
+    ("AudioMutation", "Audio Mutation"),
+    ("AlarmLocal", "Alarm Local"),
+    ("StorageNotExist", "Storage Not Exist"),
+])
+def test_camel_case_events_become_readable_names(sensor, event_name, expected):
+    assert sensor(event_name).name == "Front Door " + expected
+
+
+@pytest.mark.parametrize("event_name,expected", [
+    ("VideoMotion", "Motion Alarm"),
+    ("CrossLineDetection", "Cross Line Alarm"),
+    ("DoorbellPressed", "Button Pressed"),
+])
+def test_overridden_names_win_over_the_derived_one(sensor, event_name, expected):
+    assert sensor(event_name).name == "Front Door " + expected
+
+
+def test_consecutive_capitals_are_not_split(sensor):
+    """IVS must not become I V S."""
+    assert sensor("IVS").name == "Front Door IVS"
+
+
+# --- device classes and icons ----------------------------------------------
+
+@pytest.mark.parametrize("event_name,expected", [
+    ("VideoMotion", MOTION_SENSOR_DEVICE_CLASS),
+    ("AlarmLocal", SAFETY_DEVICE_CLASS),
+    ("VideoLoss", SAFETY_DEVICE_CLASS),
+    ("DoorStatus", DOOR_DEVICE_CLASS),
+    ("AudioMutation", SOUND_DEVICE_CLASS),
+    ("SmartMotionHuman", MOTION_SENSOR_DEVICE_CLASS),  # the fallback
+])
+def test_device_class_mapping(sensor, event_name, expected):
+    assert sensor(event_name).device_class == expected
+
+
+def test_audio_events_get_the_volume_icon(sensor):
+    assert sensor("AudioMutation").icon == VOLUME_HIGH_ICON
+    assert sensor("VideoMotion").icon is None
+
+
+# --- identity, including a back-compat case that must not be tidied away ---
+
+def test_video_motion_keeps_the_bare_serial_as_its_id(sensor):
+    """Changing this orphans every existing motion sensor on upgrade."""
+    assert sensor("VideoMotion").unique_id == "SERIAL1"
+
+
+def test_other_events_get_a_suffixed_id(sensor):
+    assert sensor("SmartMotionHuman").unique_id == "SERIAL1_smart_motion_human"
+    assert sensor("CrossLineDetection").unique_id == "SERIAL1_cross_line_alarm"
+
+
+def test_ids_are_distinct_across_the_events_a_camera_reports(sensor):
+    events = ["VideoMotion", "CrossLineDetection", "AlarmLocal", "VideoLoss",
+              "VideoBlind", "AudioMutation", "CrossRegionDetection",
+              "SmartMotionHuman", "SmartMotionVehicle"]
+    ids = [sensor(e).unique_id for e in events]
+
+    assert len(set(ids)) == len(ids), "two events would share one entity: %s" % ids
+
+
+# --- state comes from the event stream, not polling ------------------------
+
+def test_is_on_follows_the_event_timestamp(sensor):
+    c = _Coordinator()
+    s = sensor("SmartMotionHuman", c)
+
+    assert s.is_on is False
+    c.timestamps["SmartMotionHuman"] = 1_700_000_000
+    assert s.is_on is True
+    c.timestamps["SmartMotionHuman"] = 0
+    assert s.is_on is False
+
+
+def test_each_sensor_only_watches_its_own_event(sensor):
+    c = _Coordinator()
+    s = sensor("SmartMotionHuman", c)
+    c.timestamps["VideoMotion"] = 1_700_000_000
+
+    assert s.is_on is False, "reacted to a different event"
+
+
+async def test_it_subscribes_to_its_event_when_added(sensor):
+    c = _Coordinator()
+    s = sensor("CrossLineDetection", c)
+
+    await s.async_added_to_hass()
+
+    assert [name for name, _ in c.listeners] == ["CrossLineDetection"]
+
+
+def test_these_sensors_are_pushed_not_polled(sensor):
+    assert sensor("VideoMotion").should_poll is False

--- a/tests/dahua/test_light.py
+++ b/tests/dahua/test_light.py
@@ -1,0 +1,194 @@
+"""light.py had no tests at all, and day/night handling has regressed before."""
+
+import pytest
+
+from custom_components.dahua import dahua_utils
+from custom_components.dahua.light import DahuaIlluminator, DahuaInfraredLight
+
+ATTR_BRIGHTNESS = "brightness"
+
+
+class _Client:
+    def __init__(self):
+        self.v1 = []
+        self.v2 = []
+
+    async def async_set_lighting_v1(self, channel, enabled, brightness):
+        self.v1.append((channel, enabled, brightness))
+
+    async def async_set_lighting_v2(self, channel, enabled, brightness, profile_mode):
+        self.v2.append((channel, enabled, brightness, profile_mode))
+
+
+class _Coordinator:
+    def __init__(self, channel=3, profile_mode="1"):
+        self.client = _Client()
+        self._channel = channel
+        self._profile_mode = profile_mode
+        self.refreshed = 0
+        self.infrared_on = True
+        self.infrared_brightness = 128
+        self.illuminator_on = False
+        self.illuminator_brightness = 64
+
+    def get_channel(self):
+        return self._channel
+
+    def get_profile_mode(self):
+        return self._profile_mode
+
+    def get_serial_number(self):
+        return "SERIAL1"
+
+    def get_device_name(self):
+        return "Front Door"
+
+    def is_infrared_light_on(self):
+        return self.infrared_on
+
+    def get_infrared_brightness(self):
+        return self.infrared_brightness
+
+    def is_illuminator_on(self):
+        return self.illuminator_on
+
+    def get_illuminator_brightness(self):
+        return self.illuminator_brightness
+
+    async def async_refresh(self):
+        self.refreshed += 1
+
+
+def _light(cls, coordinator, name="Infrared"):
+    """Build the entity without Home Assistant's entity plumbing."""
+    entity = object.__new__(cls)
+    entity._coordinator = coordinator
+    entity.coordinator = coordinator
+    entity._name = name
+    return entity
+
+
+# --- brightness conversion -------------------------------------------------
+
+@pytest.mark.parametrize("hass_value,expected", [
+    (0, 0),
+    (255, 100),
+    (128, 50),
+    (None, 100),   # no brightness given means full, not off
+])
+def test_hass_brightness_maps_to_dahua_scale(hass_value, expected):
+    assert dahua_utils.hass_brightness_to_dahua_brightness(hass_value) == expected
+
+
+@pytest.mark.parametrize("dahua_value,expected", [
+    ("0", 0),
+    ("100", 255),
+    ("50", 127),
+    ("", 255),     # blank means full
+    (None, 255),
+])
+def test_dahua_brightness_maps_back_to_hass_scale(dahua_value, expected):
+    assert dahua_utils.dahua_brightness_to_hass_brightness(dahua_value) == expected
+
+
+def test_the_two_conversions_agree_on_what_no_value_means():
+    """Both default to "full", but they work on different scales.
+
+    Full is 100 on the Dahua scale and 255 on the HASS scale. Using 100 for
+    both made an unspecified brightness mean 39%, so a plain toggle-on lit
+    the light dimly.
+    """
+    no_value_hass = dahua_utils.dahua_brightness_to_hass_brightness(None)
+    no_value_dahua = dahua_utils.hass_brightness_to_dahua_brightness(None)
+
+    assert no_value_hass == 255, "full on the HASS scale"
+    assert no_value_dahua == 100, "full on the Dahua scale"
+    assert dahua_utils.dahua_brightness_to_hass_brightness(str(no_value_dahua)) == no_value_hass
+
+
+def test_full_and_off_survive_a_round_trip():
+    for hass_value in (0, 255):
+        dahua = dahua_utils.hass_brightness_to_dahua_brightness(hass_value)
+        assert dahua_utils.dahua_brightness_to_hass_brightness(str(dahua)) == hass_value
+
+
+# --- infrared light (v1 API) ----------------------------------------------
+
+async def test_infrared_turn_on_sends_the_channel_and_brightness():
+    c = _Coordinator(channel=3)
+    await _light(DahuaInfraredLight, c).async_turn_on(**{ATTR_BRIGHTNESS: 255})
+
+    assert c.client.v1 == [(3, True, 100)]
+    assert c.client.v2 == [], "the infrared light must not use the v2 API"
+    assert c.refreshed == 1
+
+
+async def test_infrared_turn_off_sends_enabled_false():
+    c = _Coordinator(channel=3)
+    await _light(DahuaInfraredLight, c).async_turn_off()
+
+    assert len(c.client.v1) == 1
+    channel, enabled, _ = c.client.v1[0]
+    assert (channel, enabled) == (3, False)
+
+
+async def test_infrared_turn_on_without_brightness_uses_full():
+    c = _Coordinator()
+    await _light(DahuaInfraredLight, c).async_turn_on()
+
+    assert c.client.v1[0][2] == 100
+
+
+def test_infrared_reads_state_from_the_coordinator():
+    c = _Coordinator()
+    light = _light(DahuaInfraredLight, c)
+
+    assert light.is_on is True
+    assert light.brightness == 128
+    c.infrared_on = False
+    assert light.is_on is False
+
+
+# --- illuminator (v2 API, carries the profile mode) ------------------------
+
+async def test_illuminator_passes_the_profile_mode_through():
+    """Day/night handling rides on this argument and has regressed before."""
+    c = _Coordinator(channel=2, profile_mode="1")
+
+    await _light(DahuaIlluminator, c, "Illuminator").async_turn_on(**{ATTR_BRIGHTNESS: 255})
+
+    assert c.client.v2 == [(2, True, 100, "1")]
+    assert c.client.v1 == [], "the illuminator must not use the v1 API"
+
+
+async def test_illuminator_turn_off_keeps_the_profile_mode():
+    c = _Coordinator(channel=2, profile_mode="0")
+
+    await _light(DahuaIlluminator, c, "Illuminator").async_turn_off()
+
+    channel, enabled, _, profile_mode = c.client.v2[0]
+    assert (channel, enabled, profile_mode) == (2, False, "0")
+
+
+async def test_illuminator_uses_whatever_profile_mode_is_current():
+    c = _Coordinator(profile_mode="2")
+    await _light(DahuaIlluminator, c, "Illuminator").async_turn_on()
+    assert c.client.v2[0][3] == "2"
+
+
+# --- identity --------------------------------------------------------------
+
+def test_the_two_lights_do_not_share_a_unique_id():
+    """A collision would merge two different lights into one entity."""
+    c = _Coordinator()
+    infrared = _light(DahuaInfraredLight, c).unique_id
+    illuminator = _light(DahuaIlluminator, c, "Illuminator").unique_id
+
+    assert infrared == "SERIAL1_infrared"
+    assert illuminator == "SERIAL1_illuminator"
+    assert infrared != illuminator
+
+
+def test_name_is_prefixed_with_the_device_name():
+    c = _Coordinator()
+    assert _light(DahuaInfraredLight, c, "Infrared").name == "Front Door Infrared"

--- a/tests/dahua/test_switch.py
+++ b/tests/dahua/test_switch.py
@@ -1,0 +1,175 @@
+"""switch.py had no tests. These pin the call each switch actually makes."""
+
+import pytest
+
+from custom_components.dahua.client import SECURITY_LIGHT_TYPE, SIREN_TYPE
+from custom_components.dahua.switch import (
+    DahuaDisarmingEventNotificationsLinkageBinarySwitch,
+    DahuaDisarmingLinkageBinarySwitch,
+    DahuaMotionDetectionBinarySwitch,
+    DahuaSirenBinarySwitch,
+    DahuaSmartMotionDetectionBinarySwitch,
+)
+
+
+class _Client:
+    def __init__(self):
+        self.calls = []
+
+    def _record(self, name):
+        async def call(*args):
+            self.calls.append((name,) + args)
+        return call
+
+    def __getattr__(self, name):
+        return self._record(name)
+
+
+class _Coordinator:
+    def __init__(self, channel=4, amcrest=False):
+        self.client = _Client()
+        self._channel = channel
+        self._amcrest = amcrest
+        self.refreshed = 0
+        self.states = {}
+
+    def get_channel(self):
+        return self._channel
+
+    def get_serial_number(self):
+        return "SERIAL1"
+
+    def get_device_name(self):
+        return "Garage"
+
+    def supports_smart_motion_detection_amcrest(self):
+        return self._amcrest
+
+    def is_motion_detection_enabled(self):
+        return self.states.get("motion", False)
+
+    def is_disarming_linkage_enabled(self):
+        return self.states.get("disarming", False)
+
+    def is_event_notifications_enabled(self):
+        return self.states.get("notifications", False)
+
+    def is_smart_motion_detection_enabled(self):
+        return self.states.get("smart", False)
+
+    def is_siren_on(self):
+        return self.states.get("siren", False)
+
+    async def async_refresh(self):
+        self.refreshed += 1
+
+
+def _switch(cls, coordinator):
+    entity = object.__new__(cls)
+    entity._coordinator = coordinator
+    entity.coordinator = coordinator
+    return entity
+
+
+ALL = [
+    DahuaMotionDetectionBinarySwitch,
+    DahuaDisarmingLinkageBinarySwitch,
+    DahuaDisarmingEventNotificationsLinkageBinarySwitch,
+    DahuaSmartMotionDetectionBinarySwitch,
+    DahuaSirenBinarySwitch,
+]
+
+
+# --- each switch drives its own API ----------------------------------------
+
+@pytest.mark.parametrize("cls,method", [
+    (DahuaMotionDetectionBinarySwitch, "enable_motion_detection"),
+    (DahuaDisarmingLinkageBinarySwitch, "async_set_disarming_linkage"),
+    (DahuaDisarmingEventNotificationsLinkageBinarySwitch, "async_set_event_notifications"),
+])
+async def test_channel_switches_send_channel_and_state(cls, method):
+    c = _Coordinator(channel=4)
+    s = _switch(cls, c)
+
+    await s.async_turn_on()
+    await s.async_turn_off()
+
+    assert c.client.calls == [(method, 4, True), (method, 4, False)]
+    assert c.refreshed == 2, "the UI would show a stale state without a refresh"
+
+
+async def test_siren_asks_for_the_siren_not_the_security_light():
+    """Both ride the same CGI; the type is the only thing separating them."""
+    c = _Coordinator(channel=4)
+    s = _switch(DahuaSirenBinarySwitch, c)
+
+    await s.async_turn_on()
+
+    assert c.client.calls == [("async_set_coaxial_control_state", 4, SIREN_TYPE, True)]
+    assert SIREN_TYPE != SECURITY_LIGHT_TYPE
+
+
+async def test_siren_turn_off_keeps_the_siren_type():
+    c = _Coordinator(channel=1)
+    await _switch(DahuaSirenBinarySwitch, c).async_turn_off()
+    assert c.client.calls == [("async_set_coaxial_control_state", 1, SIREN_TYPE, False)]
+
+
+# --- smart motion picks an API by vendor -----------------------------------
+
+async def test_smart_motion_uses_the_dahua_api_by_default():
+    c = _Coordinator(amcrest=False)
+    s = _switch(DahuaSmartMotionDetectionBinarySwitch, c)
+
+    await s.async_turn_on()
+    await s.async_turn_off()
+
+    assert c.client.calls == [
+        ("async_enabled_smart_motion_detection", True),
+        ("async_enabled_smart_motion_detection", False),
+    ]
+
+
+async def test_smart_motion_uses_the_ivs_rule_on_amcrest():
+    c = _Coordinator(amcrest=True)
+    s = _switch(DahuaSmartMotionDetectionBinarySwitch, c)
+
+    await s.async_turn_on()
+    await s.async_turn_off()
+
+    assert c.client.calls == [
+        ("async_set_ivs_rule", 0, 0, True),
+        ("async_set_ivs_rule", 0, 0, False),
+    ]
+
+
+# --- identity --------------------------------------------------------------
+
+def test_every_switch_has_its_own_unique_id():
+    """A collision would silently merge two switches into one entity."""
+    c = _Coordinator()
+    ids = [_switch(cls, c).unique_id for cls in ALL]
+
+    assert len(set(ids)) == len(ids), "duplicate unique_id among %s" % ids
+    assert all(i.startswith("SERIAL1_") for i in ids)
+
+
+def test_every_switch_is_named_after_the_device():
+    c = _Coordinator()
+    for cls in ALL:
+        assert _switch(cls, c).name.startswith("Garage "), cls.__name__
+
+
+@pytest.mark.parametrize("cls,key", [
+    (DahuaMotionDetectionBinarySwitch, "motion"),
+    (DahuaDisarmingLinkageBinarySwitch, "disarming"),
+    (DahuaDisarmingEventNotificationsLinkageBinarySwitch, "notifications"),
+    (DahuaSmartMotionDetectionBinarySwitch, "smart"),
+])
+def test_is_on_reflects_the_coordinator(cls, key):
+    c = _Coordinator()
+    s = _switch(cls, c)
+
+    assert s.is_on is False
+    c.states[key] = True
+    assert s.is_on is True


### PR DESCRIPTION
The last two platforms with no coverage at all. **No bugs turned up this time** — unlike #609, where the first `light.py` test failed immediately. These pin behaviour that is easy to break silently.

**Builds on #606, #607, #608 and #609** and shares their branch, so the diff currently shows those commits too. It collapses to its own change once they merge.

### switch.py

Each switch drives a different API, and the arguments are what separate them:

- **The siren and the security light both go through `async_set_coaxial_control_state`** and differ only by a type constant. A swapped constant would sound the siren when the light was asked for, with nothing else to catch it. Two tests assert `SIREN_TYPE` specifically, on and off.
- **Smart motion picks between the Amcrest IVS rule and the Dahua API by vendor** — `async_set_ivs_rule(0, 0, x)` versus `async_enabled_smart_motion_detection(x)`. Both branches are covered.
- **The three channel-scoped switches** are asserted to send the right channel and the right boolean, and to refresh afterwards — without which the UI shows a stale state.
- **Every switch keeps its own `unique_id`.** A collision merges two switches into one entity.

### binary_sensor.py

Names, device classes and unique IDs are all *derived* rather than declared:

- **The name derivation** turns `SmartMotionHuman` into "Smart Motion Human" while leaving consecutive capitals like `IVS` alone — that lookbehind is easy to break with a well-meaning regex tidy.
- **Overrides win over derivation** for `VideoMotion`, `CrossLineDetection` and `DoorbellPressed`.
- **`VideoMotion` deliberately keeps the bare serial number as its unique ID** for backwards compatibility. The comment says so; now a test does too, because tidying it away would orphan every existing motion sensor on upgrade.
- **IDs stay distinct** across the nine event codes a typical camera reports.
- **State follows the event timestamp**, and a sensor does not react to a different event's timestamp.

### Verification

In a `python:3.13` container matching CI:

```
suite: 136 passed

switch.py         0% -> 85%
binary_sensor.py  0% -> 80%
total            41% -> 48%
```

Pointing the siren at `SECURITY_LIGHT_TYPE` fails two tests.

These use the same `object.__new__` plus fake-coordinator approach as #609, so no `hass` fixture is needed and they run fast.