### PR TITLE
Hold one event stream per host, not one per channel

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -342,6 +342,158 @@ async def _release_connector(address: str) -> None:
         await holder[0].close()
 
 
+class DahuaHostEventStream:
+    """One event stream for a host, shared by every channel configured on it.
+
+    The device's event stream is not per channel: attaching to it returns every
+    channel's events regardless of who asked. An NVR with eleven channels was
+    therefore holding eleven identical streams and having ten of them throw each
+    event away. This holds one, and hands each event to the channels that want
+    it.
+    """
+
+    def __init__(self, hass: HomeAssistant, address: str) -> None:
+        self._hass = hass
+        self._address = address
+        # channel index -> coordinators listening on that channel
+        self._by_channel: Dict[int, list] = {}
+        self._owner = None  # whose client the stream currently borrows
+        self._events: frozenset = frozenset()
+        self._task: asyncio.Task | None = None
+
+    @property
+    def coordinators(self) -> list:
+        return [c for group in self._by_channel.values() for c in group]
+
+    def _union(self) -> frozenset:
+        """Every event any channel on this host asked for.
+
+        Attaching with one channel's list would silently stop delivering the
+        codes another channel selected.
+        """
+        union = set()
+        for coordinator in self.coordinators:
+            union.update(coordinator.events or [])
+        return frozenset(union)
+
+    def register(self, coordinator) -> None:
+        self._by_channel.setdefault(coordinator.get_channel(), []).append(coordinator)
+        if self._owner is None:
+            self._owner = coordinator
+        self._restart_if_needed()
+
+    async def unregister(self, coordinator) -> bool:
+        """Drop a channel. Returns True when nothing is left on this host."""
+        group = self._by_channel.get(coordinator.get_channel(), [])
+        if coordinator in group:
+            group.remove(coordinator)
+        if not group:
+            self._by_channel.pop(coordinator.get_channel(), None)
+
+        remaining = self.coordinators
+        if not remaining:
+            await self.async_stop()
+            return True
+
+        # The stream borrows the owner's client, and unloading an entry closes
+        # its session, so hand the stream to someone still here.
+        if coordinator is self._owner:
+            self._owner = remaining[0]
+            self._events = frozenset()  # force a restart on the new client
+        self._restart_if_needed()
+        return False
+
+    def _restart_if_needed(self) -> None:
+        wanted = self._union()
+        if self._task is not None and not self._task.done() and wanted == self._events:
+            return
+        self._events = wanted
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        if wanted and self._owner is not None:
+            self._task = asyncio.create_task(self._async_run())
+
+    async def async_stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+        self._by_channel.clear()
+        self._owner = None
+        self._events = frozenset()
+
+    async def _async_run(self) -> None:
+        """Hold the stream open, recycling it the way a single channel used to."""
+        while True:
+            start_time = time.monotonic()
+            try:
+                await asyncio.wait_for(
+                    self._owner.client.stream_events(
+                        self.on_receive, sorted(self._events), 0
+                    ),
+                    timeout=jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS),
+                )
+            except asyncio.CancelledError:
+                raise
+            except asyncio.TimeoutError:
+                _LOGGER.debug("Recycling event stream for %s", self._address)
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.warning(
+                    "Event stream for %s ended unexpectedly: %s", self._address, ex
+                )
+
+            if time.monotonic() - start_time < 10:
+                retry_in = jittered(EVENT_STREAM_RETRY_SECONDS)
+                _LOGGER.debug(
+                    "Event stream for %s failed quickly, retrying in %.0fs",
+                    self._address,
+                    retry_in,
+                )
+                await asyncio.sleep(retry_in)
+            else:
+                _LOGGER.debug("Reconnecting to event stream for %s", self._address)
+
+    def on_receive(self, data_bytes: bytes, _channel: int) -> None:
+        """Parse once, then hand each event only to the channels that want it."""
+        events = parse_event(data_bytes.decode("utf-8", errors="ignore"))
+        if not events:
+            return
+
+        for event in events:
+            index = 0
+            if "index" in event:
+                try:
+                    index = int(event["index"])
+                except ValueError:
+                    index = 0
+
+            # A channel nobody has configured stays silent, exactly as it did
+            # when every coordinator discarded it.
+            for coordinator in self._by_channel.get(index, ()):
+                coordinator.handle_event(dict(event))
+
+
+# address -> DahuaHostEventStream
+_HOST_STREAMS: Dict[str, DahuaHostEventStream] = {}
+
+
+def _host_stream(hass: HomeAssistant, address: str) -> DahuaHostEventStream:
+    address = normalize_address(address)
+    stream = _HOST_STREAMS.get(address)
+    if stream is None:
+        stream = _HOST_STREAMS[address] = DahuaHostEventStream(hass, address)
+    return stream
+
+
+async def _release_host_stream(coordinator) -> None:
+    address = normalize_address(coordinator.get_address())
+    stream = _HOST_STREAMS.get(address)
+    if stream is None:
+        return
+    if await stream.unregister(coordinator):
+        _HOST_STREAMS.pop(address, None)
+
+
 class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     """Class to manage fetching data from the API."""
 
