### PR TITLE
Add a diagnostics dump

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -77,6 +77,10 @@ class DahuaClient:
         # Keyed by address so every entry for one NVR shares a single budget.
         self._host_limit = _host_limiter(self._address)
         self._rpc2_session_instance = None
+        # True once this device has failed to report a serial number and we have had
+        # to derive its identity from the connection details instead. That derivation
+        # includes the password, so the identity changes if the password does.
+        self.identity_derived_from_credentials = False
         protocol = "https" if use_https else "http"
         self._base = "{0}://{1}:{2}".format(protocol, self._address, port)
 
@@ -126,6 +130,7 @@ class DahuaClient:
         try:
             return await self.get("/cgi-bin/magicBox.cgi?action=getSystemInfo")
         except aiohttp.ClientResponseError as e:
+            self.identity_derived_from_credentials = True
             not_hashed_id = "{0}_{1}_{2}_{3}".format(self._address, self._rtsp_port, self._username, self._password)
             unique_cam_id = md5(not_hashed_id.encode('UTF-8')).hexdigest()
             return {"serialNumber": unique_cam_id}
@@ -158,6 +163,7 @@ class DahuaClient:
         try:
             return await self.get("/cgi-bin/magicBox.cgi?action=getMachineName")
         except aiohttp.ClientResponseError as e:
+            self.identity_derived_from_credentials = True
             not_hashed_id = "{0}_{1}_{2}_{3}".format(self._address, self._rtsp_port, self._username, self._password)
             unique_cam_id = md5(not_hashed_id.encode('UTF-8')).hexdigest()
             return {"name": unique_cam_id}
@@ -226,6 +232,7 @@ class DahuaClient:
         try:
             return await self.get(url)
         except aiohttp.ClientResponseError as e:
+            self.identity_derived_from_credentials = True
             not_hashed_id = "{0}_{1}_{2}_{3}".format(self._address, self._rtsp_port, self._username, self._password)
             unique_cam_id = md5(not_hashed_id.encode('UTF-8')).hexdigest()
             return {"table.General.MachineName": unique_cam_id}

