### PR TITLE
Share the digest challenge across a host's config entries

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -37,6 +37,30 @@ def _host_limiter(address: str) -> asyncio.Semaphore:
     return limiter
 
 
+# The digest challenge a device hands out is not per connection: any request
+# with the right credentials can use it. Eleven config entries for one NVR were
+# each taking a 401 to get their own copy of the same challenge, at exactly the
+# moment the device is least able to spare the round trips.
+#
+# Sharing it also fixes the nonce count. Digest asks the client to send a
+# strictly increasing nc for a given nonce; eleven clients each counting from
+# one against the same nonce is what replay protection exists to reject.
+_HOST_DIGEST_STATE: dict = {}
+
+
+def _digest_state(address: str, username: str) -> dict:
+    """The digest state shared by every client for this host and user.
+
+    Keyed by user as well as host because the response digest is built from the
+    credentials, and entries for one NVR need not share them.
+    """
+    key = (address, username)
+    state = _HOST_DIGEST_STATE.get(key)
+    if state is None:
+        state = _HOST_DIGEST_STATE[key] = {}
+    return state
+
+
 SECURITY_LIGHT_TYPE = 1
 SIREN_TYPE = 2
 
@@ -61,11 +85,12 @@ class DahuaClient:
     ) -> None:
         self._username = username
         self._password = password
-        # One digest challenge shared by every request this client makes, so a
-        # call doesn't have to take a 401 before it can authenticate.
-        self._digest_state = {}
         # Strip trailing slashes from address to prevent malformed URLs like http://host/:80
         self._address = address.rstrip('/')
+        # One digest challenge shared by every request to this host, so a call
+        # doesn't have to take a 401 before it can authenticate -- and neither
+        # does the next config entry for the same NVR.
+        self._digest_state = _digest_state(self._address, username)
         self._session = session
         self._port = port
         self._rtsp_port = rtsp_port

--- a/tests/dahua/test_digest.py
+++ b/tests/dahua/test_digest.py
@@ -3,12 +3,23 @@ import asyncio
 import hashlib
 import re
 
+import pytest
+
+from custom_components.dahua import client as client_module
 from custom_components.dahua.client import DahuaClient
 from custom_components.dahua.digest import DigestAuth
 
 REALM = "DahuaRpc"
 USER = "admin"
 PASSWORD = "secret"
+
+
+@pytest.fixture(autouse=True)
+def _clean_host_digest_state():
+    """A challenge is now shared per host, so it outlives a test unless cleared."""
+    client_module._HOST_DIGEST_STATE.clear()
+    yield
+    client_module._HOST_DIGEST_STATE.clear()
 
 
 def _params(header: str) -> dict:

