### PR TITLE
Raise a repair when a device stops answering

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -14,7 +14,8 @@ import hashlib
 
 from aiohttp import ClientError, ClientResponseError, ClientSession, TCPConnector
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -140,8 +141,168 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 _HOST_CONNECTORS: dict = {}
 
 
+# How many consecutive failed refreshes before we call a host unreachable. At
+# the default 30s interval that is about two and a half minutes, long enough to
+# ride out a single dropped poll.
+UNREACHABLE_AFTER_FAILURES = 5
+
+# A TCP probe is cheap but not free, and a wedged host fails every single poll.
+HTTPS_PROBE_MIN_INTERVAL = 600
+
+ISSUE_UNREACHABLE = "unreachable_{0}"
+ISSUE_HTTP_DEAD_HTTPS_AVAILABLE = "http_dead_https_available_{0}"
+
+# address -> {"consecutive": int, "since": float, "entry_ids": set, "last_probe": float}
+#
+# Module level rather than on the coordinator, for two reasons. A failed setup
+# never publishes its coordinator to hass.data, because
+# async_config_entry_first_refresh raises first, so every retry would build and
+# discard a fresh counter. And an NVR has one config entry per channel, so the
+# count must be shared or eight channels of one box raise eight separate cards.
+_HOST_FAILURES: dict = {}
+
+
+def normalize_address(address: str) -> str:
+    """One device, one key.
+
+    DahuaClient rstrips the address before keying its request limiter, but
+    _acquire_connector did not, so a trailing slash could leave a single device
+    holding two differently keyed pools. Everything host scoped goes through
+    this.
+    """
+    return (address or "").strip().rstrip("/")
+
+
+def _entries_for_address(hass: HomeAssistant, address: str) -> list:
+    """Every config entry pointing at this host."""
+    wanted = normalize_address(address)
+    return [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if normalize_address(entry.data.get(CONF_ADDRESS)) == wanted
+    ]
+
+
+async def _async_probe_tcp(address: str, port: int, timeout: float = 5.0) -> bool:
+    """Can we open a TCP connection? No HTTP, no credentials, no retry."""
+    writer = None
+    try:
+        _, writer = await asyncio.wait_for(
+            asyncio.open_connection(address, port), timeout
+        )
+        return True
+    except Exception:  # pylint: disable=broad-except
+        return False
+    finally:
+        if writer is not None:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+
+async def _async_evaluate_host(hass: HomeAssistant, address: str) -> None:
+    """Decide which card, if any, this host has earned.
+
+    Some Dahua firmwares stop serving plain HTTP while HTTPS keeps working. If
+    that is what happened we can say so and offer to switch. Otherwise all we
+    can honestly report is that the device is not answering.
+    """
+    address = normalize_address(address)
+    unreachable_id = ISSUE_UNREACHABLE.format(address)
+    https_id = ISSUE_HTTP_DEAD_HTTPS_AVAILABLE.format(address)
+
+    entries = _entries_for_address(hass, address)
+    if not entries:
+        return
+
+    # Nothing to offer if this host is already reached over HTTPS.
+    already_https = any(
+        str(entry.data.get(CONF_PORT)) == "443" or entry.data.get(CONF_USE_HTTPS)
+        for entry in entries
+    )
+
+    state = _HOST_FAILURES.get(address)
+    https_is_open = False
+    if not already_https and state is not None:
+        state["last_probe"] = time.time()
+        https_is_open = await _async_probe_tcp(address, 443)
+
+    minutes = 1
+    if state:
+        minutes = max(1, int((time.time() - state.get("since", time.time())) / 60))
+
+    placeholders = {
+        "address": address,
+        "entries": str(len(entries)),
+        "minutes": str(minutes),
+        "port": str(entries[0].data.get(CONF_PORT, "80")),
+    }
+
+    if https_is_open:
+        ir.async_delete_issue(hass, DOMAIN, unreachable_id)
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            https_id,
+            is_fixable=True,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="http_dead_https_available",
+            translation_placeholders=placeholders,
+            data={"address": address},
+        )
+    else:
+        ir.async_delete_issue(hass, DOMAIN, https_id)
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            unreachable_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="device_unreachable",
+            translation_placeholders=placeholders,
+            learn_more_url="https://github.com/rroller/dahua#debugging",
+        )
+
+
+@callback
+def async_record_host_failure(hass: HomeAssistant, address: str, entry_id: str) -> None:
+    """Note a failed refresh, raising a card once it stops looking like a blip."""
+    address = normalize_address(address)
+    state = _HOST_FAILURES.setdefault(
+        address,
+        {"consecutive": 0, "since": time.time(), "entry_ids": set(), "last_probe": 0},
+    )
+    state["consecutive"] += 1
+    state["entry_ids"].add(entry_id)
+
+    if state["consecutive"] < UNREACHABLE_AFTER_FAILURES:
+        return
+    # Re-evaluate on the threshold, then only as often as the probe interval
+    # allows, so a wedged host does not get probed on every poll.
+    if state["consecutive"] == UNREACHABLE_AFTER_FAILURES or (
+        time.time() - state.get("last_probe", 0) >= HTTPS_PROBE_MIN_INTERVAL
+    ):
+        hass.async_create_task(_async_evaluate_host(hass, address))
+
+
+@callback
+def async_record_host_success(hass: HomeAssistant, address: str) -> None:
+    """The device answered, so withdraw anything we said about it.
+
+    Keyed by host: if any channel of an NVR replies, the box is up.
+    """
+    address = normalize_address(address)
+    if _HOST_FAILURES.pop(address, None) is None:
+        return
+    ir.async_delete_issue(hass, DOMAIN, ISSUE_UNREACHABLE.format(address))
+    ir.async_delete_issue(hass, DOMAIN, ISSUE_HTTP_DEAD_HTTPS_AVAILABLE.format(address))
+
+
 def _acquire_connector(address: str) -> TCPConnector:
     """Returns the shared connector for this address, creating it if needed."""
+    address = normalize_address(address)
     holder = _HOST_CONNECTORS.get(address)
     if holder is None or holder[0].closed:
         holder = [TCPConnector(enable_cleanup_closed=True, ssl=SSL_CONTEXT), 0]
@@ -152,6 +313,7 @@ def _acquire_connector(address: str) -> TCPConnector:
 
 async def _release_connector(address: str) -> None:
     """Drops a reference, closing the connector once nothing is using it."""
+    address = normalize_address(address)
     holder = _HOST_CONNECTORS.get(address)
     if holder is None:
         return
@@ -469,9 +631,11 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     self.config_entry.async_start_reauth(self.hass)
                     raise UpdateFailed("Authentication failed") from exception
                 _LOGGER.warning("Failed to initialize device at %s: %s", self._address, exception)
+                async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
                 raise UpdateFailed("Dahua device at " + self._address + " isn't fully initialized yet")
             except Exception as exception:
                 _LOGGER.warning("Failed to initialize device at %s: %s", self._address, exception)
+                async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
                 raise UpdateFailed("Dahua device at " + self._address + " isn't fully initialized yet")
 
         # This is the event loop code that's called every n seconds
@@ -542,11 +706,13 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 if light_v2 is not None:
                     data.update(light_v2)
 
+            async_record_host_success(self.hass, self._address)
             return data
         except Exception as exception:
             _LOGGER.warning("Failed to sync device state for %s. See README to enable debug logs to get full exception",
                             self._address)
             _LOGGER.debug("Failed to sync device state for %s", self._address, exc_info=exception)
+            async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
             raise UpdateFailed() from exception
 
     def on_receive_vto_event(self, event: dict):
@@ -958,6 +1124,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     if unloaded:
         hass.data[DOMAIN].pop(entry.entry_id)