--- a/custom_components/dahua/diagnostics.py
+++ b/custom_components/dahua/diagnostics.py
@@ -1,0 +1,326 @@
+"""Diagnostics support for Dahua.
+
+Most bug reports against this integration arrive as a screenshot of one log line.
+The dump below is meant to answer, without a round trip, the questions that are
+actually asked: what did the device report it can do, what is the coordinator's
+last error, and - on an NVR - how many other config entries are competing for the
+same host.
+
+Nothing here talks to the device. It only reports state the integration already
+holds, so it is safe to pull when the device is unreachable, which is exactly
+when someone will pull it.
+"""
+import time
+from hashlib import sha256
+from typing import Any, Callable, Mapping
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from .const import (
+    CONF_ADDRESS,
+    CONF_AUTO_DETECT_CHANNEL,
+    CONF_CHANNEL,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    DOMAIN,
+)
+
+# Redacted by key, everywhere they appear.
+#
+# The serial number is in here deliberately. When a device does not report one,
+# the integration derives it as md5("{address}_{rtsp_port}_{username}_{password}")
+# - see the fallback branches in client.py. Publishing that hash next to the
+# address and RTSP port, which are not secret, would make an offline dictionary
+# attack on the password straightforward. There is no reliable way to tell from
+# outside which devices took the fallback, so the serial is always withheld and
+# `serial_fingerprint` is offered instead.
+TO_REDACT = {
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    "unique_id",
+    "serialNumber",
+    "serial_number",
+}
+
+
+def _safe(fn: Callable[[], Any], default: Any = None) -> Any:
+    """Call an accessor, returning `default` if it raises.
+
+    Several accessors dereference `coordinator.data`, which is None until the
+    first successful refresh, and `get_serial_number()` reads an attribute that
+    is only assigned during capability detection. A diagnostics handler that
+    raises returns HTTP 500 with no explanation, so nothing here may propagate.
+    """
+    try:
+        return fn()
+    except Exception:  # pylint: disable=broad-except
+        return default
+
+
+def _serial_fingerprint(coordinator) -> str | None:
+    """A stable, non-reversible stand-in for the serial number.
+
+    Keeps the one property that matters for support - which entries belong to
+    the same physical device - without publishing the serial itself.
+    """
+    serial = _safe(coordinator.get_serial_number)
+    if not serial:
+        return None
+    return sha256(str(serial).encode("utf-8")).hexdigest()[:12]
+
+
+def _entry_block(config_entry: ConfigEntry) -> dict[str, Any]:
+    # Imported here rather than at module scope: __init__ imports this module's
+    # siblings, and a top-level import would be circular.
+    from . import (
+        get_configured_events,
+        get_configured_scan_interval,
+        get_configured_use_https,
+    )
+
+    return {
+        "entry_id": config_entry.entry_id,
+        "version": config_entry.version,
+        "source": config_entry.source,
+        "state": str(config_entry.state),
+        "disabled_by": str(config_entry.disabled_by),
+        "data": async_redact_data(dict(config_entry.data), TO_REDACT),
+        "options": dict(config_entry.options),
+        # The *effective* values, after options override entry data. Users
+        # routinely report the value they set rather than the one in force.
+        "resolved_events": get_configured_events(config_entry),
+        "resolved_use_https": get_configured_use_https(config_entry),
+        "resolved_scan_interval_seconds": _safe(
+            lambda: get_configured_scan_interval(config_entry).total_seconds()
+        ),
+    }
+
+
+def _coordinator_block(coordinator) -> dict[str, Any]:
+    last_success = getattr(coordinator, "last_update_success_time", None)
+    exception = getattr(coordinator, "last_exception", None)
+    data = coordinator.data or {}
+
+    return {
+        "initialized": coordinator.initialized,
+        "last_update_success": coordinator.last_update_success,
+        "last_update_success_time": last_success.isoformat() if last_success else None,
+        "last_exception_type": type(exception).__name__ if exception else None,
+        "last_exception": str(exception) if exception else None,
+        "update_interval_seconds": _safe(
+            lambda: coordinator.update_interval.total_seconds()
+        ),
+        "platforms": list(coordinator.platforms),
+        "data_key_count": len(data),
+        # Keys only, never values. Which keys the device returned is what decides
+        # whether an entity exists; the values are camera configuration noise.
+        "data_keys": sorted(data),
+    }
+
+
+def _device_block(coordinator, config_entry: ConfigEntry) -> dict[str, Any]:
+    return {
+        "model": _safe(coordinator.get_model),
+        "machine_name": getattr(coordinator, "machine_name", None),
+        "name": _safe(coordinator.get_device_name),
+        "firmware": _safe(coordinator.get_firmware_version),
+        "serial_fingerprint": _serial_fingerprint(coordinator),
+        "serial_is_derived_from_credentials": getattr(
+            coordinator.client, "identity_derived_from_credentials", None
+        ),
+        "channel_index": _safe(coordinator.get_channel),
+        "channel_number": _safe(coordinator.get_channel_number),
+        "auto_detect_channel": config_entry.options.get(CONF_AUTO_DETECT_CHANNEL, True),
+        "max_streams": _safe(coordinator.get_max_streams),
+        "profile_mode": _safe(coordinator.get_profile_mode),
+    }
+
+
+def _capabilities_block(coordinator) -> dict[str, Any]:
+    """What the device was probed to support, and what its model name implies.
+
+    Together these decide which entities exist, so "why do I have no siren
+    entity" is answerable from this block alone.
+    """
+    probed = {
+        name.lstrip("_").removeprefix("supports_"): getattr(coordinator, name)
+        for name in vars(coordinator)
+        if name.startswith("_supports_")
+    }
+    derived = {
+        "is_doorbell": _safe(coordinator.is_doorbell),
+        "is_amcrest_doorbell": _safe(coordinator.is_amcrest_doorbell),
+        "is_flood_light": _safe(coordinator.is_flood_light),
+        "supports_siren": _safe(coordinator.supports_siren),
+        "supports_security_light": _safe(coordinator.supports_security_light),
+        "supports_infrared_light": _safe(coordinator.supports_infrared_light),
+        "supports_illuminator": _safe(coordinator.supports_illuminator),
+        "supports_smart_motion_amcrest": _safe(
+            coordinator.supports_smart_motion_detection_amcrest
+        ),
+    }
+    return {"probed": probed, "derived_from_model": derived}
+
+
+def _client_block(coordinator, config_entry: ConfigEntry) -> dict[str, Any]:
+    client = coordinator.client
+    return {
+        # _base carries no credentials; the RTSP URL does, so it is described
+        # rather than emitted. async_redact_data works by key and would not
+        # touch a password interpolated into a URL value.
+        "base_url": getattr(client, "_base", None),
+        "address_as_client_sees_it": getattr(client, "_address", None),
+        "address_as_entry_stores_it": config_entry.data.get(CONF_ADDRESS),
+        "port": getattr(client, "_port", None),
+        "rtsp_port": getattr(client, "_rtsp_port", None),
+        "use_https": getattr(client, "_use_https", None),
+        # Boolean only. The digest state holds the challenge nonce and the
+        # response, which is derived from the password.
+        "digest_challenge_cached": bool(getattr(client, "_digest_state", None)),
+        "rpc2_session_active": getattr(client, "_rpc2_session_instance", None)
+        is not None,
+        "rtsp_url_shape": (
+            "rtsp://REDACTED:REDACTED@{address}:{rtsp_port}"
+            "/cam/realmonitor?channel={channel_number}&subtype=0"
+        ),
+    }
+
+
+def _events_block(coordinator) -> dict[str, Any]:
+    now = int(time.time())
+    timestamps = getattr(coordinator, "_dahua_event_timestamp", {}) or {}
+    event_task = getattr(coordinator, "_event_task", None)
+    vto_task = getattr(coordinator, "_vto_task", None)
+
+    return {
+        "configured": _safe(coordinator.get_event_list, []),
+        "stream_task_running": bool(event_task) and not event_task.done(),
+        "vto_task_running": bool(vto_task) and not vto_task.done(),
+        "vto_client_connected": getattr(coordinator, "_vto_client", None) is not None,
+        # Listener keys are "<EventName>-<channel>". On an NVR, listeners for
+        # channel 3 while events arrive with index 0 is the channel-offset bug.
+        "listener_keys": sorted(getattr(coordinator, "_dahua_event_listeners", {})),
+        # Ages, not epochs. A motion event 21600 seconds old is a binary sensor
+        # that has been on for six hours because no Stop action ever arrived.
+        "timestamp_age_seconds": {
+            key: (now - value) if value else None for key, value in timestamps.items()
+        },
+        "active_count": sum(1 for value in timestamps.values() if value),
+    }
+
+
+def _host_block(hass: HomeAssistant, coordinator, config_entry: ConfigEntry) -> dict[str, Any]:
+    """Per-host contention, which is invisible from a single entry today.
+
+    An NVR gets one config entry per channel, so a report titled "my camera
+    keeps dropping out" is often the sixth of eleven entries against one host.
+    """
+    from . import _HOST_CONNECTORS
+    from .client import _HOST_LIMITS, MAX_CONCURRENT_REQUESTS_PER_HOST
+
+    address = config_entry.data.get(CONF_ADDRESS)
+    client_address = getattr(coordinator.client, "_address", address)
+    holder = _HOST_CONNECTORS.get(address)
+    limiter = getattr(coordinator.client, "_host_limit", None)
+
+    siblings = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_ADDRESS) == address
+    ]
+
+    return {
+        "address": address,
+        "connector_refcount": holder[1] if holder else None,
+        "connector_closed": holder[0].closed if holder else None,
+        # If these two registries disagree - for example one key with a trailing
+        # slash and one without - a single device is holding two pools.
+        "connector_registry_keys": sorted(_HOST_CONNECTORS),
+        "limiter_registry_keys": sorted(_HOST_LIMITS),
+        "client_key_matches_connector_key": client_address == address,
+        "max_concurrent_requests_per_host": MAX_CONCURRENT_REQUESTS_PER_HOST,
+        "limiter_free_slots": getattr(limiter, "_value", None),
+        "limiter_locked": _safe(limiter.locked) if limiter else None,
+        "sibling_entry_count": len(siblings),
+        "sibling_entries": [
+            {
+                "entry_id": entry.entry_id,
+                "title": entry.title,
+                "channel": entry.data.get(CONF_CHANNEL, 0),
+                "state": str(entry.state),
+                "is_this_entry": entry.entry_id == config_entry.entry_id,
+            }
+            for entry in siblings
+        ],
+        "total_dahua_entries": len(hass.config_entries.async_entries(DOMAIN)),
+    }
+
+
+def _active_issues(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """Our own repair issues.
+
+    Home Assistant appends its own `issues` block, but for non-persistent issues
+    it emits only the id, so it does not say what the issue was.
+    """
+    registry = ir.async_get(hass)
+    return [
+        {
+            "issue_id": issue.issue_id,
+            "translation_key": issue.translation_key,
+            "severity": str(issue.severity),
+            "is_fixable": issue.is_fixable,
+            "active": issue.active,
+            "created": issue.created.isoformat() if issue.created else None,
+            "translation_placeholders": issue.translation_placeholders,
+        }
+        for (domain, _), issue in registry.issues.items()
+        if domain == DOMAIN
+    ]
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> Mapping[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    return {
+        "entry": _entry_block(config_entry),
+        "coordinator": _coordinator_block(coordinator),
+        "device": _device_block(coordinator, config_entry),
+        "capabilities": _capabilities_block(coordinator),
+        "client": _client_block(coordinator, config_entry),
+        "events": _events_block(coordinator),
+        "host": _host_block(hass, coordinator, config_entry),
+        "active_issues": _active_issues(hass),
+    }
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
+) -> Mapping[str, Any]:
+    """Return diagnostics for a device.
+
+    One config entry is one device here, so the content is the same. This exists
+    so the download button also appears on the device page, which is where
+    support threads send people.
+
+    `device.identifiers` is deliberately not emitted: it contains the serial
+    number.
+    """
+    diagnostics = dict(await async_get_config_entry_diagnostics(hass, config_entry))
+    diagnostics["device_registry"] = {
+        "name": device.name,
+        "name_by_user": device.name_by_user,
+        "model": device.model,
+        "manufacturer": device.manufacturer,
+        "sw_version": device.sw_version,
+        "area_id": device.area_id,
+        "disabled_by": str(device.disabled_by),
+        "entry_type": str(device.entry_type),
+    }
+    return diagnostics

--- a/tests/dahua/test_diagnostics.py
+++ b/tests/dahua/test_diagnostics.py
@@ -1,0 +1,361 @@
+"""A diagnostics dump gets pasted into public issue threads."""
+
+import json
+import re
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.helpers.json import ExtendedJSONEncoder
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import dahua as dahua_module
+from custom_components.dahua import client as client_module
+from custom_components.dahua.const import DOMAIN
+from custom_components.dahua.diagnostics import (
+    async_get_config_entry_diagnostics,
+    async_get_device_diagnostics,
+)
+
+# Distinctive so a substring search over the whole blob is meaningful.
+PASSWORD = "hunter2-must-never-appear"
+USERNAME = "admin-unique-token"
+SERIAL = "4X7C5A1ZAG21L3F"
+ADDRESS = "10.0.0.1"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    dahua_module._HOST_CONNECTORS.clear()
+    client_module._HOST_LIMITS.clear()
+    yield
+    dahua_module._HOST_CONNECTORS.clear()
+    client_module._HOST_LIMITS.clear()
+
+
+class _Client:
+    def __init__(self):
+        self._base = f"http://{ADDRESS}:80"
+        self._address = ADDRESS
+        self._port = 80
+        self._rtsp_port = 554
+        self._use_https = None
+        self._digest_state = {}
+        self._rpc2_session_instance = None
+        self._host_limit = client_module._host_limiter(ADDRESS)
+        self.identity_derived_from_credentials = False
+
+    def get_rtsp_stream_url(self, channel, subtype):
+        # Present because the real client has it; the dump must never call it.
+        return f"rtsp://{USERNAME}:{PASSWORD}@{ADDRESS}:554/cam/realmonitor"
+
+
+_UNSET = object()
+
+
+class _Coordinator:
+    def __init__(self, *, data=_UNSET, initialized=True):
+        self.client = _Client()
+        # A sentinel, so a test can express "data is None" - the state a
+        # coordinator is in before its first successful refresh.
+        self.data = {"table.Foo": "1"} if data is _UNSET else data
+        self.initialized = initialized
+        self.last_update_success = True
+        self.last_update_success_time = None
+        self.last_exception = None
+        self.update_interval = None
+        self.platforms = ["camera"]
+        self.machine_name = "FrontDoorCam"
+        self._supports_coaxial_control = True
+        self._supports_disarming_linkage = False
+        self._supports_lighting_v2 = True
+        self._dahua_event_timestamp = {"VideoMotion-0": 0}
+        self._dahua_event_listeners = {"VideoMotion-0": object()}
+        self._event_task = None
+        self._vto_task = None
+        self._vto_client = None
+
+    def get_model(self):
+        return "IPC-HDW5831R-ZE"
+
+    def get_device_name(self):
+        return "Front Door"
+
+    def get_firmware_version(self):
+        return "2.800.0000016.0.R"
+
+    def get_serial_number(self):
+        return SERIAL
+
+    def get_channel(self):
+        return 0
+
+    def get_channel_number(self):
+        return 1
+
+    def get_max_streams(self):
+        return 3
+
+    def get_profile_mode(self):
+        return "0"
+
+    def get_event_list(self):
+        return ["VideoMotion"]
+
+    def is_doorbell(self):
+        return False
+
+    def is_amcrest_doorbell(self):
+        return False
+
+    def is_flood_light(self):
+        return False
+
+    def supports_siren(self):
+        return False
+
+    def supports_security_light(self):
+        return False
+
+    def supports_infrared_light(self):
+        return True
+
+    def supports_illuminator(self):
+        # Deliberately dereferences data, like the real one
+        return self.data["table.Lighting"] == "1"
+
+    def supports_smart_motion_detection_amcrest(self):
+        return False
+
+
+def _entry(hass, *, address=ADDRESS, channel=0, title="Front Door"):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=title,
+        unique_id=SERIAL if channel == 0 else f"{SERIAL}_{channel}",
+        data={
+            "username": USERNAME,
+            "password": PASSWORD,
+            "address": address,
+            "port": "80",
+            "rtsp_port": "554",
+            "channel": channel,
+            "name": title,
+        },
+        options={"events": ["VideoMotion"], "scan_interval": 120},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _install(hass, entry, coordinator=None):
+    coordinator = coordinator or _Coordinator()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    return coordinator
+
+
+async def _blob(hass, entry):
+    return json.dumps(
+        await async_get_config_entry_diagnostics(hass, entry), cls=ExtendedJSONEncoder
+    )
+
+
+# --- the things that must never leak ---------------------------------------
+
+async def test_no_credential_appears_anywhere_in_the_dump(hass):
+    """Asserted over the whole blob, not per key.
+
+    Checking result["entry"]["data"]["password"] == REDACTED passes happily
+    while the password leaks through some other key, which is exactly what an
+    RTSP URL would do - async_redact_data redacts by key, not by value.
+    """
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    blob = await _blob(hass, entry)
+
+    assert PASSWORD not in blob
+    assert USERNAME not in blob
+
+
+async def test_the_serial_number_is_never_published(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert SERIAL not in json.dumps(result, cls=ExtendedJSONEncoder)
+    assert re.fullmatch(r"[0-9a-f]{12}", result["device"]["serial_fingerprint"])
+
+
+async def test_the_same_device_fingerprints_the_same_across_entries(hass):
+    """The fingerprint has to still group an NVR's channels together."""
+    a, b = _entry(hass, channel=0), _entry(hass, channel=1, title="Ch2")
+    _install(hass, a)
+    _install(hass, b)
+
+    fa = (await async_get_config_entry_diagnostics(hass, a))["device"]["serial_fingerprint"]
+    fb = (await async_get_config_entry_diagnostics(hass, b))["device"]["serial_fingerprint"]
+
+    assert fa == fb
+
+
+async def test_the_digest_state_is_reported_only_as_a_boolean(hass):
+    entry = _entry(hass)
+    coordinator = _install(hass, entry)
+    coordinator.client._digest_state = {"nonce": "NONCE-SENTINEL-VALUE"}
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "NONCE-SENTINEL-VALUE" not in json.dumps(result, cls=ExtendedJSONEncoder)
+    assert result["client"]["digest_challenge_cached"] is True
+
+
+# --- it must not fall over, especially when things are broken --------------
+
+async def test_the_dump_is_json_serialisable(hass):
+    """A non-serialisable field is a silent HTTP 500 with only a log line."""
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    json.dumps(await async_get_config_entry_diagnostics(hass, entry),
+               cls=ExtendedJSONEncoder)
+
+
+async def test_the_dump_survives_a_coordinator_that_never_refreshed(hass):
+    """The state a dump is most needed in: setup failed, data is None."""
+    entry = _entry(hass)
+    coordinator = _Coordinator(data=None, initialized=False)
+    coordinator.last_update_success = False
+    coordinator.last_exception = TimeoutError("no route to host")
+    _install(hass, entry, coordinator)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["coordinator"]["last_exception_type"] == "TimeoutError"
+    assert result["coordinator"]["data_key_count"] == 0
+    # supports_illuminator dereferences data and would raise
+    assert result["capabilities"]["derived_from_model"]["supports_illuminator"] is None
+
+
+async def test_the_dump_survives_a_missing_serial_number(hass):
+    """get_serial_number reads an attribute assigned only during detection."""
+    entry = _entry(hass)
+    coordinator = _install(hass, entry)
+    coordinator.get_serial_number = lambda: (_ for _ in ()).throw(AttributeError())
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["device"]["serial_fingerprint"] is None
+
+
+# --- the content that makes it worth pulling -------------------------------
+
+async def test_effective_options_are_reported_not_just_stored_ones(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["entry"]["resolved_events"] == ["VideoMotion"]
+    assert result["entry"]["resolved_scan_interval_seconds"] == 120
+
+
+async def test_every_capability_flag_is_represented(hass):
+    """A flag added later should show up here without anyone remembering to."""
+    entry = _entry(hass)
+    coordinator = _install(hass, entry)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    expected = {n for n in vars(coordinator) if n.startswith("_supports_")}
+    assert len(result["capabilities"]["probed"]) == len(expected)
+    assert result["capabilities"]["probed"]["coaxial_control"] is True
+    assert result["capabilities"]["probed"]["disarming_linkage"] is False
+
+
+async def test_event_timestamps_are_reported_as_ages(hass):
+    """A six-hour-old motion event is a sensor stuck on with no Stop."""
+    import time
+
+    entry = _entry(hass)
+    coordinator = _install(hass, entry)
+    coordinator._dahua_event_timestamp = {
+        "VideoMotion-0": int(time.time()) - 21600,
+        "CrossLineDetection-0": 0,
+    }
+
+    events = (await async_get_config_entry_diagnostics(hass, entry))["events"]
+
+    assert 21590 <= events["timestamp_age_seconds"]["VideoMotion-0"] <= 21610
+    assert events["timestamp_age_seconds"]["CrossLineDetection-0"] is None
+    assert events["active_count"] == 1
+
+
+async def test_siblings_on_one_address_are_reported(hass):
+    """The point of the host block: this report is 1 of N against one NVR."""
+    entries = [_entry(hass, channel=i, title=f"Ch{i}") for i in range(3)]
+    other = _entry(hass, address="10.0.0.2", channel=0, title="Doorbell")
+    for entry in [*entries, other]:
+        _install(hass, entry)
+
+    host = (await async_get_config_entry_diagnostics(hass, entries[0]))["host"]
+
+    assert host["sibling_entry_count"] == 3
+    assert host["total_dahua_entries"] == 4
+    assert sum(1 for s in host["sibling_entries"] if s["is_this_entry"]) == 1
+    assert other.entry_id not in [s["entry_id"] for s in host["sibling_entries"]]
+
+
+async def test_the_shared_connector_refcount_is_reported(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+    dahua_module._acquire_connector(ADDRESS)
+    dahua_module._acquire_connector(ADDRESS)
+
+    host = (await async_get_config_entry_diagnostics(hass, entry))["host"]
+
+    assert host["connector_refcount"] == 2
+    assert host["connector_closed"] is False
+    await dahua_module._release_connector(ADDRESS)
+    await dahua_module._release_connector(ADDRESS)
+
+
+async def test_the_per_host_limiter_is_reported(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    host = (await async_get_config_entry_diagnostics(hass, entry))["host"]
+
+    assert host["max_concurrent_requests_per_host"] == (
+        client_module.MAX_CONCURRENT_REQUESTS_PER_HOST
+    )
+    assert host["limiter_free_slots"] == client_module.MAX_CONCURRENT_REQUESTS_PER_HOST
+    assert host["limiter_locked"] is False
+
+
+async def test_a_mismatched_host_key_is_visible(hass):
+    """One device holding two differently-keyed pools should be obvious."""
+    entry = _entry(hass, address=f"{ADDRESS}/")
+    _install(hass, entry)
+
+    host = (await async_get_config_entry_diagnostics(hass, entry))["host"]
+
+    assert host["client_key_matches_connector_key"] is False
+
+
+# --- device diagnostics ----------------------------------------------------
+
+async def test_device_diagnostics_does_not_publish_the_identifiers(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+    device = SimpleNamespace(
+        identifiers={(DOMAIN, SERIAL)}, name="Front Door", name_by_user=None,
+        model="IPC", manufacturer="Dahua", sw_version="1.0", area_id=None,
+        disabled_by=None, entry_type=None,
+    )
+
+    result = await async_get_device_diagnostics(hass, entry, device)
+
+    assert SERIAL not in json.dumps(result, cls=ExtendedJSONEncoder)
+    assert result["device_registry"]["name"] == "Front Door"
+    assert "coordinator" in result


### PR DESCRIPTION
Most bug reports here arrive as a screenshot of a single log line. There is currently no way to ask *"what did the device report it supports"*, *"what was the coordinator's last error"*, or — on an NVR — *"how many other config entries are fighting over this host"* without a round trip.

This adds both diagnostics handlers. Discovery is by file presence, so **no manifest change**, and **no runtime behaviour changes** — nothing in the polling or event path is touched. Nothing here talks to the device either; it only reports state the integration already holds, so it is safe to pull when the device is unreachable, which is exactly when someone will pull it.

`async_get_device_diagnostics` delegates to the config-entry one and exists so the download button also appears on the device page, where support threads send people.

### The host section is why this is worth having

An NVR gets one config entry per channel. A report titled "my camera keeps dropping out" is often the sixth of eleven entries against one box, and nothing in the integration says so today:

```json
"host": {
  "connector_refcount": 11,
  "limiter_free_slots": 2,
  "max_concurrent_requests_per_host": 2,
  "sibling_entry_count": 11,
  "total_dahua_entries": 12,
  "connector_registry_keys": ["192.168.0.213"],
  "client_key_matches_connector_key": true
}
```

Those last two are there because `_acquire_connector()` is called with the raw entry address while `DahuaClient` does `address.rstrip('/')` before keying its semaphore — a trailing slash gives one device two differently-keyed pools. This surfaces it rather than fixing it.

Other sections worth calling out:

- **`entry.resolved_*`** — the *effective* events, HTTPS flag and scan interval after options override entry data. Users routinely report the value they set rather than the one in force.
- **`capabilities`** — every probed `_supports_*` flag plus the model-string derivations, together deciding which entities exist. Answers most "why do I have no siren entity" threads from one screen.
- **`events.timestamp_age_seconds`** — ages, not epochs. A `VideoMotion-0` at 21600 is a binary sensor that has been on for six hours because no `Stop` action ever arrived (`is_on` is `get_event_timestamp(...) > 0` with no timer anywhere). Surfacing it rather than proposing a fix here.
- **`coordinator.last_exception` + `data_keys`** — keys only, never values. Which keys the device returned is what decides whether an entity exists; the values are camera-config noise.

### Three things deliberately withheld

**The serial number, unconditionally.** When a device reports no serial, the integration derives one as `md5(f"{address}_{rtsp_port}_{username}_{password}")`. Publishing that hash beside the address and RTSP port — which are not secret — would make an offline dictionary attack on the password straightforward, and there is no reliable way to tell from outside which devices took that path. A `sha256(...)[:12]` fingerprint is reported instead, which still groups an NVR's channels together across a multi-entry dump.

**The digest state, reported as a boolean.** It holds the challenge nonce and a response derived from the password.

**The RTSP URL, described rather than emitted.** `get_rtsp_stream_url()` interpolates the password, and `async_redact_data` redacts by *key*, so that value would pass through untouched.

That last point is why the credential test asserts over the **whole serialised blob** rather than per key:

```python
blob = json.dumps(await async_get_config_entry_diagnostics(hass, entry), cls=ExtendedJSONEncoder)
assert PASSWORD not in blob and USERNAME not in blob
```

Asserting `result["entry"]["data"]["password"] == REDACTED` passes happily while the password leaves through a different key.

Also adds `identity_derived_from_credentials` to `DahuaClient` (4 lines, set in the three fallback branches) so a dump can say whether this is a device whose identity would change if its password did.

### Robustness

A handler that raises returns HTTP 500 with no explanation, so every derived read goes through a `_safe()` wrapper. Two real cases are covered by tests: `coordinator.data` is `None` before the first successful refresh (several accessors dereference it), and `self._serial_number` is annotated but only assigned during capability detection, so `get_serial_number()` raises `AttributeError` if setup failed early — precisely when a dump is most wanted.

### Verification

In a `python:3.13` container matching CI:

```
suite: 151 passed   (136 before)
```

Both of these deliberate breaks fail the credential test, which is the point of asserting on the whole blob:

```
emit the live RTSP URL instead of the shape  -> 1 failed
drop CONF_PASSWORD from TO_REDACT            -> 1 failed
```

`json.dumps(..., cls=ExtendedJSONEncoder)` is also asserted directly, because `_async_get_json_file_response` catches `TypeError` and returns HTTP 500 with only a log line — a non-serialisable field would otherwise be a silent total failure of the feature.