### PR TITLE
Read this channel's day/night profile, not channel one's

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -481,9 +481,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 try:
                     mode_data = await self.client.async_get_video_in_mode()
                     data.update(mode_data)
-                    self._profile_mode = mode_data.get("table.VideoInMode[0].Config[0]", "0")
-                    if not self._profile_mode:
-                        self._profile_mode = "0"
+                    self._profile_mode = self.read_profile_mode(mode_data)
                 except Exception as exception:
                     # I believe this API is missing on some cameras so we'll just ignore it and move on
                     _LOGGER.debug("Could not get profile mode", exc_info=exception)
@@ -897,6 +895,22 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     def is_security_light_on(self) -> bool:
         """Return true if the security light is on. This is the red/blue flashing light"""
         return self.get_status_value("WhiteLight").lower() == "on"
+
+    def read_profile_mode(self, mode_data: dict) -> str:
+        """Picks this channel's day/night profile out of the VideoInMode table.
+
+        The read is host-wide -- getConfig&name=VideoInMode returns a row per
+        channel -- so an NVR channel has to take its own row. Reading row 0 for
+        every channel gave the whole device channel 1's day/night profile, and
+        that profile is then what selects which Lighting[channel][profile] the
+        IR light is read from and written to.
+
+        Falls back to row 0, which is all a single-channel camera returns.
+        """
+        mode = mode_data.get("table.VideoInMode[{0}].Config[0]".format(self._channel))
+        if mode is None:
+            mode = mode_data.get("table.VideoInMode[0].Config[0]", "0")
+        return mode or "0"
 
     def get_profile_mode(self) -> str:
         # profile_mode 0=day, 1=night, 2=scene

--- a/tests/dahua/test_profile_mode.py
+++ b/tests/dahua/test_profile_mode.py
@@ -1,0 +1,93 @@
+"""VideoInMode is one host-wide read with a row per channel."""
+
+import pytest
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+# What an eleven channel NVR returns. Channel 0 is on the day profile, most of
+# the rest are on night, and channel 4 has been put on the scene profile.
+NVR_TABLE = {
+    "table.VideoInMode[0].Config[0]": "0",
+    "table.VideoInMode[0].Mode": "0",
+    "table.VideoInMode[1].Config[0]": "1",
+    "table.VideoInMode[2].Config[0]": "1",
+    "table.VideoInMode[3].Config[0]": "1",
+    "table.VideoInMode[4].Config[0]": "2",
+    "table.VideoInMode[5].Config[0]": "1",
+    "table.VideoInMode[6].Config[0]": "1",
+    "table.VideoInMode[7].Config[0]": "1",
+    "table.VideoInMode[8].Config[0]": "1",
+    "table.VideoInMode[9].Config[0]": "1",
+    "table.VideoInMode[10].Config[0]": "0",
+}
+
+# A single camera returns one row, and that row is row 0.
+SINGLE_CAMERA_TABLE = {
+    "table.VideoInMode[0].Config[0]": "1",
+    "table.VideoInMode[0].Mode": "0",
+}
+
+
+def _coordinator(channel):
+    coordinator = object.__new__(DahuaDataUpdateCoordinator)
+    coordinator._channel = channel
+    return coordinator
+
+
+@pytest.mark.parametrize("channel,expected", [
+    (0, "0"),
+    (1, "1"),
+    (4, "2"),
+    (10, "0"),
+])
+def test_each_channel_reads_its_own_row(channel, expected):
+    """Reading row 0 for every channel gave the whole NVR channel 1's profile."""
+    assert _coordinator(channel).read_profile_mode(NVR_TABLE) == expected
+
+
+def test_the_profile_is_not_the_same_for_every_channel():
+    """The bug stated as a property: eleven channels are not one answer."""
+    modes = {_coordinator(c).read_profile_mode(NVR_TABLE) for c in range(11)}
+
+    assert len(modes) > 1
+
+
+# --- a single camera must be untouched --------------------------------------
+
+def test_a_single_camera_still_reads_row_zero():
+    assert _coordinator(0).read_profile_mode(SINGLE_CAMERA_TABLE) == "1"
+
+
+def test_a_channel_with_no_row_of_its_own_falls_back_to_row_zero():
+    """Firmware that reports one row for a device configured on channel 3."""
+    assert _coordinator(3).read_profile_mode(SINGLE_CAMERA_TABLE) == "1"
+
+
+# --- the old defaults ------------------------------------------------------
+
+def test_an_empty_table_is_the_day_profile():
+    assert _coordinator(0).read_profile_mode({}) == "0"
+    assert _coordinator(7).read_profile_mode({}) == "0"
+
+
+def test_a_blank_value_is_the_day_profile():
+    """The device answering with nothing must not become an empty profile,
+    which would then be interpolated into Lighting[channel][]."""
+    assert _coordinator(0).read_profile_mode(
+        {"table.VideoInMode[0].Config[0]": ""}
+    ) == "0"
+
+
+def test_a_blank_value_on_this_channel_does_not_fall_through_to_row_zero():
+    """A row that exists and is blank is this channel's answer, not row 0's."""
+    table = dict(NVR_TABLE)
+    table["table.VideoInMode[4].Config[0]"] = ""
+
+    assert _coordinator(4).read_profile_mode(table) == "0"
+
+
+def test_the_profile_is_always_a_string():
+    """It is interpolated straight into a config name, so it cannot be None."""
+    for table in (NVR_TABLE, SINGLE_CAMERA_TABLE, {}):
+        for channel in (0, 4, 10):
+            assert isinstance(_coordinator(channel).read_profile_mode(table), str)