@@ -424,39 +576,14 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     async def async_start_event_listener(self):
         """ Starts the event listeners for IP cameras (this does not work for doorbells (VTO)) """
         if self.events is not None:
-            self._event_task = asyncio.create_task(self._async_stream_events())
+            # Join this host's stream rather than opening another one. The
+            # device sends every channel's events down any stream, so one is
+            # enough no matter how many channels are configured.
+            _host_stream(self.hass, self._address).register(self)
 
     async def async_start_vto_event_listener(self):
         """ Starts the event listeners for doorbells (VTO). This will not work for IP cameras"""
         self._vto_task = asyncio.create_task(self._async_stream_vto_events())
-
-    async def _async_stream_events(self):
-        """Continuously stream events from the camera, reconnecting on failure."""
-        while True:
-            start_time = time.monotonic()
-            try:
-                await asyncio.wait_for(
-                    self.client.stream_events(self.on_receive, self.events, self._channel),
-                    timeout=jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS),
-                )
-            except asyncio.CancelledError:
-                raise
-            except asyncio.TimeoutError:
-                _LOGGER.debug("Recycling event stream for %s", self._address)
-            except Exception as ex:
-                _LOGGER.warning("Event stream for %s ended unexpectedly: %s", self._address, ex)
-
-            elapsed = time.monotonic() - start_time
-            if elapsed < 10:
-                retry_in = jittered(EVENT_STREAM_RETRY_SECONDS)
-                _LOGGER.debug(
-                    "Event stream for %s failed quickly, retrying in %.0fs",
-                    self._address,
-                    retry_in,
-                )
-                await asyncio.sleep(retry_in)
-            else:
-                _LOGGER.debug("Reconnecting to event stream for %s", self._address)
 
     async def _async_stream_vto_events(self):
         """Continuously stream VTO events from a doorbell, reconnecting on failure."""
@@ -483,6 +610,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def async_stop(self, event: Any = None):
         """ Stop anything we need to stop """
+        await _release_host_stream(self)
         if self._event_task is not None:
             self._event_task.cancel()
             self._event_task = None
