### PR TITLE
Add NVR TiOC active deterrence control and status synchronization

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -45,6 +45,7 @@ from .const import (
     CONF_AUTO_DETECT_CHANNEL,
     CONF_USE_HTTPS,
     CONF_SCAN_INTERVAL,
+    CONF_NVR_ACTIVE_DETERRENCE,
     DEFAULT_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
 )
@@ -623,6 +624,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         self.connected = None
         self.events: list = events
         self._supports_coaxial_control = False
+        self._nvr_active_deterrence = entry.options.get(CONF_NVR_ACTIVE_DETERRENCE, False)
         self._supports_disarming_linkage = False
         self._supports_event_notifications = False
         self._supports_smart_motion_detection = False
@@ -1223,6 +1225,10 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         m = self.model.upper()
         return "-AS-PV" in m or "L46N" in m or m.startswith("W452ASD")
 
+    def supports_nvr_active_deterrence(self) -> bool:
+        """Return whether NVR active-deterrence entities were explicitly enabled."""
+        return self._nvr_active_deterrence
+
     def supports_security_light(self) -> bool:
         """
         Returns true if this camera has the red/blue flashing security light feature.  For example, the
@@ -1524,7 +1530,13 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if coordinator is None:
+        # Setup may have failed before the coordinator was registered, or a
+        # previous unload may already have removed it. Treat that as unloaded
+        # so an options-triggered reload can continue cleanly.
+        return True
+
     await coordinator.async_stop()
     unloaded = all(
         await asyncio.gather(
@@ -1553,5 +1565,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -1463,6 +1463,10 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         """returns the channel index of this camera. 0 based. Channel index 0 is channel number 1"""
         return self._channel
 
+    def is_nvr_channel(self) -> bool:
+        """Return whether this entry represents a camera channel on an NVR."""
+        return self._channel > 0 or "NVR" in self.model.upper()
+
     def get_channel_number(self) -> int:
         """returns the channel number of this camera"""
         return self._channel_number

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -836,7 +836,8 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.debug("Using channel number %s (auto_detect=%s)", self._channel_number, auto_detect)
 
                 try:
-                    await self.client.async_get_coaxial_control_io_status()
+                    coaxial_channel = self._channel_number if self.is_nvr_channel() else 1
+                    await self.client.async_get_coaxial_control_io_status(coaxial_channel)
                     self._supports_coaxial_control = True
                 except ClientResponseError:
                     self._supports_coaxial_control = False
@@ -979,7 +980,12 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 coros.append(asyncio.ensure_future(self.client.async_get_event_notifications()))
             # The siren switch and the security light both read this one.
             if self._supports_coaxial_control and self._wanted_by(LIGHT, SWITCH):
-                coros.append(asyncio.ensure_future(self.client.async_get_coaxial_control_io_status()))
+                coaxial_channel = self._channel_number if self.is_nvr_channel() else 1
+                coros.append(
+                    asyncio.ensure_future(
+                        self.client.async_get_coaxial_control_io_status(coaxial_channel)
+                    )
+                )
             if self._supports_smart_motion_detection and self._wanted_by(SWITCH):
                 coros.append(asyncio.ensure_future(self.client.async_get_smart_motion_detection()))
             if self.supports_smart_motion_detection_amcrest() and self._wanted_by(SWITCH):

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -306,7 +306,7 @@ class DahuaClient:
         # If we can't fetch, just assume 2 since that's pretty standard
         return 3
 
-    async def async_get_coaxial_control_io_status(self) -> dict:
+    async def async_get_coaxial_control_io_status(self, channel: int = 1) -> dict:
         """
         async_get_coaxial_control_io_status returns the the current state of the speaker and white light.
         Note that the "white light" here seems to also work for cameras that have the red/blue flashing alarm light