### PR DESCRIPTION
Part of the `#310` / `#233` cluster.

`getConfig&name=VideoInMode` is a **host-wide** read: it returns a row per channel.

```
table.VideoInMode[0].Config[0]=0     <- channel 1, on the day profile
table.VideoInMode[1].Config[0]=1     <- channel 2, on night
...
table.VideoInMode[4].Config[0]=2     <- channel 5, on scene
```

Every channel was taking row `[0]`, so on an NVR all eleven channels believed they were on channel 1's day/night profile. The write at `client.py:518` already uses the real channel — `setConfig&VideoInMode[{channel}].Config[0]` — so only the read was wrong.

### It is not a cosmetic value

The profile is what selects which lighting config the IR light is read from and written to:

```python
await self.client.async_get_config_lighting(self._channel, self._profile_mode)
#                                    Lighting[channel][profile]
```

A channel actually on night, told it was on day, had its **day** profile adjusted instead — the brightness change lands on a profile the camera is not currently using, so the light appears not to respond.

### Single cameras are untouched

One row is all a single camera returns, and that row is row `[0]`. The fallback keeps that path identical, including for firmware that reports one row for a device configured on a non-zero channel.

The read itself is unchanged and still one request, so this composes with the per-host read sharing in #616: one fetch for the device, each channel indexing its own row out of it.

### Verification

```
suite: 147 passed   (136 before)
```

Eleven tests against a canned eleven-channel table. Each behaviour proven by reintroducing the bug:

| broken | tests that fail |
|---|---|
| back to row 0 for every channel | 3 |
| fallback to row 0 removed | `test_a_channel_with_no_row_of_its_own_falls_back_to_row_zero` |
| a blank profile passed through | 2 |

### The other channel-arithmetic bug is deliberately not here

`client.py:197` reads `coaxialControlIO.cgi?action=getStatus&channel=1` — hardcoded — while `client.py:743` writes with `&channel={channel}`. It looks like the same bug and is not, for two reasons:

1. **I do not know which side is wrong.** The write sends `get_channel()`, which is 0-based; the read sends `1`. If the endpoint is 1-based then the *write* is the defect, and "making the read match the write" would change `channel=1` to `channel=0` for every existing single-camera install on a guess.
2. **The response carries no channel at all** — `status.status.Speaker=Off`. So `is_siren_on()` is reading a flat value whatever the URL says, and the response shape may be the actual defect rather than the URL.

Resolving it needs one readback from a real NVR on a non-zero channel, not a reading of this repo. It is left alone rather than half-fixed.