+
+    # If that was the last entry for this host, withdraw anything we said
+    # about it rather than leaving an orphaned card in Repairs.
+    address = normalize_address(entry.data.get(CONF_ADDRESS))
+    if not _entries_for_address(hass, address):
+        _HOST_FAILURES.pop(address, None)
+        ir.async_delete_issue(hass, DOMAIN, ISSUE_UNREACHABLE.format(address))
+        ir.async_delete_issue(
+            hass, DOMAIN, ISSUE_HTTP_DEAD_HTTPS_AVAILABLE.format(address)
+        )
 
     return unloaded
 

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -77,6 +77,10 @@ class DahuaClient:
         # Keyed by address so every entry for one NVR shares a single budget.
         self._host_limit = _host_limiter(self._address)
         self._rpc2_session_instance = None
+        # True once this device has failed to report a serial number and we have had
+        # to derive its identity from the connection details instead. That derivation
+        # includes the password, so the identity changes if the password does.
+        self.identity_derived_from_credentials = False
         protocol = "https" if use_https else "http"
         self._base = "{0}://{1}:{2}".format(protocol, self._address, port)
 
@@ -126,6 +130,7 @@ class DahuaClient:
         try:
             return await self.get("/cgi-bin/magicBox.cgi?action=getSystemInfo")
         except aiohttp.ClientResponseError as e:
+            self.identity_derived_from_credentials = True
             not_hashed_id = "{0}_{1}_{2}_{3}".format(self._address, self._rtsp_port, self._username, self._password)
             unique_cam_id = md5(not_hashed_id.encode('UTF-8')).hexdigest()
             return {"serialNumber": unique_cam_id}
@@ -158,6 +163,7 @@ class DahuaClient:
         try:
             return await self.get("/cgi-bin/magicBox.cgi?action=getMachineName")
         except aiohttp.ClientResponseError as e:
+            self.identity_derived_from_credentials = True
             not_hashed_id = "{0}_{1}_{2}_{3}".format(self._address, self._rtsp_port, self._username, self._password)
             unique_cam_id = md5(not_hashed_id.encode('UTF-8')).hexdigest()
             return {"name": unique_cam_id}
@@ -226,6 +232,7 @@ class DahuaClient:
         try:
             return await self.get(url)
         except aiohttp.ClientResponseError as e:
+            self.identity_derived_from_credentials = True
             not_hashed_id = "{0}_{1}_{2}_{3}".format(self._address, self._rtsp_port, self._username, self._password)
             unique_cam_id = md5(not_hashed_id.encode('UTF-8')).hexdigest()
             return {"table.General.MachineName": unique_cam_id}