@@ -832,50 +960,46 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             'name': 'Cam8', 'Code': 'CrossLineDetection', 'action': 'Start', 'index': '0', 'data': {'Class': 'Normal', 'DetectLine': [[18, 4098], [8155, 5549]], 'Direction':      'RightToLeft', 'EventSeq': 40, 'FrameSequence': 549073, 'GroupID': 40, 'Mark': 0, 'Name': 'Rule1', 'Object': {'Action': 'Appear', 'BoundingBox': [4816, 4552, 5248, 5272], 'Center': [5032, 4912], 'Confidence': 0, 'FrameSequence': 0, 'ObjectID': 542, 'ObjectType': 'Unknown', 'RelativeID': 0, 'Source': 0.0, 'Speed': 0, 'SpeedTypeInternal': 0}, 'PTS': 42986015370.0, 'RuleId': 1, 'Source': 51190936.0, 'Track': None, 'UTC': 1620477656, 'UTCMS': 180}
         }
         """
-        data = data_bytes.decode("utf-8", errors="ignore")
-        events = parse_event(data)
-
-        if len(events) == 0:
-            return
-
-        _LOGGER.debug(f"Events received from {self.get_address()} on channel {channel}: {events}")
-
-        for event in events:
+        for event in parse_event(data_bytes.decode("utf-8", errors="ignore")):
             index = 0
             if "index" in event:
                 try:
                     index = int(event["index"])
                 except ValueError:
                     index = 0
+            if index == self._channel:
+                self.handle_event(event)
 
-            # This is a short term fix. Right now for NVRs this integration creates a thread per channel to listen to events. Every thread gets the same response. We need to
-            # discard events not for this channel. Longer term work should create only a single thread per channel.
-            if index != self._channel:
-                continue
+    def handle_event(self, event: dict):
+        """Handle one event the host stream has decided belongs to this channel."""
+        _LOGGER.debug(
+            "Event received from %s on channel %s: %s",
+            self.get_address(),
+            self._channel,
+            event,
+        )
 
-            # Put the vent on the HA event bus
-            event["name"] = self.get_device_name()
-            event["DeviceName"] = self.get_device_name()
-            self.hass.bus.fire("dahua_event_received", event)
+        # Put the event on the HA event bus
+        event["name"] = self.get_device_name()
+        event["DeviceName"] = self.get_device_name()
+        self.hass.bus.fire("dahua_event_received", event)
 
-            # When there's an event start we'll update the a map x to the current timestamp in seconds for the event.
-            # We'll reset it to 0 when the event stops.
-            # We'll use these timestamps in binary_sensor to know how long to trigger the sensor
+        # When there's an event start we'll update the a map x to the current timestamp in seconds for the event.
+        # We'll reset it to 0 when the event stops.
+        # We'll use these timestamps in binary_sensor to know how long to trigger the sensor
 
-            # This is the event code, example: VideoMotion, CrossLineDetection, etc
-            event_names = self.translate_event_code(event)
-
-            for event_name in event_names:
-                event_key = self.get_event_key(event_name)
-                listener = self._dahua_event_listeners.get(event_key)
-                if listener is not None:
-                    action = event["action"]
-                    if action == "Start":
-                        self._dahua_event_timestamp[event_key] = int(time.time())
-                        listener()
-                    elif action == "Stop":
-                        self._dahua_event_timestamp[event_key] = 0
-                        listener()
+        # This is the event code, example: VideoMotion, CrossLineDetection, etc
+        for event_name in self.translate_event_code(event):
+            event_key = self.get_event_key(event_name)
+            listener = self._dahua_event_listeners.get(event_key)
+            if listener is not None:
+                action = event.get("action")
+                if action == "Start":
+                    self._dahua_event_timestamp[event_key] = int(time.time())
+                    listener()
+                elif action == "Stop":
+                    self._dahua_event_timestamp[event_key] = 0
+                    listener()
 
     def translate_event_code(self, event: dict):
         """

