### PR TITLE
Share one read per host instead of one per channel

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 
 from . import dahua_utils
-from .client import DahuaClient
+from .client import DahuaClient, clear_host_cache
 from .model_profiles import is_sdt4e425
 
 from .const import (
@@ -339,6 +339,7 @@ async def _release_connector(address: str) -> None:
     holder[1] -= 1
     if holder[1] <= 0:
         _HOST_CONNECTORS.pop(address, None)
+        clear_host_cache(address)
         await holder[0].close()
 
 

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -2,6 +2,7 @@
 import logging
 import socket
 import asyncio
+import time
 import aiohttp
 import async_timeout
 
@@ -59,6 +60,58 @@ def _digest_state(address: str, username: str) -> dict:
     if state is None:
         state = _HOST_DIGEST_STATE[key] = {}
     return state
+
+
+# Most of what a coordinator reads every poll carries no channel argument:
+# MotionDetect, DisableLinkage, DisableEventNotify, SmartMotionDetect,
+# Lighting_V2, VideoInMode, coaxialControlIO and ptz.cgi are all host-wide. An
+# NVR with eleven config entries therefore asks eleven times for byte-identical
+# answers, every cycle. Share them.
+#
+# The key is the URL, so nothing has to be classified by hand: a read that does
+# carry a channel has a different URL per channel and is never shared. Only
+# reads are cached; anything else drops the host's entries, because a write is
+# how these values change.
+HOST_CACHE_TTL_SECONDS = 5
+_HOST_CACHE: dict = {}
+
+# CGI reads are "action=getSomething". Everything else -- setConfig, reboot,
+# ptz control, door open -- is a write. Unrecognised is treated as a write,
+# which is the safe way round.
+READ_ACTION_PREFIX = "action=get"
+
+
+def _is_read(url: str) -> bool:
+    return READ_ACTION_PREFIX in url
+
+
+def clear_host_cache(address: str) -> None:
+    """Drop every shared read for this host.
+
+    Called on every write, since a write is the reason a value the device
+    reports would change, and when the last entry for the host goes away.
+    """
+    for key in [k for k in _HOST_CACHE if k[0] == address]:
+        del _HOST_CACHE[key]
+
+
+class _SharedRead:
+    """One read of one URL, shared by every entry on the host that wants it.
+
+    While the request is in flight, later callers wait on the same task rather
+    than issuing their own. Once it lands, it answers again for the TTL.
+    """
+
+    __slots__ = ("task", "expires_at")
+
+    def __init__(self, task: asyncio.Task) -> None:
+        self.task = task
+        self.expires_at = None  # stamped when the request lands
+
+    def is_usable(self, now: float) -> bool:
+        if not self.task.done():
+            return True
+        return self.expires_at is not None and now < self.expires_at
 
 
 SECURITY_LIGHT_TYPE = 1
@@ -1010,7 +1063,44 @@ class DahuaClient:
                     response.close()
 
     async def get(self, url: str, verify_ok=False) -> dict:
-        """Get information from the API."""
+        """Get information from the API, sharing the read across this host.
+
+        Two entries for one NVR asking the same question at the same moment get
+        one round trip between them, and a repeat inside the TTL gets none.
+        """
+        if not _is_read(url):
+            clear_host_cache(self._address)
+            return await self._request(url, verify_ok)
+
+        # Credentials are part of the key: entries for one host may be
+        # configured with different users, and a successful read is not
+        # otherwise scoped to who made it.
+        key = (self._address, self._username, url)
+        now = time.monotonic()
+        entry = _HOST_CACHE.get(key)
+        if entry is None or not entry.is_usable(now):
+            # Registering before the request starts is what makes this work:
+            # the per-host limiter queues callers inside _request, so by the
+            # time the first one has a slot the rest are already sharing it.
+            entry = _SharedRead(asyncio.ensure_future(self._request(url, verify_ok)))
+            _HOST_CACHE[key] = entry
+
+        # Shielded so that one entry's cancelled refresh -- a reload, a
+        # timeout -- does not take the read away from the others.
+        result = await asyncio.shield(entry.task)
+
+        # A read is only published once it lands. A failure leaves the expiry
+        # unset, so is_usable rejects it and the next poll asks the device
+        # again rather than being told no for the rest of the TTL. And a write
+        # that dropped this entry while it was in flight has already replaced
+        # it, so it settles for whoever is waiting without going back in.
+        if _HOST_CACHE.get(key) is entry and entry.expires_at is None:
+            entry.expires_at = time.monotonic() + HOST_CACHE_TTL_SECONDS
+
+        return dict(result)
+
+    async def _request(self, url: str, verify_ok=False) -> dict:
+        """Make the request. One caller per shared read reaches here."""
         url = self._base + url
         try:
             async with async_timeout.timeout(TIMEOUT_SECONDS), self._host_limit:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,3 +3,17 @@ import pytest
 
 # Re-export fixtures from pytest-homeassistant-custom-component
 pytest_plugins = ["pytest_homeassistant_custom_component"]
+
+
+@pytest.fixture(autouse=True)
+def _clear_shared_host_reads():
+    """The host read cache is module state and holds tasks.
+
+    A task left behind by one test belongs to that test's event loop, so this
+    has to be cleared for every test, not just the ones that know about it.
+    """
+    from custom_components.dahua import client as client_module
+
+    client_module._HOST_CACHE.clear()
+    yield
+    client_module._HOST_CACHE.clear()

--- a/tests/dahua/test_host_read_cache.py
+++ b/tests/dahua/test_host_read_cache.py
@@ -1,0 +1,284 @@
+"""Eleven channels of one NVR ask the same host-wide questions every poll."""
+
+import asyncio
+
+import pytest
+
+from custom_components.dahua import client as client_module
+from custom_components.dahua.client import (
+    HOST_CACHE_TTL_SECONDS,
+    DahuaClient,
+    clear_host_cache,
+)
+
+MOTION = "/cgi-bin/configManager.cgi?action=getConfig&name=MotionDetect"
+LINKAGE = "/cgi-bin/configManager.cgi?action=getConfig&name=DisableLinkage"
+PTZ = "/cgi-bin/ptz.cgi?action=getStatus"
+WRITE = "/cgi-bin/configManager.cgi?action=setConfig&MotionDetect[0].Enable=true"
+
+
+@pytest.fixture(autouse=True)
+def _clean_limiters():
+    client_module._HOST_LIMITS.clear()
+    yield
+    client_module._HOST_LIMITS.clear()
+
+
+class _Probe:
+    """Stands in for the session and counts the round trips actually made."""
+
+    def __init__(self, hold=0.02, body="key=value"):
+        self.hold = hold
+        self.body = body
+        self.urls = []
+
+    @property
+    def calls(self):
+        return len(self.urls)
+
+    async def request(self, method, url, headers=None, **kwargs):
+        self.urls.append(url)
+        await asyncio.sleep(self.hold)
+        return _Resp(self.body)
+
+
+class _Resp:
+    status = 200
+    headers = {}
+
+    def __init__(self, body):
+        self._body = body
+
+    def raise_for_status(self):
+        return None
+
+    async def text(self):
+        return self._body
+
+    def close(self):
+        return None
+
+
+def _client(probe, address="10.0.0.1", username="u"):
+    return DahuaClient(username, "p", address, 80, 554, probe)
+
+
+# --- the case this exists for ----------------------------------------------
+
+async def test_two_entries_asking_at_once_cost_one_round_trip():
+    probe = _Probe()
+    a, b = _client(probe), _client(probe)
+
+    await asyncio.gather(a.get(MOTION), b.get(MOTION))
+
+    assert probe.calls == 1, "each entry still made its own request"
+
+
+async def test_eleven_channels_make_one_request_between_them():
+    """The NVR shape: one host, one config entry per channel."""
+    probe = _Probe()
+    clients = [_client(probe) for _ in range(11)]
+
+    results = await asyncio.gather(*(c.get(MOTION) for c in clients))
+
+    assert probe.calls == 1
+    assert all(r == {"key": "value"} for r in results), "a waiter got nothing back"
+
+
+async def test_a_repeat_inside_the_ttl_costs_nothing():
+    probe = _Probe(hold=0)
+    c = _client(probe)
+
+    await c.get(MOTION)
+    await c.get(MOTION)
+
+    assert probe.calls == 1
+
+
+async def test_different_reads_are_not_confused_for_each_other():
+    probe = _Probe(hold=0)
+    c = _client(probe)
+
+    await c.get(MOTION)
+    await c.get(LINKAGE)
+
+    assert probe.calls == 2
+
+
+# --- what must never be shared ---------------------------------------------
+
+async def test_a_read_that_names_a_channel_is_not_shared():
+    """The key is the URL, so a per-channel read separates itself.
+
+    This is what keeps the cache correct when a hardcoded channel is fixed:
+    the URLs stop matching and the sharing stops with them.
+    """
+    probe = _Probe(hold=0)
+    c = _client(probe)
+
+    await c.async_get_config("Lighting[0][0]")
+    await c.async_get_config("Lighting[1][0]")
+
+    assert probe.calls == 2, "channel 1 was served channel 0's lighting"
+
+
+async def test_two_hosts_do_not_share_a_read():
+    probe = _Probe(hold=0)
+    a, b = _client(probe, "10.0.0.1"), _client(probe, "10.0.0.2")
+
+    await asyncio.gather(a.get(MOTION), b.get(MOTION))
+
+    assert probe.calls == 2
+
+
+async def test_two_users_on_one_host_do_not_share_a_read():
+    """Entries for one NVR can be configured with different credentials."""
+    probe = _Probe(hold=0)
+    a, b = _client(probe, username="alice"), _client(probe, username="bob")
+
+    await asyncio.gather(a.get(MOTION), b.get(MOTION))
+
+    assert probe.calls == 2
+
+
+async def test_a_write_is_never_served_from_the_cache():
+    probe = _Probe(hold=0)
+    c = _client(probe)
+
+    await c.get(WRITE)
+    await c.get(WRITE)
+
+    assert probe.calls == 2, "a write was answered without reaching the device"
+
+
+# --- invalidation -----------------------------------------------------------
+
+async def test_a_write_drops_what_the_host_had_cached():
+    """Otherwise a switch would spring back for the rest of the TTL."""
+    probe = _Probe(hold=0)
+    c = _client(probe)
+    await c.get(MOTION)
+
+    await c.get(WRITE)
+    await c.get(MOTION)
+
+    assert probe.urls[-1].endswith(MOTION), "the read after the write was stale"
+    assert probe.calls == 3
+
+
+async def test_one_entrys_write_invalidates_for_every_entry_on_the_host():
+    probe = _Probe(hold=0)
+    a, b = _client(probe), _client(probe)
+    await a.get(MOTION)
+
+    await b.get(WRITE)
+    await a.get(MOTION)
+
+    assert probe.calls == 3
+
+
+async def test_a_write_does_not_disturb_another_host():
+    probe = _Probe(hold=0)
+    a, b = _client(probe, "10.0.0.1"), _client(probe, "10.0.0.2")
+    await asyncio.gather(a.get(MOTION), b.get(MOTION))
+    before = probe.calls
+
+    await a.get(WRITE)
+    await b.get(MOTION)
+
+    assert probe.calls == before + 1, "the other host's read was thrown away too"
+
+
+async def test_a_write_while_a_read_is_in_flight_does_not_republish_it():
+    probe = _Probe(hold=0.05)
+    c = _client(probe)
+    reading = asyncio.create_task(c.get(MOTION))
+    await asyncio.sleep(0)
+
+    await c.get(WRITE)
+    await reading
+
+    await c.get(MOTION)
+    assert probe.calls == 3, "the in-flight read was published after the write"
+
+
+async def test_the_last_entry_leaving_forgets_the_host():
+    probe = _Probe(hold=0)
+    await _client(probe).get(MOTION)
+    assert client_module._HOST_CACHE
+
+    clear_host_cache("10.0.0.1")
+
+    assert not client_module._HOST_CACHE
+
+
+# --- failures ---------------------------------------------------------------
+
+class _FailingProbe(_Probe):
+    def __init__(self):
+        super().__init__(hold=0)
+        self.fail = True
+
+    async def request(self, method, url, headers=None, **kwargs):
+        self.urls.append(url)
+        if self.fail:
+            raise ConnectionError("device is not answering")
+        return _Resp(self.body)
+
+
+async def test_a_failed_read_is_not_remembered():
+    """A device that just came back must not be told no for the whole TTL."""
+    probe = _FailingProbe()
+    c = _client(probe)
+    with pytest.raises(Exception):
+        await c.get(MOTION)
+
+    probe.fail = False
+    assert await c.get(MOTION) == {"key": "value"}
+    assert probe.calls == 2
+
+
+async def test_every_waiter_sees_the_failure():
+    probe = _FailingProbe()
+    clients = [_client(probe) for _ in range(5)]
+
+    results = await asyncio.gather(
+        *(c.get(MOTION) for c in clients), return_exceptions=True
+    )
+
+    assert probe.calls == 1
+    assert all(isinstance(r, Exception) for r in results)
+
+
+async def test_one_cancelled_entry_does_not_take_the_read_away():
+    """A reload cancels that entry's refresh mid-poll. The others are fine."""
+    probe = _Probe(hold=0.05)
+    a, b = _client(probe), _client(probe)
+    leaving = asyncio.create_task(a.get(MOTION))
+    staying = asyncio.create_task(b.get(MOTION))
+    await asyncio.sleep(0)
+
+    leaving.cancel()
+
+    assert await staying == {"key": "value"}
+    assert probe.calls == 1
+
+
+# --- shape ------------------------------------------------------------------
+
+async def test_callers_cannot_scribble_on_each_others_result():
+    probe = _Probe(hold=0)
+    c = _client(probe)
+
+    first = await c.get(MOTION)
+    first["key"] = "tampered"
+    second = await c.get(MOTION)
+
+    assert second["key"] == "value"
+
+
+async def test_the_ttl_stays_under_the_shortest_poll_a_user_can_ask_for():
+    """A cache that outlives the poll interval would stop the data updating."""
+    from custom_components.dahua.const import MIN_SCAN_INTERVAL
+
+    assert 0 < HOST_CACHE_TTL_SECONDS < MIN_SCAN_INTERVAL

--- a/tests/dahua/test_shared_digest_state.py
+++ b/tests/dahua/test_shared_digest_state.py
@@ -12,7 +12,13 @@ from custom_components.dahua.client import (
 
 from .test_digest import PASSWORD, USER, FakeSession, nc_of
 
-URL = "/cgi-bin/magicBox.cgi?action=getSystemInfo"
+# Each client reads a *different* URL. Reads are shared per host by URL, so
+# eleven clients asking the same question would collapse to one request and
+# these tests would be measuring the read cache rather than the digest state.
+# In practice a channel makes nine different reads a poll anyway, and the
+# challenge is shared across all of them regardless.
+def _url(n):
+    return "/cgi-bin/magicBox.cgi?action=getSystemInfo&n=%d" % n
 
 
 @pytest.fixture(autouse=True)
@@ -37,10 +43,10 @@ def _probes(session):
 
 async def test_the_second_entry_does_not_re_probe():
     session = FakeSession()
-    await _client(session).get(URL)
+    await _client(session).get(_url(0))
     before = len(session.requests)
 
-    await _client(session).get(URL)
+    await _client(session).get(_url(1))
 
     assert len(session.requests) == before + 1, "the second entry took its own 401"
 
@@ -55,7 +61,7 @@ async def test_the_cold_start_burst_does_not_grow_with_the_channel_count():
     session = FakeSession()
     clients = [_client(session) for _ in range(11)]
 
-    await asyncio.gather(*(c.get(URL) for c in clients))
+    await asyncio.gather(*(c.get(_url(i)) for i, c in enumerate(clients)))
 
     assert len(_probes(session)) <= MAX_CONCURRENT_REQUESTS_PER_HOST, (
         "%d of 11 entries challenged the device" % len(_probes(session))
@@ -66,10 +72,11 @@ async def test_thirty_entries_cost_no_more_probes_than_eleven():
     """The property stated plainly: the burst is capped, not proportional."""
     small, large = FakeSession(), FakeSession()
 
-    await asyncio.gather(*(_client(small).get(URL) for _ in range(11)))
+    await asyncio.gather(*(_client(small).get(_url(i)) for i in range(11)))
     client_module._HOST_DIGEST_STATE.clear()
     client_module._HOST_LIMITS.clear()
-    await asyncio.gather(*(_client(large).get(URL) for _ in range(30)))
+    client_module._HOST_CACHE.clear()
+    await asyncio.gather(*(_client(large).get(_url(i)) for i in range(30)))
 
     assert len(_probes(large)) <= len(_probes(small))
 
@@ -78,7 +85,7 @@ async def test_every_caller_still_gets_its_answer():
     session = FakeSession(body="key=value")
     clients = [_client(session) for _ in range(11)]
 
-    results = await asyncio.gather(*(c.get(URL) for c in clients))
+    results = await asyncio.gather(*(c.get(_url(i)) for i, c in enumerate(clients)))
 
     assert all(r == {"key": "value"} for r in results)
 
@@ -116,8 +123,8 @@ async def test_the_count_keeps_rising_across_entries():
     session = FakeSession(strict_nc=True)
     clients = [_client(session) for _ in range(11)]
 
-    for c in clients:
-        await c.get(URL)
+    for i, c in enumerate(clients):
+        await c.get(_url(i))
 
     counts = [nc_of(r) for r in session.requests if nc_of(r)]
     assert len(set(counts)) == len(counts), "the same count was sent twice"
@@ -129,7 +136,7 @@ async def test_a_strict_device_accepts_every_entry():
     session = FakeSession(strict_nc=True, body="key=value")
     clients = [_client(session) for _ in range(11)]
 
-    results = await asyncio.gather(*(c.get(URL) for c in clients))
+    results = await asyncio.gather(*(c.get(_url(i)) for i, c in enumerate(clients)))
 
     assert all(r == {"key": "value"} for r in results)
 
@@ -140,11 +147,12 @@ async def test_a_rotated_nonce_is_picked_up_once_for_the_whole_host():
     """When the device moves on, one entry absorbs the stale 401, not eleven."""
     session = FakeSession()
     clients = [_client(session) for _ in range(11)]
-    await clients[0].get(URL)
+    await clients[0].get(_url(0))
 
     session.nonce = "nonce-2"
     already_sent = len(session.requests)
-    await asyncio.gather(*(c.get(URL) for c in clients))
+    client_module._HOST_CACHE.clear()
+    await asyncio.gather(*(c.get(_url(i)) for i, c in enumerate(clients)))
 
     after = session.requests[already_sent:]
     stale = [r for r in after
@@ -162,4 +170,4 @@ async def test_a_wrong_password_still_gives_up():
     c = _client(session)
 
     with pytest.raises(Exception):
-        await c.get(URL)
+        await c.get(_url(0))


### PR DESCRIPTION
Addresses `#577` "massive login/logout in NVR log".

Eight of the nine CGI calls a coordinator makes every poll carry **no channel argument at all**:

```
MotionDetect  DisableLinkage  DisableEventNotify  SmartMotionDetect
Lighting_V2   VideoInMode     coaxialControlIO    ptz.cgi
```

An NVR with eleven config entries is therefore asked the same eight questions eleven times a cycle, and answers identically eleven times. Only `Lighting[channel][mode]` differs between them.

### The key is the URL

That is the whole design, and it is why this is safe: nothing has to be classified by hand as host-wide or per-channel. A read that carries a channel already has a different URL per channel, so `Lighting[0][0]` and `Lighting[1][0]` separate themselves and can never be confused for one another. There is no list to maintain and no list to get wrong.

It also means that when the hardcoded `coaxialControlIO.cgi?action=getStatus&channel=1` is fixed to use the real channel, the URLs stop matching and the sharing on that URL stops with them — correctly, with no change here.

### What it does

- Two entries asking the same question at the same moment cost **one** round trip between them. Registration happens before the request starts, so callers queued on the per-host limiter from #606 share the slot rather than each waiting for their own.
- A repeat within a five second TTL costs none.
- Only reads are cached. Anything else is a write, and a write drops the host's entries — a write is how these values change.

I am not going to quote a request-count figure. HA restarts each coordinator's interval from its own last completion, so eleven entries drift apart by however long their setups took, and I have not measured the real alignment on a live NVR. What is certain: reads that overlap now cost one request, repeats within the TTL cost none, and the reduction scales with alignment up to about 5x in the aligned case.

### Three things it has to get right

**One entry's cancellation must not take the read from the other ten.** The shared read is a task every caller awaits under `asyncio.shield`. A reload or a timeout on one channel is not the other ten channels' problem — and #613's HTTPS repair flow reloads every entry on a host in sequence, so this is reachable.

**A failed read is not remembered.** The expiry is stamped only once the request lands, so a device that just came back is asked again rather than told no for the rest of the TTL.

**A write during an in-flight read wins.** The write drops the entry; the in-flight read settles for whoever is already waiting and does not put itself back. Otherwise a toggled switch would spring back for five seconds.

Callers get a copy, not the cached dict.

### Verification

```
suite: 342 passed   (324 before)
```

Eighteen new tests. Each property was proven by reintroducing the bug and confirming the right test fails:

| broken | tests that fail |
|---|---|
| coalescing removed | 6 |
| credentials dropped from the key | `test_two_users_on_one_host_do_not_share_a_read` |
| writes no longer invalidate | 3 |
| a failed read treated as usable | `test_a_failed_read_is_not_remembered` |
| `shield` removed | `test_one_cancelled_entry_does_not_take_the_read_away` |
| result returned by reference | `test_callers_cannot_scribble_on_each_others_result` |
| in-flight read republished after a write | `test_a_write_while_a_read_is_in_flight_does_not_republish_it` |

The first pass had a redundant failure-cleanup branch that no test could distinguish; it is gone rather than papered over with a test written to fit it.

Rebased onto main now that #615, #617, #618 and #619 have merged.

### Landing after #617 changed two things worth calling out

**The digest tests were quietly hollowed out, and are fixed here.** `test_shared_digest_state.py` had eleven clients read the *same* URL. With reads now shared by URL, those eleven collapse into one request — so the tests stopped observing the digest state at all. `test_the_count_keeps_rising_across_entries` was left with a single nonce count to check for monotonicity, and passed for that reason. Each client now reads a different URL, which is also what a real channel does: nine different reads a poll, one shared challenge across all of them. Reverting to per-client digest state still fails the same seven tests it failed on #617, so they still bite.

**The autouse fixture went in the wrong file.** It was a second `conftest.py` at the repo root, beside the real `tests/conftest.py`. It is now in `tests/conftest.py` where it belongs.