--- a/custom_components/dahua/diagnostics.py
+++ b/custom_components/dahua/diagnostics.py
@@ -1,0 +1,326 @@
+"""Diagnostics support for Dahua.
+
+Most bug reports against this integration arrive as a screenshot of one log line.
+The dump below is meant to answer, without a round trip, the questions that are
+actually asked: what did the device report it can do, what is the coordinator's
+last error, and - on an NVR - how many other config entries are competing for the
+same host.
+
+Nothing here talks to the device. It only reports state the integration already
+holds, so it is safe to pull when the device is unreachable, which is exactly
+when someone will pull it.
+"""
+import time
+from hashlib import sha256
+from typing import Any, Callable, Mapping
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.helpers.device_registry import DeviceEntry
+
+from .const import (
+    CONF_ADDRESS,
+    CONF_AUTO_DETECT_CHANNEL,
+    CONF_CHANNEL,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    DOMAIN,
+)
+
+# Redacted by key, everywhere they appear.
+#
+# The serial number is in here deliberately. When a device does not report one,
+# the integration derives it as md5("{address}_{rtsp_port}_{username}_{password}")
+# - see the fallback branches in client.py. Publishing that hash next to the
+# address and RTSP port, which are not secret, would make an offline dictionary
+# attack on the password straightforward. There is no reliable way to tell from
+# outside which devices took the fallback, so the serial is always withheld and
+# `serial_fingerprint` is offered instead.
+TO_REDACT = {
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    "unique_id",
+    "serialNumber",
+    "serial_number",
+}
+
+
+def _safe(fn: Callable[[], Any], default: Any = None) -> Any:
+    """Call an accessor, returning `default` if it raises.
+
+    Several accessors dereference `coordinator.data`, which is None until the
+    first successful refresh, and `get_serial_number()` reads an attribute that
+    is only assigned during capability detection. A diagnostics handler that
+    raises returns HTTP 500 with no explanation, so nothing here may propagate.
+    """
+    try:
+        return fn()
+    except Exception:  # pylint: disable=broad-except
+        return default
+
+
+def _serial_fingerprint(coordinator) -> str | None:
+    """A stable, non-reversible stand-in for the serial number.
+
+    Keeps the one property that matters for support - which entries belong to
+    the same physical device - without publishing the serial itself.
+    """
+    serial = _safe(coordinator.get_serial_number)
+    if not serial:
+        return None
+    return sha256(str(serial).encode("utf-8")).hexdigest()[:12]
+
+
+def _entry_block(config_entry: ConfigEntry) -> dict[str, Any]:
+    # Imported here rather than at module scope: __init__ imports this module's
+    # siblings, and a top-level import would be circular.
+    from . import (
+        get_configured_events,
+        get_configured_scan_interval,
+        get_configured_use_https,
+    )
+
+    return {
+        "entry_id": config_entry.entry_id,
+        "version": config_entry.version,
+        "source": config_entry.source,
+        "state": str(config_entry.state),
+        "disabled_by": str(config_entry.disabled_by),
+        "data": async_redact_data(dict(config_entry.data), TO_REDACT),
+        "options": dict(config_entry.options),
+        # The *effective* values, after options override entry data. Users
+        # routinely report the value they set rather than the one in force.
+        "resolved_events": get_configured_events(config_entry),
+        "resolved_use_https": get_configured_use_https(config_entry),
+        "resolved_scan_interval_seconds": _safe(
+            lambda: get_configured_scan_interval(config_entry).total_seconds()
+        ),
+    }
+
+
+def _coordinator_block(coordinator) -> dict[str, Any]:
+    last_success = getattr(coordinator, "last_update_success_time", None)
+    exception = getattr(coordinator, "last_exception", None)
+    data = coordinator.data or {}
+
+    return {
+        "initialized": coordinator.initialized,
+        "last_update_success": coordinator.last_update_success,
+        "last_update_success_time": last_success.isoformat() if last_success else None,
+        "last_exception_type": type(exception).__name__ if exception else None,
+        "last_exception": str(exception) if exception else None,
+        "update_interval_seconds": _safe(
+            lambda: coordinator.update_interval.total_seconds()
+        ),
+        "platforms": list(coordinator.platforms),
+        "data_key_count": len(data),
+        # Keys only, never values. Which keys the device returned is what decides
+        # whether an entity exists; the values are camera configuration noise.
+        "data_keys": sorted(data),
+    }
+
+
+def _device_block(coordinator, config_entry: ConfigEntry) -> dict[str, Any]:
+    return {
+        "model": _safe(coordinator.get_model),
+        "machine_name": getattr(coordinator, "machine_name", None),
+        "name": _safe(coordinator.get_device_name),
+        "firmware": _safe(coordinator.get_firmware_version),
+        "serial_fingerprint": _serial_fingerprint(coordinator),
+        "serial_is_derived_from_credentials": getattr(
+            coordinator.client, "identity_derived_from_credentials", None
+        ),
+        "channel_index": _safe(coordinator.get_channel),
+        "channel_number": _safe(coordinator.get_channel_number),
+        "auto_detect_channel": config_entry.options.get(CONF_AUTO_DETECT_CHANNEL, True),
+        "max_streams": _safe(coordinator.get_max_streams),
+        "profile_mode": _safe(coordinator.get_profile_mode),
+    }
+
+
+def _capabilities_block(coordinator) -> dict[str, Any]:
+    """What the device was probed to support, and what its model name implies.
+
+    Together these decide which entities exist, so "why do I have no siren
+    entity" is answerable from this block alone.
+    """
+    probed = {
+        name.lstrip("_").removeprefix("supports_"): getattr(coordinator, name)
+        for name in vars(coordinator)
+        if name.startswith("_supports_")
+    }
+    derived = {
+        "is_doorbell": _safe(coordinator.is_doorbell),
+        "is_amcrest_doorbell": _safe(coordinator.is_amcrest_doorbell),
+        "is_flood_light": _safe(coordinator.is_flood_light),
+        "supports_siren": _safe(coordinator.supports_siren),
+        "supports_security_light": _safe(coordinator.supports_security_light),
+        "supports_infrared_light": _safe(coordinator.supports_infrared_light),
+        "supports_illuminator": _safe(coordinator.supports_illuminator),
+        "supports_smart_motion_amcrest": _safe(
+            coordinator.supports_smart_motion_detection_amcrest
+        ),
+    }
+    return {"probed": probed, "derived_from_model": derived}
+
+
+def _client_block(coordinator, config_entry: ConfigEntry) -> dict[str, Any]:
+    client = coordinator.client
+    return {
+        # _base carries no credentials; the RTSP URL does, so it is described
+        # rather than emitted. async_redact_data works by key and would not
+        # touch a password interpolated into a URL value.
+        "base_url": getattr(client, "_base", None),
+        "address_as_client_sees_it": getattr(client, "_address", None),
+        "address_as_entry_stores_it": config_entry.data.get(CONF_ADDRESS),
+        "port": getattr(client, "_port", None),
+        "rtsp_port": getattr(client, "_rtsp_port", None),
+        "use_https": getattr(client, "_use_https", None),
+        # Boolean only. The digest state holds the challenge nonce and the
+        # response, which is derived from the password.
+        "digest_challenge_cached": bool(getattr(client, "_digest_state", None)),
+        "rpc2_session_active": getattr(client, "_rpc2_session_instance", None)
+        is not None,
+        "rtsp_url_shape": (
+            "rtsp://REDACTED:REDACTED@{address}:{rtsp_port}"
+            "/cam/realmonitor?channel={channel_number}&subtype=0"
+        ),
+    }
+
+
+def _events_block(coordinator) -> dict[str, Any]:
+    now = int(time.time())
+    timestamps = getattr(coordinator, "_dahua_event_timestamp", {}) or {}
+    event_task = getattr(coordinator, "_event_task", None)
+    vto_task = getattr(coordinator, "_vto_task", None)
+
+    return {
+        "configured": _safe(coordinator.get_event_list, []),
+        "stream_task_running": bool(event_task) and not event_task.done(),
+        "vto_task_running": bool(vto_task) and not vto_task.done(),
+        "vto_client_connected": getattr(coordinator, "_vto_client", None) is not None,
+        # Listener keys are "<EventName>-<channel>". On an NVR, listeners for
+        # channel 3 while events arrive with index 0 is the channel-offset bug.
+        "listener_keys": sorted(getattr(coordinator, "_dahua_event_listeners", {})),
+        # Ages, not epochs. A motion event 21600 seconds old is a binary sensor
+        # that has been on for six hours because no Stop action ever arrived.
+        "timestamp_age_seconds": {
+            key: (now - value) if value else None for key, value in timestamps.items()
+        },
+        "active_count": sum(1 for value in timestamps.values() if value),
+    }
+
+
+def _host_block(hass: HomeAssistant, coordinator, config_entry: ConfigEntry) -> dict[str, Any]:
+    """Per-host contention, which is invisible from a single entry today.
+
+    An NVR gets one config entry per channel, so a report titled "my camera
+    keeps dropping out" is often the sixth of eleven entries against one host.
+    """
+    from . import _HOST_CONNECTORS
+    from .client import _HOST_LIMITS, MAX_CONCURRENT_REQUESTS_PER_HOST
+
+    address = config_entry.data.get(CONF_ADDRESS)
+    client_address = getattr(coordinator.client, "_address", address)
+    holder = _HOST_CONNECTORS.get(address)
+    limiter = getattr(coordinator.client, "_host_limit", None)
+
+    siblings = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.data.get(CONF_ADDRESS) == address
+    ]
+
+    return {
+        "address": address,
+        "connector_refcount": holder[1] if holder else None,
+        "connector_closed": holder[0].closed if holder else None,
+        # If these two registries disagree - for example one key with a trailing
+        # slash and one without - a single device is holding two pools.
+        "connector_registry_keys": sorted(_HOST_CONNECTORS),
+        "limiter_registry_keys": sorted(_HOST_LIMITS),
+        "client_key_matches_connector_key": client_address == address,
+        "max_concurrent_requests_per_host": MAX_CONCURRENT_REQUESTS_PER_HOST,
+        "limiter_free_slots": getattr(limiter, "_value", None),
+        "limiter_locked": _safe(limiter.locked) if limiter else None,
+        "sibling_entry_count": len(siblings),
+        "sibling_entries": [
+            {
+                "entry_id": entry.entry_id,
+                "title": entry.title,
+                "channel": entry.data.get(CONF_CHANNEL, 0),
+                "state": str(entry.state),
+                "is_this_entry": entry.entry_id == config_entry.entry_id,
+            }
+            for entry in siblings
+        ],
+        "total_dahua_entries": len(hass.config_entries.async_entries(DOMAIN)),
+    }
+
+
+def _active_issues(hass: HomeAssistant) -> list[dict[str, Any]]:
+    """Our own repair issues.
+
+    Home Assistant appends its own `issues` block, but for non-persistent issues
+    it emits only the id, so it does not say what the issue was.
+    """
+    registry = ir.async_get(hass)
+    return [
+        {
+            "issue_id": issue.issue_id,
+            "translation_key": issue.translation_key,
+            "severity": str(issue.severity),
+            "is_fixable": issue.is_fixable,
+            "active": issue.active,
+            "created": issue.created.isoformat() if issue.created else None,
+            "translation_placeholders": issue.translation_placeholders,
+        }
+        for (domain, _), issue in registry.issues.items()
+        if domain == DOMAIN
+    ]
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> Mapping[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    return {
+        "entry": _entry_block(config_entry),
+        "coordinator": _coordinator_block(coordinator),
+        "device": _device_block(coordinator, config_entry),
+        "capabilities": _capabilities_block(coordinator),
+        "client": _client_block(coordinator, config_entry),
+        "events": _events_block(coordinator),
+        "host": _host_block(hass, coordinator, config_entry),
+        "active_issues": _active_issues(hass),
+    }
+
+
+async def async_get_device_diagnostics(
+    hass: HomeAssistant, config_entry: ConfigEntry, device: DeviceEntry
+) -> Mapping[str, Any]:
+    """Return diagnostics for a device.
+
+    One config entry is one device here, so the content is the same. This exists
+    so the download button also appears on the device page, which is where
+    support threads send people.
+
+    `device.identifiers` is deliberately not emitted: it contains the serial
+    number.
+    """
+    diagnostics = dict(await async_get_config_entry_diagnostics(hass, config_entry))
+    diagnostics["device_registry"] = {
+        "name": device.name,
+        "name_by_user": device.name_by_user,
+        "model": device.model,
+        "manufacturer": device.manufacturer,
+        "sw_version": device.sw_version,
+        "area_id": device.area_id,
+        "disabled_by": str(device.disabled_by),
+        "entry_type": str(device.entry_type),
+    }
+    return diagnostics

--- a/custom_components/dahua/manifest.json
+++ b/custom_components/dahua/manifest.json
@@ -8,6 +8,9 @@
     "@rroller"
   ],
   "config_flow": true,