--- a/tests/dahua/test_shared_digest_state.py
+++ b/tests/dahua/test_shared_digest_state.py
@@ -1,0 +1,165 @@
+"""Eleven config entries for one NVR should not each take a 401 to get going."""
+
+import asyncio
+
+import pytest
+
+from custom_components.dahua import client as client_module
+from custom_components.dahua.client import (
+    MAX_CONCURRENT_REQUESTS_PER_HOST,
+    DahuaClient,
+)
+
+from .test_digest import PASSWORD, USER, FakeSession, nc_of
+
+URL = "/cgi-bin/magicBox.cgi?action=getSystemInfo"
+
+
+@pytest.fixture(autouse=True)
+def _clean_host_state():
+    client_module._HOST_DIGEST_STATE.clear()
+    client_module._HOST_LIMITS.clear()
+    yield
+    client_module._HOST_DIGEST_STATE.clear()
+    client_module._HOST_LIMITS.clear()
+
+
+def _client(session, address="10.0.0.1", username=USER, password=PASSWORD):
+    return DahuaClient(username, password, address, 80, 554, session)
+
+
+def _probes(session):
+    """Requests that went out with no Authorization header."""
+    return [r for r in session.requests if "AUTHORIZATION" not in r["headers"]]
+
+
+# --- the burst this exists to remove ---------------------------------------
+
+async def test_the_second_entry_does_not_re_probe():
+    session = FakeSession()
+    await _client(session).get(URL)
+    before = len(session.requests)
+
+    await _client(session).get(URL)
+
+    assert len(session.requests) == before + 1, "the second entry took its own 401"
+
+
+async def test_the_cold_start_burst_does_not_grow_with_the_channel_count():
+    """One NVR, one config entry per channel, all starting up together.
+
+    Entries that are already in flight when the first challenge lands cannot
+    use it, so this is not one probe -- it is bounded by how many requests the
+    host limiter lets run at once, whether that is eleven channels or thirty.
+    """
+    session = FakeSession()
+    clients = [_client(session) for _ in range(11)]
+
+    await asyncio.gather(*(c.get(URL) for c in clients))
+
+    assert len(_probes(session)) <= MAX_CONCURRENT_REQUESTS_PER_HOST, (
+        "%d of 11 entries challenged the device" % len(_probes(session))
+    )
+
+
+async def test_thirty_entries_cost_no_more_probes_than_eleven():
+    """The property stated plainly: the burst is capped, not proportional."""
+    small, large = FakeSession(), FakeSession()
+
+    await asyncio.gather(*(_client(small).get(URL) for _ in range(11)))
+    client_module._HOST_DIGEST_STATE.clear()
+    client_module._HOST_LIMITS.clear()
+    await asyncio.gather(*(_client(large).get(URL) for _ in range(30)))
+
+    assert len(_probes(large)) <= len(_probes(small))
+
+
+async def test_every_caller_still_gets_its_answer():
+    session = FakeSession(body="key=value")
+    clients = [_client(session) for _ in range(11)]
+
+    results = await asyncio.gather(*(c.get(URL) for c in clients))
+
+    assert all(r == {"key": "value"} for r in results)
+
+
+# --- what must not be shared ------------------------------------------------
+
+async def test_two_hosts_do_not_share_a_challenge():
+    """A challenge is the device's, and a nonce from one is nothing to another."""
+    a, b = _client(FakeSession()), _client(FakeSession(), "10.0.0.2")
+
+    assert a._digest_state is not b._digest_state
+
+
+async def test_two_users_on_one_host_do_not_share_a_challenge():
+    """The response digest is built from the credentials, so the count that
+    goes with a nonce belongs to the user, not just the host."""
+    session = FakeSession()
+    a = _client(session, username="alice")
+    b = _client(session, username="bob")
+
+    assert a._digest_state is not b._digest_state
+
+
+async def test_a_trailing_slash_is_the_same_host():
+    assert _client(FakeSession())._digest_state is (
+        _client(FakeSession(), "10.0.0.1/")._digest_state
+    )
+
+
+# --- the count, which is why the whole state is shared and not just the nonce
+
+async def test_the_count_keeps_rising_across_entries():
+    """Digest asks for a strictly increasing nc per nonce. Eleven clients each
+    counting from one is exactly what replay protection rejects."""
+    session = FakeSession(strict_nc=True)
+    clients = [_client(session) for _ in range(11)]
+
+    for c in clients:
+        await c.get(URL)
+
+    counts = [nc_of(r) for r in session.requests if nc_of(r)]
+    assert len(set(counts)) == len(counts), "the same count was sent twice"
+    assert counts == sorted(counts)
+
+
+async def test_a_strict_device_accepts_every_entry():
+    """The end of the same story: no channel is refused for replaying a count."""
+    session = FakeSession(strict_nc=True, body="key=value")
+    clients = [_client(session) for _ in range(11)]
+
+    results = await asyncio.gather(*(c.get(URL) for c in clients))
+
+    assert all(r == {"key": "value"} for r in results)
+
+
+# --- recovery ---------------------------------------------------------------
+
+async def test_a_rotated_nonce_is_picked_up_once_for_the_whole_host():
+    """When the device moves on, one entry absorbs the stale 401, not eleven."""
+    session = FakeSession()
+    clients = [_client(session) for _ in range(11)]
+    await clients[0].get(URL)
+
+    session.nonce = "nonce-2"
+    already_sent = len(session.requests)
+    await asyncio.gather(*(c.get(URL) for c in clients))
+
+    after = session.requests[already_sent:]
+    stale = [r for r in after
+             if "nonce-1" in r["headers"].get("AUTHORIZATION", "")]
+    assert len(stale) <= MAX_CONCURRENT_REQUESTS_PER_HOST, (
+        "%d of 11 entries each rediscovered the new nonce" % len(stale)
+    )
+    assert all("nonce-2" in r["headers"].get("AUTHORIZATION", "")
+               for r in after[-11:]), "the host did not settle on the new nonce"
+
+
+async def test_a_wrong_password_still_gives_up():
+    """Shared state must not turn one refusal into an endless retry."""
+    session = FakeSession(password="not-the-password")
+    c = _client(session)
+
+    with pytest.raises(Exception):
+        await c.get(URL)


### PR DESCRIPTION
A digest challenge is the **device's**, not the connection's: any request carrying the right credentials can use it. But eleven config entries for one NVR each held their own copy of `_digest_state`, so each one took a 401 to discover the same challenge — at exactly the moment the device is least able to spare the round trips. This keys that state by host and user instead.

### Sharing the counter is the point, not a side effect

Digest asks the client to send a **strictly increasing `nc`** for a given nonce. Eleven clients each counting from `00000001` against the same nonce is precisely what replay protection exists to reject.

So the whole state is shared, not just the challenge. Handing out the nonce while every client kept its own counter would *manufacture* the collision that doesn't happen today — today each client gets its own nonce from its own probe, so the duplicate `(nonce, nc)` pairs never arise.

The test suite's `FakeSession` already had a `strict_nc` mode that refuses a replayed count. Keeping the counter per-client while sharing the challenge makes such a device **refuse channels**: `test_a_strict_device_accepts_every_entry` fails.

No lock is needed. `_build_digest_header` increments and reads the count with no `await` in between, so on one event loop the assignment is atomic.

Keyed by `(host, user)` because the response digest is built from the credentials, and entries for one NVR need not share them.

### Two things this does not claim

**The cold start is not reduced to one probe.** Entries already in flight when the first challenge lands cannot use it, so the burst is bounded by `MAX_CONCURRENT_REQUESTS_PER_HOST` from #606 — not by the number of channels. I wrote the test asserting one probe, watched it fail with two, and changed the assertion to the property that is actually true and actually useful: the burst is *capped*, not proportional. `test_thirty_entries_cost_no_more_probes_than_eleven` states it directly. A lock to squeeze two down to one is not worth putting in the auth path.

**The state is not dropped when a host's last entry unloads.** It is four short strings, and a stale challenge costs exactly one 401 to correct. Wiring it into `_release_connector` would collide with #616 for no benefit.

### Verification

```
suite: 147 passed   (136 before)
```

Eleven new tests. Each property proven by reintroducing the bug:

| broken | tests that fail |
|---|---|
| back to per-client state | 7 |
| user dropped from the key | `test_two_users_on_one_host_do_not_share_a_challenge` |
| keyed on the un-stripped address | `test_a_trailing_slash_is_the_same_host` |
| counter per client, challenge shared | `test_the_count_keeps_rising_across_entries`, `test_a_strict_device_accepts_every_entry` |

`test_digest.py` gains an autouse fixture clearing the registry — the challenge now outlives a test.

Independent of #614, #615 and #616.