@@ -317,7 +317,7 @@ class DahuaClient:
         status.status.Speaker=Off
         status.status.WhiteLight=Off
         """
-        url = "/cgi-bin/coaxialControlIO.cgi?action=getStatus&channel=1"
+        url = "/cgi-bin/coaxialControlIO.cgi?action=getStatus&channel={channel}".format(channel=channel)
         return await self.get(url)
 
     async def async_get_lighting_v2(self) -> dict:

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -875,13 +875,15 @@ class DahuaClient:
         _LOGGER.debug("Setting coaxial control state to %s: %s", io, url)
         return await self.get(url)
 
-    async def async_set_nvr_coaxial_control_state(self, channel: int, enabled: bool) -> dict:
-        """Set an NVR-connected camera's active deterrence light state."""
+    async def async_set_nvr_coaxial_control_state(
+        self, channel: int, dahua_type: int, enabled: bool
+    ) -> dict:
+        """Set an NVR-connected camera's coaxial deterrence state."""
         io = 1 if enabled else 2
         url = (
             "/cgi-bin/coaxialControlIO.cgi?action=control&channel={channel}"
-            "&info[0].Type=1&info[0].IO={io}&info[0].TriggerMode=2"
-        ).format(channel=channel, io=io)
+            "&info[0].Type={dahua_type}&info[0].IO={io}&info[0].TriggerMode=2"
+        ).format(channel=channel, dahua_type=dahua_type, io=io)
         _LOGGER.debug("Setting NVR coaxial control state to %s: %s", io, url)
         return await self.get(url)
 

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -875,6 +875,16 @@ class DahuaClient:
         _LOGGER.debug("Setting coaxial control state to %s: %s", io, url)
         return await self.get(url)
 