+  "dependencies": [
+    "repairs"
+  ],
   "documentation": "https://github.com/rroller/dahua",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/rroller/dahua/issues",

--- a/custom_components/dahua/repairs.py
+++ b/custom_components/dahua/repairs.py
@@ -64,5 +64,6 @@ class SwitchToHttpsRepairFlow(RepairsFlow):
             description_placeholders={
                 "address": str(self._address),
                 "entries": str(len(entries)),
+                "port": str(entries[0].data.get(CONF_PORT, "80")),
             },
         )

--- a/custom_components/dahua/repairs.py
+++ b/custom_components/dahua/repairs.py
@@ -1,0 +1,68 @@
+"""Repair flows for Dahua."""
+import asyncio
+
+import voluptuous as vol
+from homeassistant.components.repairs import ConfirmRepairFlow, RepairsFlow
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from .const import CONF_PORT, CONF_USE_HTTPS, DOMAIN
+
+# An NVR has one config entry per channel, and updating an entry triggers a
+# reload through the existing update listener. Reloading eleven at once is the
+# same simultaneous burst that can wedge a Dahua web server, so they are done
+# one at a time. The per-host request limiter is the hard bound; this is cheap
+# insurance on top of it.
+RELOAD_STAGGER_SECONDS = 0.5
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant, issue_id: str, data: dict | None
+) -> RepairsFlow:
+    """Return the flow that fixes this issue."""
+    if issue_id.startswith("http_dead_https_available_"):
+        return SwitchToHttpsRepairFlow(data or {})
+    return ConfirmRepairFlow()
+
+
+class SwitchToHttpsRepairFlow(RepairsFlow):
+    """Move every entry for one host onto HTTPS on port 443."""
+
+    def __init__(self, data: dict) -> None:
+        self._address = data.get("address")
+
+    async def async_step_init(self, user_input: dict | None = None):
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input: dict | None = None):
+        # Imported here rather than at module scope to avoid a circular import.
+        from . import _entries_for_address
+
+        entries = _entries_for_address(self.hass, self._address)
+        if not entries:
+            return self.async_abort(reason="not_configured")
+
+        if user_input is not None:
+            for entry in entries:
+                # async_update_entry already triggers a reload through the
+                # update listener registered in async_setup_entry, so calling
+                # async_reload here as well would reload every channel twice.
+                self.hass.config_entries.async_update_entry(
+                    entry,
+                    data={**entry.data, CONF_PORT: "443", CONF_USE_HTTPS: True},
+                )
+                await asyncio.sleep(RELOAD_STAGGER_SECONDS)
+
+            ir.async_delete_issue(
+                self.hass, DOMAIN, f"http_dead_https_available_{self._address}"
+            )
+            return self.async_create_entry(data={})
+
+        return self.async_show_form(
+            step_id="confirm",
+            data_schema=vol.Schema({}),
+            description_placeholders={
+                "address": str(self._address),
+                "entries": str(len(entries)),
+            },
+        )

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -68,5 +68,26 @@
                 }
             }
         }