--- a/tests/dahua/test_shared_event_stream.py
+++ b/tests/dahua/test_shared_event_stream.py
@@ -1,0 +1,259 @@
+"""One NVR holds one event stream, not one per channel."""
+
+import asyncio
+
+import pytest
+
+from custom_components import dahua as dahua_module
+from custom_components.dahua import (
+    DahuaHostEventStream,
+    _host_stream,
+    _release_host_stream,
+)
+
+ADDRESS = "10.0.0.1"
+
+MOTION_CH2 = (
+    b"--myboundary\n"
+    b"Content-Type: text/plain\n"
+    b"Content-Length: 40\n"
+    b"\n"
+    b"Code=VideoMotion;action=Start;index=2\n"
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_streams():
+    dahua_module._HOST_STREAMS.clear()
+    yield
+    dahua_module._HOST_STREAMS.clear()
+
+
+class _Client:
+    """Holds the stream open so the task stays alive, and records the attach."""
+
+    def __init__(self):
+        self.attached_with = []
+        self.attach_count = 0
+        self.closed = False
+
+    async def stream_events(self, on_receive, events, channel):
+        self.attach_count += 1
+        self.attached_with.append(list(events))
+        if self.closed:
+            raise RuntimeError("session is closed")
+        await asyncio.Event().wait()
+
+
+class _Coordinator:
+    def __init__(self, channel, events, client=None):
+        self._channel = channel
+        self.events = events
+        self.client = client or _Client()
+        self.handled = []
+
+    def get_channel(self):
+        return self._channel
+
+    def get_address(self):
+        return ADDRESS
+
+    def handle_event(self, event):
+        self.handled.append(event)
+
+
+async def _settle():
+    """Let the freshly created stream task reach its first await."""
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+# --- one stream, not eleven -------------------------------------------------
+
+async def test_eleven_channels_share_one_stream(hass):
+    stream = _host_stream(hass, ADDRESS)
+    coordinators = [_Coordinator(i, ["VideoMotion"]) for i in range(11)]
+    for coordinator in coordinators:
+        stream.register(coordinator)
+    await _settle()
+
+    attaches = sum(c.client.attach_count for c in coordinators)
+    assert attaches == 1, "the device is still seeing one stream per channel"
+    assert len(dahua_module._HOST_STREAMS) == 1
+
+
+async def test_two_hosts_keep_their_own_streams(hass):
+    a = _host_stream(hass, ADDRESS)
+    b = _host_stream(hass, "10.0.0.2")
+    assert a is not b
+
+
+async def test_a_trailing_slash_is_the_same_host(hass):
+    assert _host_stream(hass, ADDRESS) is _host_stream(hass, ADDRESS + "/")
+
+
+# --- the refcount case that would break an NVR -----------------------------
+
+async def test_unloading_one_channel_leaves_the_others_streaming(hass):
+    """Reloading a single channel calls unload then setup on that entry only.
+
+    If that tore down the shared stream, the other ten channels would go deaf.
+    """
+    stream = _host_stream(hass, ADDRESS)
+    kept = [_Coordinator(i, ["VideoMotion"]) for i in range(10)]
+    leaving = _Coordinator(10, ["VideoMotion"])
+    for coordinator in [*kept, leaving]:
+        stream.register(coordinator)
+    await _settle()
+
+    emptied = await stream.unregister(leaving)
+    await _settle()
+
+    assert emptied is False
+    assert stream._task is not None and not stream._task.done()
+    stream.on_receive(MOTION_CH2, 0)
+    assert kept[2].handled, "the survivors stopped receiving events"
+
+
+async def test_the_last_channel_leaving_stops_the_stream(hass):
+    stream = _host_stream(hass, ADDRESS)
+    only = _Coordinator(0, ["VideoMotion"])
+    stream.register(only)
+    await _settle()
+    task = stream._task
+
+    await _release_host_stream(only)
+    await _settle()
+
+    assert task.cancelled() or task.done()
+    assert ADDRESS not in dahua_module._HOST_STREAMS
+
+
+async def test_the_stream_moves_off_a_departing_owner(hass):
+    """The stream borrows a client, and unloading an entry closes its session."""
+    stream = _host_stream(hass, ADDRESS)
+    owner = _Coordinator(0, ["VideoMotion"])
+    other = _Coordinator(1, ["VideoMotion"])
+    stream.register(owner)
+    stream.register(other)
+    await _settle()
+
+    owner.client.closed = True
+    await stream.unregister(owner)
+    await _settle()
+
+    assert stream._owner is other
+    assert other.client.attach_count >= 1, "did not re-attach on a live client"
+
+
+# --- dispatch ---------------------------------------------------------------
+
+async def test_an_event_reaches_only_its_own_channel(hass):
+    stream = _host_stream(hass, ADDRESS)
+    channels = [_Coordinator(i, ["VideoMotion"]) for i in range(4)]
+    for coordinator in channels:
+        stream.register(coordinator)
+    await _settle()
+
+    stream.on_receive(MOTION_CH2, 0)
+
+    assert len(channels[2].handled) == 1
+    assert channels[2].handled[0]["Code"] == "VideoMotion"
+    for i in (0, 1, 3):
+        assert channels[i].handled == [], f"channel {i} received another channel's event"
+
+
+async def test_an_unconfigured_channel_stays_silent(hass):
+    """Every coordinator used to discard these, so nothing fired. Keep it that way."""
+    stream = _host_stream(hass, ADDRESS)
+    only = _Coordinator(0, ["VideoMotion"])
+    stream.register(only)
+    await _settle()
+
+    stream.on_receive(MOTION_CH2, 0)  # index 2, and nobody is on channel 2
+
+    assert only.handled == []
+
+
+async def test_two_entries_on_one_channel_both_get_it(hass):
+    stream = _host_stream(hass, ADDRESS)
+    a, b = _Coordinator(2, ["VideoMotion"]), _Coordinator(2, ["VideoMotion"])
+    stream.register(a)
+    stream.register(b)
+    await _settle()
+
+    stream.on_receive(MOTION_CH2, 0)
+
+    assert len(a.handled) == 1 and len(b.handled) == 1
+
+
+async def test_each_channel_gets_its_own_copy(hass):
+    """handle_event mutates the event, so channels must not share one dict."""
+    stream = _host_stream(hass, ADDRESS)
+    a, b = _Coordinator(2, ["VideoMotion"]), _Coordinator(2, ["VideoMotion"])
+    stream.register(a)
+    stream.register(b)
+    await _settle()
+
+    stream.on_receive(MOTION_CH2, 0)
+
+    assert a.handled[0] is not b.handled[0]
+
+
+async def test_junk_on_the_wire_is_ignored(hass):
+    stream = _host_stream(hass, ADDRESS)
+    only = _Coordinator(0, ["VideoMotion"])
+    stream.register(only)
+    await _settle()
+
+    stream.on_receive(b"not an event at all", 0)
+
+    assert only.handled == []
+
+
+# --- the attach itself ------------------------------------------------------
+
+async def test_the_stream_attaches_with_every_channels_events(hass):
+    """Attaching with one channel's list would stop delivering another's codes."""
+    stream = _host_stream(hass, ADDRESS)
+    first = _Coordinator(0, ["VideoMotion"])
+    second = _Coordinator(1, ["CrossLineDetection", "AlarmLocal"])
+    stream.register(first)
+    stream.register(second)
+    await _settle()
+
+    attached = first.client.attached_with[-1]
+    assert set(attached) == {"VideoMotion", "CrossLineDetection", "AlarmLocal"}
+
+
+async def test_it_does_not_re_attach_when_nothing_new_is_wanted(hass):
+    stream = _host_stream(hass, ADDRESS)
+    first = _Coordinator(0, ["VideoMotion"])
+    stream.register(first)
+    await _settle()
+    before = first.client.attach_count
+
+    stream.register(_Coordinator(1, ["VideoMotion"]))
+    await _settle()
+
+    assert first.client.attach_count == before, "re-attached for no reason"
+
+
+async def test_it_re_attaches_when_a_channel_wants_something_new(hass):
+    stream = _host_stream(hass, ADDRESS)
+    first = _Coordinator(0, ["VideoMotion"])
+    stream.register(first)
+    await _settle()
+
+    stream.register(_Coordinator(1, ["FaceDetection"]))
+    await _settle()
+
+    assert "FaceDetection" in first.client.attached_with[-1]
+
+
+async def test_a_channel_with_no_events_starts_nothing(hass):
+    stream = DahuaHostEventStream(hass, ADDRESS)
+    stream.register(_Coordinator(0, []))
+    await _settle()
+
+    assert stream._task is None


### PR DESCRIPTION
Closes the gap `#603` describes ("Reconnect login burst exceeds camera's max connections"), and does what the code's own comment has been asking for.

Attaching to a Dahua event stream returns **every** channel's events, regardless of which channel asked. So an NVR with eleven channels was holding eleven identical streams and having ten of them throw each event away. `on_receive` said as much:

> This is a short term fix. Right now for NVRs this integration creates a thread per channel to listen to events. Every thread gets the same response. We need to discard events not for this channel. **Longer term work should create only a single thread per channel.**

**Builds on #614** and shares its branch, so the diff currently shows that commit too. It collapses once #614 merges.

### The change

`DahuaHostEventStream`, keyed by address, holds one stream, attaches with the **union** of every channel's configured events, and hands each event only to the channels registered for its index.

```
before                          after
11 persistent connections       1
11 hourly reconnections         1
10 of 11 events discarded       none discarded
```

The union is load-bearing: attaching with a single channel's list would silently stop delivering codes another channel had selected. A test covers it, and narrowing it back to the owner's own list fails two tests.

### Three deliberate decisions

**A channel nobody has configured stays silent.** Every coordinator used to discard those events, so a dispatch table that helpfully started firing them would be a behaviour change dressed as a fix.

**Each channel gets its own copy of the event.** `handle_event` writes the device name into it, so sharing one dict between channels would have them scribbling on each other's.

**The stream moves off a departing owner.** It borrows a client, and unloading an entry closes that client's session. Reloading a single channel calls unload then setup on that entry alone — tearing the shared stream down there would have made the other ten deaf. That is the case `test_unloading_one_channel_leaves_the_others_streaming` exists for, and it is the mistake this design most invites.

### Verification

In a `python:3.13` container matching CI:

```
suite: 159 passed   (144 after #614)
```

Fifteen new tests, including one asserting eleven registered channels produce exactly **one** attach.

### Note

`normalize_address` here duplicates the helper added in #613. They are the same function; whichever lands second should drop its copy.