+    async def async_set_nvr_coaxial_control_state(self, channel: int, enabled: bool) -> dict:
+        """Set an NVR-connected camera's active deterrence light state."""
+        io = 1 if enabled else 2
+        url = (
+            "/cgi-bin/coaxialControlIO.cgi?action=control&channel={channel}"
+            "&info[0].Type=1&info[0].IO={io}&info[0].TriggerMode=2"
+        ).format(channel=channel, io=io)
+        _LOGGER.debug("Setting NVR coaxial control state to %s: %s", io, url)
+        return await self.get(url)
+
     async def async_set_disarming_linkage(self, channel: int, enabled: bool) -> dict:
         """
         async_set_disarming_linkage will set the camera's disarming linkage (Event -> Disarming in the UI)

--- a/custom_components/dahua/config_flow.py
+++ b/custom_components/dahua/config_flow.py
@@ -26,6 +26,7 @@ from .const import (
     CONF_AUTO_DETECT_CHANNEL,
     CONF_USE_HTTPS,
     CONF_SCAN_INTERVAL,
+    CONF_NVR_ACTIVE_DETERRENCE,
     DEFAULT_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
 )
@@ -324,6 +325,12 @@ class DahuaOptionsFlowHandler(config_entries.OptionsFlow):
                 default=self.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
             )
         ] = vol.All(vol.Coerce(int), vol.Range(min=MIN_SCAN_INTERVAL))
+        schema[
+            vol.Required(
+                CONF_NVR_ACTIVE_DETERRENCE,
+                default=self.options.get(CONF_NVR_ACTIVE_DETERRENCE, False),
+            )
+        ] = bool
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(schema),

--- a/custom_components/dahua/const.py
+++ b/custom_components/dahua/const.py
@@ -48,6 +48,7 @@ CONF_CHANNEL = "channel"
 CONF_AUTO_DETECT_CHANNEL = "auto_detect_channel"
 CONF_USE_HTTPS = "use_https"
 CONF_SCAN_INTERVAL = "scan_interval"
+CONF_NVR_ACTIVE_DETERRENCE = "nvr_active_deterrence"
 
 # Defaults
 DEFAULT_NAME = "Dahua"

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -30,9 +30,12 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     if coordinator.is_flood_light():
         entities.append(FloodLight(coordinator, entry, "Flood Light"))
 
-    if coordinator.supports_security_light() and not coordinator.is_amcrest_doorbell():
+    if (
+        coordinator.supports_security_light() or coordinator.is_nvr_channel()
+    ) and not coordinator.is_amcrest_doorbell():
         #  The Amcrest doorbell works a little different and is added in select.py
-        entities.append(DahuaSecurityLight(coordinator, entry, "Security Light"))
+        security_light_name = "Warning Light" if coordinator.is_nvr_channel() else "Security Light"
+        entities.append(DahuaSecurityLight(coordinator, entry, security_light_name))
 
     if coordinator.is_amcrest_doorbell():
         entities.append(AmcrestRingLight(coordinator, entry, "Ring Light"))
@@ -168,7 +171,7 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         profile_mode = self._coordinator.get_profile_mode()
         if self._coordinator.is_nvr_channel():
             await self._coordinator.client.async_set_nvr_coaxial_control_state(
-                self._coordinator.get_channel_number(), True
+                self._coordinator.get_channel_number(), SECURITY_LIGHT_TYPE, True
             )
         else:
             await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode)
@@ -182,7 +185,7 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         profile_mode = self._coordinator.get_profile_mode()
         if self._coordinator.is_nvr_channel():
             await self._coordinator.client.async_set_nvr_coaxial_control_state(
-                self._coordinator.get_channel_number(), False
+                self._coordinator.get_channel_number(), SECURITY_LIGHT_TYPE, False
             )
         else:
             await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode)
@@ -295,7 +298,7 @@ class FloodLight(DahuaBaseEntity, LightEntity):
             await self._coordinator.client.async_set_floodlightmode(2)
             if self._coordinator.is_nvr_channel():
                 await self._coordinator.client.async_set_nvr_coaxial_control_state(
-                    self._coordinator.get_channel_number(), True
+                    self._coordinator.get_channel_number(), SECURITY_LIGHT_TYPE, True
                 )
             else:
                 await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, True)
@@ -312,7 +315,7 @@ class FloodLight(DahuaBaseEntity, LightEntity):
             channel = self._coordinator.get_channel()
             if self._coordinator.is_nvr_channel():
                 await self._coordinator.client.async_set_nvr_coaxial_control_state(
-                    self._coordinator.get_channel_number(), False
+                    self._coordinator.get_channel_number(), SECURITY_LIGHT_TYPE, False
                 )
             else:
                 await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, False)
@@ -364,7 +367,7 @@ class DahuaSecurityLight(DahuaBaseEntity, LightEntity):
         channel = self._coordinator.get_channel()
         if self._coordinator.is_nvr_channel():
             await self._coordinator.client.async_set_nvr_coaxial_control_state(
-                self._coordinator.get_channel_number(), True
+                self._coordinator.get_channel_number(), SECURITY_LIGHT_TYPE, True
             )
         else:
             await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, True)
@@ -375,7 +378,7 @@ class DahuaSecurityLight(DahuaBaseEntity, LightEntity):
         channel = self._coordinator.get_channel()
         if self._coordinator.is_nvr_channel():
             await self._coordinator.client.async_set_nvr_coaxial_control_state(
-                self._coordinator.get_channel_number(), False
+                self._coordinator.get_channel_number(), SECURITY_LIGHT_TYPE, False
             )
         else:
             await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, False)

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -169,12 +169,7 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         dahua_brightness = dahua_utils.hass_brightness_to_dahua_brightness(hass_brightness)
         channel = self._coordinator.get_channel()
         profile_mode = self._coordinator.get_profile_mode()
-        if self._coordinator.is_nvr_channel():
-            await self._coordinator.client.async_set_nvr_coaxial_control_state(
-                self._coordinator.get_channel_number(), SECURITY_LIGHT_TYPE, True
-            )
-        else:
-            await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode)
+        await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode)
         await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):
@@ -183,12 +178,7 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         dahua_brightness = dahua_utils.hass_brightness_to_dahua_brightness(hass_brightness)
         channel = self._coordinator.get_channel()
         profile_mode = self._coordinator.get_profile_mode()
-        if self._coordinator.is_nvr_channel():
-            await self._coordinator.client.async_set_nvr_coaxial_control_state(
-                self._coordinator.get_channel_number(), SECURITY_LIGHT_TYPE, False
-            )
-        else:
-            await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode)
+        await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode)
         await self._coordinator.async_refresh()
 
 

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -166,7 +166,12 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         dahua_brightness = dahua_utils.hass_brightness_to_dahua_brightness(hass_brightness)
         channel = self._coordinator.get_channel()
         profile_mode = self._coordinator.get_profile_mode()
-        await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode)
+        if self._coordinator.is_nvr_channel():
+            await self._coordinator.client.async_set_nvr_coaxial_control_state(
+                self._coordinator.get_channel_number(), True
+            )
+        else:
+            await self._coordinator.client.async_set_lighting_v2(channel, True, dahua_brightness, profile_mode)
         await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):
@@ -175,7 +180,12 @@ class DahuaIlluminator(DahuaBaseEntity, LightEntity):
         dahua_brightness = dahua_utils.hass_brightness_to_dahua_brightness(hass_brightness)
         channel = self._coordinator.get_channel()
         profile_mode = self._coordinator.get_profile_mode()
-        await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode)
+        if self._coordinator.is_nvr_channel():
+            await self._coordinator.client.async_set_nvr_coaxial_control_state(
+                self._coordinator.get_channel_number(), False
+            )
+        else:
+            await self._coordinator.client.async_set_lighting_v2(channel, False, dahua_brightness, profile_mode)
         await self._coordinator.async_refresh()
 
 
@@ -283,7 +293,12 @@ class FloodLight(DahuaBaseEntity, LightEntity):
             channel = self._coordinator.get_channel()
             self._coordinator._floodlight_mode = await self._coordinator.client.async_get_floodlightmode()
             await self._coordinator.client.async_set_floodlightmode(2)
-            await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, True)
+            if self._coordinator.is_nvr_channel():
+                await self._coordinator.client.async_set_nvr_coaxial_control_state(
+                    self._coordinator.get_channel_number(), True
+                )
+            else:
+                await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, True)
             await self._coordinator.async_refresh()
         else:
             channel = self._coordinator.get_channel()
@@ -295,7 +310,12 @@ class FloodLight(DahuaBaseEntity, LightEntity):
         """Turn the light off"""
         if self._coordinator._supports_floodlightmode:
             channel = self._coordinator.get_channel()
-            await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, False)
+            if self._coordinator.is_nvr_channel():
+                await self._coordinator.client.async_set_nvr_coaxial_control_state(
+                    self._coordinator.get_channel_number(), False
+                )
+            else:
+                await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, False)
             await self._coordinator.client.async_set_floodlightmode(self._coordinator._floodlight_mode)
             await self._coordinator.async_refresh()
         else:
@@ -342,13 +362,23 @@ class DahuaSecurityLight(DahuaBaseEntity, LightEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the light on"""
         channel = self._coordinator.get_channel()