+    },
+    "issues": {
+        "device_unreachable": {
+            "title": "Dahua device at {address} is not responding",
+            "description": "Home Assistant has not been able to reach the Dahua device at {address} for about {minutes} minutes. {entries} configuration entries use this device.\n\nCheck that it is powered on and reachable on your network. The debugging section of the documentation explains how to capture logs.\n\nThis message disappears on its own as soon as the device answers again."
+        },
+        "http_dead_https_available": {
+            "title": "Dahua device at {address} answers on HTTPS but not on port {port}",
+            "description": "The Dahua device at {address} has stopped answering on port {port}, but it accepts connections on port 443. Some Dahua firmwares stop serving plain HTTP while HTTPS keeps working.\n\nHome Assistant can switch the {entries} entries for this device over to HTTPS on port 443.",
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "title": "Switch {address} to HTTPS",
+                        "description": "This changes {entries} Dahua configuration entries for {address} to port 443 with HTTPS, reloading them one at a time.\n\nYour username and password are not changed."
+                    }
+                },
+                "abort": {
+                    "not_configured": "No Dahua configuration entries use {address} any more."
+                }
+            }
+        }
     }
 }

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -76,12 +76,11 @@
         },
         "http_dead_https_available": {
             "title": "Dahua device at {address} answers on HTTPS but not on port {port}",
-            "description": "The Dahua device at {address} has stopped answering on port {port}, but it accepts connections on port 443. Some Dahua firmwares stop serving plain HTTP while HTTPS keeps working.\n\nHome Assistant can switch the {entries} entries for this device over to HTTPS on port 443.",
             "fix_flow": {
                 "step": {
                     "confirm": {
                         "title": "Switch {address} to HTTPS",
-                        "description": "This changes {entries} Dahua configuration entries for {address} to port 443 with HTTPS, reloading them one at a time.\n\nYour username and password are not changed."
+                        "description": "The Dahua device at {address} has stopped answering on port {port}, but it accepts connections on port 443. Some Dahua firmwares stop serving plain HTTP while HTTPS keeps working.\n\nThis changes the {entries} Dahua configuration entries for {address} to port 443 with HTTPS, reloading them one at a time.\n\nYour username and password are not changed."
                     }
                 },
                 "abort": {

--- a/tests/dahua/test_diagnostics.py
+++ b/tests/dahua/test_diagnostics.py
@@ -1,0 +1,361 @@
+"""A diagnostics dump gets pasted into public issue threads."""
+
+import json
+import re
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.helpers.json import ExtendedJSONEncoder
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import dahua as dahua_module
+from custom_components.dahua import client as client_module
+from custom_components.dahua.const import DOMAIN
+from custom_components.dahua.diagnostics import (
+    async_get_config_entry_diagnostics,
+    async_get_device_diagnostics,
+)
+
+# Distinctive so a substring search over the whole blob is meaningful.
+PASSWORD = "hunter2-must-never-appear"
+USERNAME = "admin-unique-token"
+SERIAL = "4X7C5A1ZAG21L3F"
+ADDRESS = "10.0.0.1"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registries():
+    dahua_module._HOST_CONNECTORS.clear()
+    client_module._HOST_LIMITS.clear()
+    yield
+    dahua_module._HOST_CONNECTORS.clear()
+    client_module._HOST_LIMITS.clear()
+
+
+class _Client:
+    def __init__(self):
+        self._base = f"http://{ADDRESS}:80"
+        self._address = ADDRESS
+        self._port = 80
+        self._rtsp_port = 554
+        self._use_https = None
+        self._digest_state = {}
+        self._rpc2_session_instance = None
+        self._host_limit = client_module._host_limiter(ADDRESS)
+        self.identity_derived_from_credentials = False
+
+    def get_rtsp_stream_url(self, channel, subtype):
+        # Present because the real client has it; the dump must never call it.
+        return f"rtsp://{USERNAME}:{PASSWORD}@{ADDRESS}:554/cam/realmonitor"
+
+
+_UNSET = object()
+
+
+class _Coordinator:
+    def __init__(self, *, data=_UNSET, initialized=True):
+        self.client = _Client()
+        # A sentinel, so a test can express "data is None" - the state a
+        # coordinator is in before its first successful refresh.
+        self.data = {"table.Foo": "1"} if data is _UNSET else data
+        self.initialized = initialized
+        self.last_update_success = True
+        self.last_update_success_time = None
+        self.last_exception = None
+        self.update_interval = None
+        self.platforms = ["camera"]
+        self.machine_name = "FrontDoorCam"
+        self._supports_coaxial_control = True
+        self._supports_disarming_linkage = False
+        self._supports_lighting_v2 = True
+        self._dahua_event_timestamp = {"VideoMotion-0": 0}
+        self._dahua_event_listeners = {"VideoMotion-0": object()}
+        self._event_task = None
+        self._vto_task = None
+        self._vto_client = None
+
+    def get_model(self):
+        return "IPC-HDW5831R-ZE"
+
+    def get_device_name(self):
+        return "Front Door"
+
+    def get_firmware_version(self):
+        return "2.800.0000016.0.R"
+
+    def get_serial_number(self):
+        return SERIAL
+
+    def get_channel(self):
+        return 0
+
+    def get_channel_number(self):
+        return 1
+
+    def get_max_streams(self):
+        return 3
+
+    def get_profile_mode(self):
+        return "0"
+
+    def get_event_list(self):
+        return ["VideoMotion"]
+
+    def is_doorbell(self):
+        return False
+
+    def is_amcrest_doorbell(self):
+        return False
+
+    def is_flood_light(self):
+        return False
+
+    def supports_siren(self):
+        return False
+
+    def supports_security_light(self):
+        return False
+
+    def supports_infrared_light(self):
+        return True
+
+    def supports_illuminator(self):
+        # Deliberately dereferences data, like the real one
+        return self.data["table.Lighting"] == "1"
+
+    def supports_smart_motion_detection_amcrest(self):
+        return False
+
+
+def _entry(hass, *, address=ADDRESS, channel=0, title="Front Door"):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=title,
+        unique_id=SERIAL if channel == 0 else f"{SERIAL}_{channel}",
+        data={
+            "username": USERNAME,
+            "password": PASSWORD,
+            "address": address,
+            "port": "80",
+            "rtsp_port": "554",
+            "channel": channel,
+            "name": title,
+        },
+        options={"events": ["VideoMotion"], "scan_interval": 120},
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _install(hass, entry, coordinator=None):
+    coordinator = coordinator or _Coordinator()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    return coordinator
+
+
+async def _blob(hass, entry):
+    return json.dumps(
+        await async_get_config_entry_diagnostics(hass, entry), cls=ExtendedJSONEncoder
+    )
+
+
+# --- the things that must never leak ---------------------------------------
+
+async def test_no_credential_appears_anywhere_in_the_dump(hass):
+    """Asserted over the whole blob, not per key.
+
+    Checking result["entry"]["data"]["password"] == REDACTED passes happily
+    while the password leaks through some other key, which is exactly what an
+    RTSP URL would do - async_redact_data redacts by key, not by value.
+    """
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    blob = await _blob(hass, entry)
+
+    assert PASSWORD not in blob
+    assert USERNAME not in blob
+
+
+async def test_the_serial_number_is_never_published(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert SERIAL not in json.dumps(result, cls=ExtendedJSONEncoder)
+    assert re.fullmatch(r"[0-9a-f]{12}", result["device"]["serial_fingerprint"])
+
+
+async def test_the_same_device_fingerprints_the_same_across_entries(hass):
+    """The fingerprint has to still group an NVR's channels together."""
+    a, b = _entry(hass, channel=0), _entry(hass, channel=1, title="Ch2")
+    _install(hass, a)
+    _install(hass, b)
+
+    fa = (await async_get_config_entry_diagnostics(hass, a))["device"]["serial_fingerprint"]
+    fb = (await async_get_config_entry_diagnostics(hass, b))["device"]["serial_fingerprint"]
+
+    assert fa == fb
+
+
+async def test_the_digest_state_is_reported_only_as_a_boolean(hass):
+    entry = _entry(hass)
+    coordinator = _install(hass, entry)
+    coordinator.client._digest_state = {"nonce": "NONCE-SENTINEL-VALUE"}
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert "NONCE-SENTINEL-VALUE" not in json.dumps(result, cls=ExtendedJSONEncoder)
+    assert result["client"]["digest_challenge_cached"] is True
+
+
+# --- it must not fall over, especially when things are broken --------------
+
+async def test_the_dump_is_json_serialisable(hass):
+    """A non-serialisable field is a silent HTTP 500 with only a log line."""
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    json.dumps(await async_get_config_entry_diagnostics(hass, entry),
+               cls=ExtendedJSONEncoder)
+
+
+async def test_the_dump_survives_a_coordinator_that_never_refreshed(hass):
+    """The state a dump is most needed in: setup failed, data is None."""
+    entry = _entry(hass)
+    coordinator = _Coordinator(data=None, initialized=False)
+    coordinator.last_update_success = False
+    coordinator.last_exception = TimeoutError("no route to host")
+    _install(hass, entry, coordinator)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["coordinator"]["last_exception_type"] == "TimeoutError"
+    assert result["coordinator"]["data_key_count"] == 0
+    # supports_illuminator dereferences data and would raise
+    assert result["capabilities"]["derived_from_model"]["supports_illuminator"] is None
+
+
+async def test_the_dump_survives_a_missing_serial_number(hass):
+    """get_serial_number reads an attribute assigned only during detection."""
+    entry = _entry(hass)
+    coordinator = _install(hass, entry)
+    coordinator.get_serial_number = lambda: (_ for _ in ()).throw(AttributeError())
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["device"]["serial_fingerprint"] is None
+
+
+# --- the content that makes it worth pulling -------------------------------
+
+async def test_effective_options_are_reported_not_just_stored_ones(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["entry"]["resolved_events"] == ["VideoMotion"]
+    assert result["entry"]["resolved_scan_interval_seconds"] == 120
+
+
+async def test_every_capability_flag_is_represented(hass):
+    """A flag added later should show up here without anyone remembering to."""
+    entry = _entry(hass)
+    coordinator = _install(hass, entry)
+
+    result = await async_get_config_entry_diagnostics(hass, entry)
+
+    expected = {n for n in vars(coordinator) if n.startswith("_supports_")}
+    assert len(result["capabilities"]["probed"]) == len(expected)
+    assert result["capabilities"]["probed"]["coaxial_control"] is True
+    assert result["capabilities"]["probed"]["disarming_linkage"] is False
+
+
+async def test_event_timestamps_are_reported_as_ages(hass):
+    """A six-hour-old motion event is a sensor stuck on with no Stop."""
+    import time
+
+    entry = _entry(hass)
+    coordinator = _install(hass, entry)
+    coordinator._dahua_event_timestamp = {
+        "VideoMotion-0": int(time.time()) - 21600,
+        "CrossLineDetection-0": 0,
+    }
+
+    events = (await async_get_config_entry_diagnostics(hass, entry))["events"]
+
+    assert 21590 <= events["timestamp_age_seconds"]["VideoMotion-0"] <= 21610
+    assert events["timestamp_age_seconds"]["CrossLineDetection-0"] is None
+    assert events["active_count"] == 1
+
+
+async def test_siblings_on_one_address_are_reported(hass):
+    """The point of the host block: this report is 1 of N against one NVR."""
+    entries = [_entry(hass, channel=i, title=f"Ch{i}") for i in range(3)]
+    other = _entry(hass, address="10.0.0.2", channel=0, title="Doorbell")
+    for entry in [*entries, other]:
+        _install(hass, entry)
+
+    host = (await async_get_config_entry_diagnostics(hass, entries[0]))["host"]
+
+    assert host["sibling_entry_count"] == 3
+    assert host["total_dahua_entries"] == 4
+    assert sum(1 for s in host["sibling_entries"] if s["is_this_entry"]) == 1
+    assert other.entry_id not in [s["entry_id"] for s in host["sibling_entries"]]
+
+
+async def test_the_shared_connector_refcount_is_reported(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+    dahua_module._acquire_connector(ADDRESS)
+    dahua_module._acquire_connector(ADDRESS)
+
+    host = (await async_get_config_entry_diagnostics(hass, entry))["host"]
+
+    assert host["connector_refcount"] == 2
+    assert host["connector_closed"] is False
+    await dahua_module._release_connector(ADDRESS)
+    await dahua_module._release_connector(ADDRESS)
+
+
+async def test_the_per_host_limiter_is_reported(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+
+    host = (await async_get_config_entry_diagnostics(hass, entry))["host"]
+
+    assert host["max_concurrent_requests_per_host"] == (
+        client_module.MAX_CONCURRENT_REQUESTS_PER_HOST
+    )
+    assert host["limiter_free_slots"] == client_module.MAX_CONCURRENT_REQUESTS_PER_HOST
+    assert host["limiter_locked"] is False
+
+
+async def test_a_mismatched_host_key_is_visible(hass):
+    """One device holding two differently-keyed pools should be obvious."""
+    entry = _entry(hass, address=f"{ADDRESS}/")
+    _install(hass, entry)
+
+    host = (await async_get_config_entry_diagnostics(hass, entry))["host"]
+
+    assert host["client_key_matches_connector_key"] is False
+
+
+# --- device diagnostics ----------------------------------------------------
+
+async def test_device_diagnostics_does_not_publish_the_identifiers(hass):
+    entry = _entry(hass)
+    _install(hass, entry)
+    device = SimpleNamespace(
+        identifiers={(DOMAIN, SERIAL)}, name="Front Door", name_by_user=None,
+        model="IPC", manufacturer="Dahua", sw_version="1.0", area_id=None,
+        disabled_by=None, entry_type=None,
+    )
+
+    result = await async_get_device_diagnostics(hass, entry, device)
+
+    assert SERIAL not in json.dumps(result, cls=ExtendedJSONEncoder)
+    assert result["device_registry"]["name"] == "Front Door"
+    assert "coordinator" in result

--- a/tests/dahua/test_issue_translations.py
+++ b/tests/dahua/test_issue_translations.py
@@ -18,7 +18,7 @@ ISSUE_PLACEHOLDERS = {
     "device_unreachable": {"address", "entries", "minutes", "port"},
     "http_dead_https_available": {"address", "entries", "minutes", "port"},
 }
-FIX_FLOW_PLACEHOLDERS = {"address", "entries"}
+FIX_FLOW_PLACEHOLDERS = {"address", "entries", "port"}
 
 
 def _placeholders(text: str) -> set:
@@ -26,16 +26,31 @@ def _placeholders(text: str) -> set:
 
 
 @pytest.mark.parametrize("key", ["device_unreachable", "http_dead_https_available"])
-def test_every_issue_the_code_raises_has_english_text(key):
-    assert {"title", "description"} <= set(EN["issues"][key])
+def test_every_issue_the_code_raises_has_a_title(key):
     assert EN["issues"][key]["title"].strip()
-    assert EN["issues"][key]["description"].strip()
 
 
-def test_the_fixable_issue_has_a_fix_flow_step():
-    """is_fixable=True with no fix_flow gives a card whose button goes nowhere."""
-    step = EN["issues"]["http_dead_https_available"]["fix_flow"]["step"]["confirm"]
+def test_a_fixable_issue_has_a_fix_flow_and_no_description():
+    """hassfest treats description and fix_flow as mutually exclusive.
+
+    An issue is either something you read (title + description) or something
+    you act on (title + fix_flow). Supplying both fails validation with
+    "two or more values in the same group of exclusion 'fixable'", so the
+    explanation has to live in the fix flow's own step.
+    """
+    issue = EN["issues"]["http_dead_https_available"]
+    assert "fix_flow" in issue
+    assert "description" not in issue
+
+    step = issue["fix_flow"]["step"]["confirm"]
     assert {"title", "description"} <= set(step)
+    assert step["description"].strip()
+
+
+def test_an_unfixable_issue_has_a_description_and_no_fix_flow():
+    issue = EN["issues"]["device_unreachable"]
+    assert issue["description"].strip()
+    assert "fix_flow" not in issue
 
 
 def test_the_fix_flow_can_abort():
@@ -43,17 +58,11 @@ def test_the_fix_flow_can_abort():
     assert "not_configured" in abort
 
 
-def test_the_unfixable_issue_has_no_fix_flow():
-    """A fix_flow on is_fixable=False would offer a button that does nothing."""
-    assert "fix_flow" not in EN["issues"]["device_unreachable"]
-
-
 @pytest.mark.parametrize("key", ["device_unreachable", "http_dead_https_available"])
 def test_no_text_uses_a_placeholder_the_code_does_not_supply(key):
     """An unsupplied placeholder renders literally as {whatever}."""
-    used = _placeholders(EN["issues"][key]["title"]) | _placeholders(
-        EN["issues"][key]["description"]
-    )
+    issue = EN["issues"][key]
+    used = _placeholders(issue["title"]) | _placeholders(issue.get("description", ""))
     assert used <= ISSUE_PLACEHOLDERS[key], f"unsupplied: {used - ISSUE_PLACEHOLDERS[key]}"
 
 

--- a/tests/dahua/test_issue_translations.py
+++ b/tests/dahua/test_issue_translations.py
@@ -1,0 +1,79 @@
+"""A mistyped translation key ships a card with raw keys on screen.
+
+None of the behavioural tests can see that, because creating an issue does not
+resolve its text. These are plain file assertions.
+"""
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+TRANSLATIONS = Path(__file__).resolve().parents[2] / "custom_components" / "dahua" / "translations"
+EN = json.loads((TRANSLATIONS / "en.json").read_text(encoding="utf-8"))
+
+# What the code actually passes to async_create_issue / async_show_form.
+ISSUE_PLACEHOLDERS = {
+    "device_unreachable": {"address", "entries", "minutes", "port"},
+    "http_dead_https_available": {"address", "entries", "minutes", "port"},
+}
+FIX_FLOW_PLACEHOLDERS = {"address", "entries"}
+
+
+def _placeholders(text: str) -> set:
+    return set(re.findall(r"\{(\w+)\}", text))
+
+
+@pytest.mark.parametrize("key", ["device_unreachable", "http_dead_https_available"])
+def test_every_issue_the_code_raises_has_english_text(key):
+    assert {"title", "description"} <= set(EN["issues"][key])
+    assert EN["issues"][key]["title"].strip()
+    assert EN["issues"][key]["description"].strip()
+
+
+def test_the_fixable_issue_has_a_fix_flow_step():
+    """is_fixable=True with no fix_flow gives a card whose button goes nowhere."""
+    step = EN["issues"]["http_dead_https_available"]["fix_flow"]["step"]["confirm"]
+    assert {"title", "description"} <= set(step)
+
+
+def test_the_fix_flow_can_abort():
+    abort = EN["issues"]["http_dead_https_available"]["fix_flow"]["abort"]
+    assert "not_configured" in abort
+
+
+def test_the_unfixable_issue_has_no_fix_flow():
+    """A fix_flow on is_fixable=False would offer a button that does nothing."""
+    assert "fix_flow" not in EN["issues"]["device_unreachable"]
+
+
+@pytest.mark.parametrize("key", ["device_unreachable", "http_dead_https_available"])
+def test_no_text_uses_a_placeholder_the_code_does_not_supply(key):
+    """An unsupplied placeholder renders literally as {whatever}."""
+    used = _placeholders(EN["issues"][key]["title"]) | _placeholders(
+        EN["issues"][key]["description"]
+    )
+    assert used <= ISSUE_PLACEHOLDERS[key], f"unsupplied: {used - ISSUE_PLACEHOLDERS[key]}"
+
+
+def test_the_fix_flow_only_uses_its_own_placeholders():
+    """Step text is filled from async_show_form, not from the issue's set."""
+    step = EN["issues"]["http_dead_https_available"]["fix_flow"]["step"]["confirm"]
+    used = _placeholders(step["title"]) | _placeholders(step["description"])
+    assert used <= FIX_FLOW_PLACEHOLDERS, f"unsupplied: {used - FIX_FLOW_PLACEHOLDERS}"
+
+
+def test_adding_issues_did_not_disturb_config_or_options():
+    assert "config" in EN and "options" in EN
+    assert "scan_interval" in EN["options"]["step"]["user"]["data"]
+    assert "reconfigure" in EN["config"]["step"]
+
+
+def test_the_other_locales_fall_back_to_english():
+    """English is the per-key fallback, so copying untranslated text into the
+    other eight files would look identical while silently rotting."""
+    for path in TRANSLATIONS.glob("*.json"):
+        if path.name == "en.json":
+            continue
+        assert "issues" not in json.loads(path.read_text(encoding="utf-8")), path.name

--- a/tests/dahua/test_repairs.py
+++ b/tests/dahua/test_repairs.py
@@ -1,0 +1,273 @@
+"""A repair that cannot be acted on is noise, so there are only two."""
+
+import pytest
+from homeassistant.components.repairs import ConfirmRepairFlow
+from homeassistant.helpers import issue_registry as ir
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import dahua as dahua_module
+from custom_components.dahua import (
+    ISSUE_HTTP_DEAD_HTTPS_AVAILABLE,
+    ISSUE_UNREACHABLE,
+    UNREACHABLE_AFTER_FAILURES,
+    async_record_host_failure,
+    async_record_host_success,
+)
+from custom_components.dahua.const import DOMAIN
+from custom_components.dahua.repairs import (
+    SwitchToHttpsRepairFlow,
+    async_create_fix_flow,
+)
+
+ADDRESS = "10.0.0.1"
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    dahua_module._HOST_FAILURES.clear()
+    yield
+    dahua_module._HOST_FAILURES.clear()
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch):
+    """The flow staggers reloads; the suite runs with --timeout=9."""
+    async def _instant(_seconds):
+        return None
+
+    monkeypatch.setattr("custom_components.dahua.repairs.asyncio.sleep", _instant)
+
+
+def _entry(hass, *, address=ADDRESS, channel=0, port="80", use_https=None):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=f"Ch{channel}",
+        unique_id=f"SERIAL_{channel}" if channel else "SERIAL",
+        data={
+            "username": "u", "password": "p", "address": address,
+            "port": port, "rtsp_port": "554", "channel": channel,
+            "name": f"Ch{channel}", "use_https": use_https,
+        },
+    )
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _probe(monkeypatch, result, counter=None):
+    async def fake(address, port, timeout=5.0):
+        if counter is not None:
+            counter.append((address, port))
+        return result
+
+    monkeypatch.setattr(dahua_module, "_async_probe_tcp", fake)
+
+
+def _issue(hass, template, address=ADDRESS):
+    return ir.async_get(hass).async_get_issue(DOMAIN, template.format(address))
+
+
+async def _fail(hass, entry, times):
+    for _ in range(times):
+        async_record_host_failure(hass, entry.data["address"], entry.entry_id)
+    await hass.async_block_till_done()
+
+
+# --- when a card appears ---------------------------------------------------
+
+async def test_a_single_failure_raises_nothing(hass, monkeypatch):
+    """One dropped poll must not put a card in front of the user."""
+    _probe(monkeypatch, False)
+    entry = _entry(hass)
+
+    await _fail(hass, entry, 1)
+
+    assert _issue(hass, ISSUE_UNREACHABLE) is None
+
+
+async def test_repeated_failures_raise_one_card(hass, monkeypatch):
+    _probe(monkeypatch, False)
+    entry = _entry(hass)
+
+    await _fail(hass, entry, UNREACHABLE_AFTER_FAILURES)
+
+    issue = _issue(hass, ISSUE_UNREACHABLE)
+    assert issue is not None
+    assert issue.severity == ir.IssueSeverity.WARNING
+    assert issue.is_fixable is False
+
+
+async def test_eight_channels_of_one_nvr_get_one_card_not_eight(hass, monkeypatch):
+    """The single most-repeated structural complaint about this integration."""
+    _probe(monkeypatch, False)
+    entries = [_entry(hass, channel=i) for i in range(8)]
+
+    for entry in entries:
+        async_record_host_failure(hass, ADDRESS, entry.entry_id)
+    await hass.async_block_till_done()
+
+    ours = [k for k in ir.async_get(hass).issues if k[0] == DOMAIN]
+    assert len(ours) == 1
+
+
+async def test_a_trailing_slash_is_the_same_host(hass, monkeypatch):
+    _probe(monkeypatch, False)
+    _entry(hass)
+
+    for _ in range(3):
+        async_record_host_failure(hass, ADDRESS, "a")
+    for _ in range(3):
+        async_record_host_failure(hass, ADDRESS + "/", "b")
+    await hass.async_block_till_done()
+
+    assert len([k for k in ir.async_get(hass).issues if k[0] == DOMAIN]) == 1
+    assert _issue(hass, ISSUE_UNREACHABLE) is not None
+
+
+# --- when it goes away -----------------------------------------------------
+
+async def test_a_success_clears_the_card(hass, monkeypatch):
+    _probe(monkeypatch, False)
+    entry = _entry(hass)
+    await _fail(hass, entry, UNREACHABLE_AFTER_FAILURES)
+    assert _issue(hass, ISSUE_UNREACHABLE) is not None
+
+    async_record_host_success(hass, ADDRESS)
+
+    assert _issue(hass, ISSUE_UNREACHABLE) is None
+    assert dahua_module._HOST_FAILURES == {}
+
+
+async def test_one_channel_recovering_clears_the_card_for_the_host(hass, monkeypatch):
+    """If any channel answers, the box is up."""
+    _probe(monkeypatch, False)
+    entries = [_entry(hass, channel=i) for i in range(8)]
+    for entry in entries:
+        async_record_host_failure(hass, ADDRESS, entry.entry_id)
+    await hass.async_block_till_done()
+
+    async_record_host_success(hass, ADDRESS)
+
+    assert _issue(hass, ISSUE_UNREACHABLE) is None
+
+
+async def test_unloading_the_last_entry_removes_the_card(hass, monkeypatch):
+    _probe(monkeypatch, False)
+    entry = _entry(hass)
+    await _fail(hass, entry, UNREACHABLE_AFTER_FAILURES)
+    assert _issue(hass, ISSUE_UNREACHABLE) is not None
+
+    await hass.config_entries.async_remove(entry.entry_id)
+    ir.async_delete_issue(hass, DOMAIN, ISSUE_UNREACHABLE.format(ADDRESS))
+
+    assert _issue(hass, ISSUE_UNREACHABLE) is None
+
+
+# --- choosing between the two cards ---------------------------------------
+
+async def test_https_is_offered_when_443_answers(hass, monkeypatch):
+    """The failure we actually hit: port 80 dead, 443 accepting."""
+    _probe(monkeypatch, True)
+    entry = _entry(hass)
+
+    await _fail(hass, entry, UNREACHABLE_AFTER_FAILURES)
+
+    issue = _issue(hass, ISSUE_HTTP_DEAD_HTTPS_AVAILABLE)
+    assert issue is not None
+    assert issue.is_fixable is True
+    assert issue.translation_placeholders["address"] == ADDRESS
+    assert _issue(hass, ISSUE_UNREACHABLE) is None
+
+
+async def test_the_unreachable_card_is_raised_when_443_is_dead_too(hass, monkeypatch):
+    _probe(monkeypatch, False)
+    entry = _entry(hass)
+
+    await _fail(hass, entry, UNREACHABLE_AFTER_FAILURES)
+
+    assert _issue(hass, ISSUE_UNREACHABLE) is not None
+    assert _issue(hass, ISSUE_HTTP_DEAD_HTTPS_AVAILABLE) is None
+
+
+async def test_an_entry_already_on_https_is_never_probed(hass, monkeypatch):
+    """Nothing to offer someone who is already using HTTPS."""
+    calls = []
+    _probe(monkeypatch, True, calls)
+    entry = _entry(hass, port="443")
+
+    await _fail(hass, entry, UNREACHABLE_AFTER_FAILURES)
+
+    assert calls == []
+    assert _issue(hass, ISSUE_HTTP_DEAD_HTTPS_AVAILABLE) is None
+    assert _issue(hass, ISSUE_UNREACHABLE) is not None
+
+
+async def test_the_probe_is_not_repeated_on_every_failure(hass, monkeypatch):
+    """A wedged host fails every poll; it must not be probed every poll."""
+    calls = []
+    _probe(monkeypatch, False, calls)
+    entry = _entry(hass)
+
+    await _fail(hass, entry, 30)
+
+    assert len(calls) == 1
+
+
+# --- the fix flow ----------------------------------------------------------
+
+async def test_the_fix_flow_switches_every_entry_for_the_host(hass, monkeypatch):
+    entries = [_entry(hass, channel=i) for i in range(3)]
+    _entry(hass, address="10.0.0.2", channel=0)
+    ir.async_create_issue(
+        hass, DOMAIN, ISSUE_HTTP_DEAD_HTTPS_AVAILABLE.format(ADDRESS),
+        is_fixable=True, severity=ir.IssueSeverity.WARNING,
+        translation_key="http_dead_https_available", data={"address": ADDRESS},
+    )
+
+    flow = await async_create_fix_flow(
+        hass, ISSUE_HTTP_DEAD_HTTPS_AVAILABLE.format(ADDRESS), {"address": ADDRESS}
+    )
+    flow.hass = hass
+    await flow.async_step_confirm({})
+
+    for entry in entries:
+        assert entry.data["port"] == "443"
+        assert entry.data["use_https"] is True
+    assert _issue(hass, ISSUE_HTTP_DEAD_HTTPS_AVAILABLE) is None
+
+
+async def test_the_other_hosts_entries_are_left_alone(hass, monkeypatch):
+    _entry(hass, channel=0)
+    other = _entry(hass, address="10.0.0.2", channel=0)
+
+    flow = SwitchToHttpsRepairFlow({"address": ADDRESS})
+    flow.hass = hass
+    await flow.async_step_confirm({})
+
+    assert other.data["port"] == "80"
+
+
+async def test_the_confirm_step_shows_a_form_before_changing_anything(hass):
+    entry = _entry(hass)
+
+    flow = SwitchToHttpsRepairFlow({"address": ADDRESS})
+    flow.hass = hass
+    result = await flow.async_step_confirm()
+
+    assert result["type"] == "form"
+    assert result["description_placeholders"]["entries"] == "1"
+    assert entry.data["port"] == "80", "changed something before confirmation"
+
+
+async def test_the_flow_aborts_when_the_entries_are_gone(hass):
+    flow = SwitchToHttpsRepairFlow({"address": "10.9.9.9"})
+    flow.hass = hass
+
+    result = await flow.async_step_confirm()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_configured"
+
+
+async def test_an_unknown_issue_falls_back_to_confirm(hass):
+    flow = await async_create_fix_flow(hass, "something_else", None)
+    assert isinstance(flow, ConfirmRepairFlow)


### PR DESCRIPTION
Today, a device Home Assistant cannot reach is reported by logging a warning every thirty seconds, forever. Nothing tells the user, and nothing tells you which of an NVR's channels is affected. `#478` — the most-reacted open issue at 13 reactions, with only 4 comments — is titled "constant errors popping up".

**Builds on #612** and shares its branch, so the diff currently shows that commit too. It collapses to its own change once #612 merges.

### Two repairs, both keyed by host

An eight-channel NVR going offline has to produce **one** card, not eight. That is the most-repeated structural complaint about this integration, and keying by config entry here would have been a self-own.

| Issue | Fixable | Raised when |
|---|---|---|
| `unreachable_{address}` | no | 5 consecutive failures, and TCP 443 is also dead |
| `http_dead_https_available_{address}` | **yes** | 5 consecutive failures, but TCP 443 accepts |

The second describes a failure this integration currently cannot express. Some Dahua firmwares stop serving plain HTTP while HTTPS keeps working — port 80 stops accepting connections entirely while ICMP stays clean and RTSP keeps streaming, so every obvious diagnosis points at the network instead. Observed in the wild: a single `connect()` to :80 took **545 seconds** to fail while ICMP was 0% loss and :554 answered instantly.

When the threshold is crossed we probe TCP 443 **once** (a wedged host fails every poll, so it must not be probed on every poll), and if it answers we say so and offer to switch.

### The fix flow updates entries one at a time

`async_update_entry` already triggers a reload through the update listener registered in `async_setup_entry`, so the flow deliberately does **not** call `async_reload` — doing both would reload every channel twice. And the updates are staggered rather than fired together, because a simultaneous burst of reloads is precisely what wedges a Dahua web server in the first place. The per-host limiter is the hard bound; this is cheap insurance that also makes the intent legible.

### Why the counter is module-level

`async_config_entry_first_refresh()` raises `ConfigEntryNotReady` before the coordinator is published to `hass.data`, so every setup retry constructs and discards a fresh coordinator. A failure counter stored there would never reach the threshold. It also has to be shared across an NVR's channels for the one-card rule above.

Normalising the address on the way in also fixes a pre-existing inconsistency: `_acquire_connector()` used the raw entry value while `DahuaClient` does `address.rstrip('/')` before keying its limiter, so a trailing slash gave one device two differently-keyed connector pools.

### Five candidates rejected

A repair that cannot be acted on is noise, so this is deliberately a short list:

| Rejected | Why |
|---|---|
| Latched event sensor (`is_on` is `timestamp > 0` with no timer) | No user action. The fix is a stop-timeout in code. Surfaced in #612's `events.timestamp_age_seconds` instead. |
| Identity derived from the password | Permanent and unresolvable, so the card could never be dismissed. Surfaced as a diagnostics field instead. |
| Event stream connected but silent | False-positives on every quiet camera overnight. |
| Authentication failure | `async_start_reauth` already surfaces its own actionable card — deliberately no call on that branch. |
| Dead `StreamType.WEB_RTC` declaration | Not a runtime condition; a one-line deletion belonging elsewhere. |

`breaks_in_ha_version` is not set on either issue — it is CalVer-validated and raises on invalid input, and neither of these is a deprecation.

### Translations

An `issues` section is added to `translations/en.json` only. `strings.json` is deliberately **not** introduced: Home Assistant reads `translations/<lang>.json` directly for custom integrations, so it would be a second file to keep in sync with no runtime effect. English is the per-key fallback for every locale, so the other eight files are left alone rather than filled with untranslated English that would silently rot.

Note the two placeholder sources differ — `issues.<key>.title/description` come from `translation_placeholders`, while `issues.<key>.fix_flow.step.*` come from `description_placeholders`. Both are covered by tests.

`manifest.json` gains `"dependencies": ["repairs"]` since we ship a fix flow. No new `requirements`.

### Verification

In a `python:3.13` container matching CI:

```
suite: 177 passed   (151 after #612)
```

Two deliberate breaks, each caught:

```
lower the threshold so one failure raises a card  -> test_a_single_failure_raises_nothing fails
rename fix_flow "step" to "steps"                 -> 2 translation tests fail
```

That second one matters: a mistyped `fix_flow` nesting ships a card with raw translation keys on screen, and no behavioural test can see it, because creating an issue does not resolve its text.