### PR TITLE
Spread the event stream reconnections

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -4,6 +4,7 @@ Custom integration to integrate Dahua cameras with Home Assistant.
 import asyncio
 from typing import Any, Dict
 import logging
+import random
 import ssl
 import time
 
@@ -50,6 +51,24 @@ from .vto import DahuaVTOClient
 # A stream that keeps heartbeating but has stopped reporting events looks
 # healthy to a read timeout, so recycle it periodically as well.
 EVENT_STREAM_MAX_LIFETIME_SECONDS = 3600
+
+# An NVR gets one config entry per channel, and they all start within a moment
+# of each other, so a fixed lifetime makes every channel drop and re-attach in
+# the same second, once an hour. Spreading them means the device sees a trickle
+# of reconnections instead of a burst.
+EVENT_STREAM_JITTER = 0.1
+
+# The same applies after a failure: a device that rejected every channel at once
+# would otherwise be retried by every channel at once, sixty seconds later.
+EVENT_STREAM_RETRY_SECONDS = 60
+
+
+def jittered(seconds: float, fraction: float = EVENT_STREAM_JITTER) -> float:
+    """Spread a shared interval so simultaneous callers stop being simultaneous."""
+    if seconds <= 0 or fraction <= 0:
+        return seconds
+    spread = seconds * fraction
+    return max(1.0, seconds + random.uniform(-spread, spread))
 
 SSL_CONTEXT = ssl.create_default_context()
 SSL_CONTEXT.set_ciphers("DEFAULT")
@@ -256,7 +275,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             try:
                 await asyncio.wait_for(
                     self.client.stream_events(self.on_receive, self.events, self._channel),
-                    timeout=EVENT_STREAM_MAX_LIFETIME_SECONDS,
+                    timeout=jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS),
                 )
             except asyncio.CancelledError:
                 raise
@@ -267,8 +286,13 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
             elapsed = time.monotonic() - start_time
             if elapsed < 10:
-                _LOGGER.debug("Event stream for %s failed quickly, retrying in 60s", self._address)
-                await asyncio.sleep(60)
+                retry_in = jittered(EVENT_STREAM_RETRY_SECONDS)
+                _LOGGER.debug(
+                    "Event stream for %s failed quickly, retrying in %.0fs",
+                    self._address,
+                    retry_in,
+                )
+                await asyncio.sleep(retry_in)
             else:
                 _LOGGER.debug("Reconnecting to event stream for %s", self._address)
 

--- a/tests/dahua/test_stream_jitter.py
+++ b/tests/dahua/test_stream_jitter.py
@@ -1,0 +1,69 @@
+"""Eleven channels of one NVR must not all reconnect in the same second."""
+
+import statistics
+
+from custom_components.dahua import (
+    EVENT_STREAM_JITTER,
+    EVENT_STREAM_MAX_LIFETIME_SECONDS,
+    EVENT_STREAM_RETRY_SECONDS,
+    jittered,
+)
+
+
+def test_the_lifetime_is_not_the_same_twice():
+    """A fixed lifetime is what synchronises the reconnections."""
+    values = {jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS) for _ in range(50)}
+
+    assert len(values) > 40, "the lifetime is barely varying"
+
+
+def test_the_spread_stays_within_the_configured_fraction():
+    spread = EVENT_STREAM_MAX_LIFETIME_SECONDS * EVENT_STREAM_JITTER
+    low, high = (
+        EVENT_STREAM_MAX_LIFETIME_SECONDS - spread,
+        EVENT_STREAM_MAX_LIFETIME_SECONDS + spread,
+    )
+
+    for _ in range(200):
+        assert low <= jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS) <= high
+
+
+def test_the_average_is_still_the_interval_asked_for():
+    """Jitter should spread the reconnections, not quietly change the period."""
+    mean = statistics.fmean(
+        jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS) for _ in range(2000)
+    )
+
+    assert abs(mean - EVENT_STREAM_MAX_LIFETIME_SECONDS) < (
+        EVENT_STREAM_MAX_LIFETIME_SECONDS * 0.02
+    )
+
+
+def test_eleven_streams_land_in_different_seconds():
+    """The case this exists for: one NVR, one entry per channel."""
+    seconds = {int(jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS)) for _ in range(11)}
+
+    assert len(seconds) == 11
+
+
+def test_the_retry_after_a_failure_is_spread_too():
+    """A device that rejected every channel would otherwise be retried by
+    every channel at the same moment, sixty seconds later."""
+    values = {jittered(EVENT_STREAM_RETRY_SECONDS) for _ in range(50)}
+
+    assert len(values) > 40
+
+
+def test_it_never_returns_something_useless():
+    """A tiny or negative delay would turn a retry into a hot loop."""
+    for seconds in (1, 5, 60, 3600):
+        for _ in range(200):
+            assert jittered(seconds) >= 1.0
+
+
+def test_jitter_can_be_switched_off():
+    assert jittered(3600, fraction=0) == 3600
+
+
+def test_a_zero_interval_is_left_alone():
+    assert jittered(0) == 0


### PR DESCRIPTION
An NVR gets one config entry per channel, and they all start within a moment of each other. `EVENT_STREAM_MAX_LIFETIME_SECONDS` is a flat 3600, so every channel drops and re-attaches **in the same second, once an hour**. Eleven channels means eleven simultaneous reconnections against a device whose web server does not have many connections to spare.

The retry path has the same shape and matters more:

```python
if elapsed < 10:
    await asyncio.sleep(60)     # every channel, at the same moment
```

A device that has just rejected every channel gets retried by every channel at once, sixty seconds later.

### The change

```python
def jittered(seconds: float, fraction: float = EVENT_STREAM_JITTER) -> float:
    """Spread a shared interval so simultaneous callers stop being simultaneous."""
```

Applied to the stream lifetime and the failure retry. The **mean is unchanged**, so the recycle still happens about hourly and the retry still waits about a minute — the reconnections simply stop landing together. A test asserts the mean stays within 2% of the interval asked for, so this cannot quietly become a period change.

### Scope

This does **not** fix #603 on its own. That is about connection *count*, and the real fix is one event stream per host instead of one per channel — which the comment at `__init__.py:663` already proposes and which I am working on separately. This is three lines that de-synchronise the burst on every existing install today, with no structural change and nothing to migrate.

### Verification

In a `python:3.13` container matching CI:

```
suite: 144 passed   (136 before)
```

Neutralising the jitter fails three tests:

```
test_the_lifetime_is_not_the_same_twice
test_eleven_streams_land_in_different_seconds
test_the_retry_after_a_failure_is_spread_too
```

`jittered()` also never returns less than a second, so a small interval cannot turn a retry into a hot loop.