-        await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, True)
+        if self._coordinator.is_nvr_channel():
+            await self._coordinator.client.async_set_nvr_coaxial_control_state(
+                self._coordinator.get_channel_number(), True
+            )
+        else:
+            await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, True)
         await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):
         """Turn the light off"""
         channel = self._coordinator.get_channel()
-        await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, False)
+        if self._coordinator.is_nvr_channel():
+            await self._coordinator.client.async_set_nvr_coaxial_control_state(
+                self._coordinator.get_channel_number(), False
+            )
+        else:
+            await self._coordinator.client.async_set_coaxial_control_state(channel, SECURITY_LIGHT_TYPE, False)
         await self._coordinator.async_refresh()
 
     @property

--- a/custom_components/dahua/light.py
+++ b/custom_components/dahua/light.py
@@ -30,11 +30,16 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
     if coordinator.is_flood_light():
         entities.append(FloodLight(coordinator, entry, "Flood Light"))
 
-    if (
-        coordinator.supports_security_light() or coordinator.is_nvr_channel()
-    ) and not coordinator.is_amcrest_doorbell():
+    has_security_light = (
+        coordinator.supports_nvr_active_deterrence()
+        if coordinator.is_nvr_channel()
+        else coordinator.supports_security_light()
+    )
+    if has_security_light and not coordinator.is_amcrest_doorbell():
         #  The Amcrest doorbell works a little different and is added in select.py
-        security_light_name = "Warning Light" if coordinator.is_nvr_channel() else "Security Light"
+        security_light_name = (
+            "Warning Light" if coordinator.is_nvr_channel() else "Security Light"
+        )
         entities.append(DahuaSecurityLight(coordinator, entry, security_light_name))
 
     if coordinator.is_amcrest_doorbell():

--- a/custom_components/dahua/switch.py
+++ b/custom_components/dahua/switch.py
@@ -19,7 +19,12 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     ]
 
     # But only some cams have a siren, very few do actually
-    if coordinator.supports_siren() or coordinator.is_nvr_channel():
+    has_siren = (
+        coordinator.supports_nvr_active_deterrence()
+        if coordinator.is_nvr_channel()
+        else coordinator.supports_siren()
+    )
+    if has_siren:
         devices.append(
             DahuaSirenBinarySwitch(
                 coordinator,
@@ -229,6 +234,8 @@ class DahuaSmartMotionDetectionBinarySwitch(DahuaBaseEntity, SwitchEntity):
 
 class DahuaSirenBinarySwitch(DahuaBaseEntity, SwitchEntity):
     """dahua siren switch class. Used to enable or disable camera built in sirens"""
+
+    _name = "Siren"
 
     def __init__(self, coordinator, entry, name="Siren"):
         super().__init__(coordinator, entry)

--- a/custom_components/dahua/switch.py
+++ b/custom_components/dahua/switch.py
@@ -19,8 +19,14 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     ]
 
     # But only some cams have a siren, very few do actually
-    if coordinator.supports_siren():
-        devices.append(DahuaSirenBinarySwitch(coordinator, entry))
+    if coordinator.supports_siren() or coordinator.is_nvr_channel():
+        devices.append(
+            DahuaSirenBinarySwitch(
+                coordinator,
+                entry,
+                name="Alarm" if coordinator.is_nvr_channel() else "Siren",
+            )
+        )
     if coordinator.supports_smart_motion_detection() or coordinator.supports_smart_motion_detection_amcrest():
         devices.append(DahuaSmartMotionDetectionBinarySwitch(coordinator, entry))
 
@@ -224,22 +230,36 @@ class DahuaSmartMotionDetectionBinarySwitch(DahuaBaseEntity, SwitchEntity):
 class DahuaSirenBinarySwitch(DahuaBaseEntity, SwitchEntity):
     """dahua siren switch class. Used to enable or disable camera built in sirens"""
 
+    def __init__(self, coordinator, entry, name="Siren"):
+        super().__init__(coordinator, entry)
+        self._name = name
+
     async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn on/enable the camera's siren"""
         channel = self._coordinator.get_channel()
-        await self._coordinator.client.async_set_coaxial_control_state(channel, SIREN_TYPE, True)
+        if self._coordinator.is_nvr_channel():
+            await self._coordinator.client.async_set_nvr_coaxial_control_state(
+                self._coordinator.get_channel_number(), SIREN_TYPE, True
+            )
+        else:
+            await self._coordinator.client.async_set_coaxial_control_state(channel, SIREN_TYPE, True)
         await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
         """Turn off/disable camera siren"""
         channel = self._coordinator.get_channel()
-        await self._coordinator.client.async_set_coaxial_control_state(channel, SIREN_TYPE, False)
+        if self._coordinator.is_nvr_channel():
+            await self._coordinator.client.async_set_nvr_coaxial_control_state(
+                self._coordinator.get_channel_number(), SIREN_TYPE, False
+            )
+        else:
+            await self._coordinator.client.async_set_coaxial_control_state(channel, SIREN_TYPE, False)
         await self._coordinator.async_refresh()
 
     @property
     def name(self):
         """Return the name of the switch."""
-        return self._coordinator.get_device_name() + " Siren"
+        return self._coordinator.get_device_name() + " " + self._name
 
     @property
     def unique_id(self):

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -65,7 +65,8 @@
                     "button": "Button enabled",
                     "auto_detect_channel": "Auto-detect channel index (disable if HTTP snapshot at channel=0 works but RTSP only streams on channel=1)",
                     "events": "Events to subscribe to",
-                    "scan_interval": "Seconds between device polls (events are not affected)"
+                    "scan_interval": "Seconds between device polls (events are not affected)",
+                    "nvr_active_deterrence": "Enable NVR active deterrence controls"
                 }
             }
         }

--- a/tests/dahua/test_nvr_coaxial_light.py
+++ b/tests/dahua/test_nvr_coaxial_light.py
@@ -9,14 +9,20 @@ async def test_nvr_coaxial_control_state_uses_required_parameters():
     client = DahuaClient("u", "p", "nvr", 80, 554, None)
     client.get = AsyncMock(return_value={})
 
-    await client.async_set_nvr_coaxial_control_state(3, True)
+    await client.async_set_nvr_coaxial_control_state(3, 1, True)
     assert client.get.await_args.args == (
         "/cgi-bin/coaxialControlIO.cgi?action=control&channel=3"
         "&info[0].Type=1&info[0].IO=1&info[0].TriggerMode=2",
     )
 
-    await client.async_set_nvr_coaxial_control_state(3, False)
+    await client.async_set_nvr_coaxial_control_state(3, 1, False)
     assert client.get.await_args.args == (
         "/cgi-bin/coaxialControlIO.cgi?action=control&channel=3"
         "&info[0].Type=1&info[0].IO=2&info[0].TriggerMode=2",
+    )
+
+    await client.async_set_nvr_coaxial_control_state(3, 2, True)
+    assert client.get.await_args.args == (
+        "/cgi-bin/coaxialControlIO.cgi?action=control&channel=3"
+        "&info[0].Type=2&info[0].IO=1&info[0].TriggerMode=2",
     )

--- a/tests/dahua/test_nvr_coaxial_light.py
+++ b/tests/dahua/test_nvr_coaxial_light.py
@@ -1,0 +1,22 @@
+"""Tests for active deterrence control on NVR channels."""
+
+from unittest.mock import AsyncMock
+
+from custom_components.dahua.client import DahuaClient
+
+
+async def test_nvr_coaxial_control_state_uses_required_parameters():
+    client = DahuaClient("u", "p", "nvr", 80, 554, None)
+    client.get = AsyncMock(return_value={})
+
+    await client.async_set_nvr_coaxial_control_state(3, True)
+    assert client.get.await_args.args == (
+        "/cgi-bin/coaxialControlIO.cgi?action=control&channel=3"
+        "&info[0].Type=1&info[0].IO=1&info[0].TriggerMode=2",
+    )
+
+    await client.async_set_nvr_coaxial_control_state(3, False)
+    assert client.get.await_args.args == (
+        "/cgi-bin/coaxialControlIO.cgi?action=control&channel=3"
+        "&info[0].Type=1&info[0].IO=2&info[0].TriggerMode=2",
+    )

--- a/tests/dahua/test_options_scan_interval.py
+++ b/tests/dahua/test_options_scan_interval.py
@@ -96,3 +96,17 @@ async def test_platform_toggles_are_still_offered(hass):
     for field in ("camera", "light", "switch", "binary_sensor", "select"):
         assert field in defaults, f"lost the {field} toggle"
     assert "auto_detect_channel" in defaults
+
+
+async def test_nvr_active_deterrence_defaults_to_disabled(hass):
+    defaults = _schema_defaults(await _shown_options_form(hass, _entry()))
+
+    assert defaults["nvr_active_deterrence"] is False
+
+
+async def test_nvr_active_deterrence_preserves_the_configured_value(hass):
+    defaults = _schema_defaults(
+        await _shown_options_form(hass, _entry(nvr_active_deterrence=True))
+    )
+
+    assert defaults["nvr_active_deterrence"] is True

--- a/tests/dahua/test_switch.py
+++ b/tests/dahua/test_switch.py
@@ -36,6 +36,15 @@ class _Coordinator:
     def get_channel(self):
         return self._channel
 
+    def get_channel_number(self):
+        return self._channel + 1
+
+    def is_nvr_channel(self):
+        return False
+
+    def supports_nvr_active_deterrence(self):
+        return False
+
     def get_serial_number(self):
         return "SERIAL1"
 


### PR DESCRIPTION
## Description

This pull request adds reliable coaxial control and status synchronization for TiOC cameras connected through Dahua NVR channels.

Dahua NVRs mask the capabilities of connected cameras, so Home Assistant could fail to discover the active deterrence entities and could send light or siren commands through the wrong API.

These changes:

- Force the creation of the `Warning Light` and `Alarm` entities for NVR channels.
- Route NVR warning-light commands through `coaxialControlIO.cgi` with `Type=1`.
- Route NVR siren commands through `coaxialControlIO.cgi` with `Type=2`.
- Map `IO=1` to ON and `IO=2` to OFF.
- Include `TriggerMode=2` for NVR control requests.
- Use the resolved NVR channel number for control and status requests.
- Preserve the original direct-camera behavior and keep the normal `Illuminator` separate from the `Warning Light`.

## Tested Hardware

- **NVR:** DHI-NVR4116HS-8P-EI
- **Camera:** DH-IPC-HFW3449T1-AS-PV-S3
- **Camera type:** TiOC 3.0 / WizSense S3

## Verification

Warning-light and siren ON/OFF control was tested successfully. Status and event history in Home Assistant remained synchronized with the physical device and the DMSS app.
<img width="960" height="599" alt="Screenshot 2026-09-04 122151" src="https://github.com/user-attachments/assets/96e37c4d-a648-4870-ab1d-fb9575479c3b" />
