### PR TITLE
Give back what a failed setup took

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -17,7 +17,6 @@ from aiohttp import ClientError, ClientResponseError, ClientSession, TCPConnecto
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
@@ -130,11 +129,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     coordinator = DahuaDataUpdateCoordinator(hass, entry=entry, events=events, address=address, port=port,
                                              rtsp_port=rtsp_port, username=username, password=password, name=name,
                                              channel=channel, use_https=use_https)
-    await coordinator.async_config_entry_first_refresh()
-
-    if not coordinator.last_update_success:
-        _LOGGER.warning("dahua async_setup_entry for init, data not ready")
-        raise ConfigEntryNotReady
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception:
+        # The coordinator opens a session and takes a reference on the host's
+        # shared connection pool in its constructor, and only async_stop gives
+        # them back. Nothing reaches async_stop unless the coordinator makes it
+        # into hass.data, which a failed setup never does -- so without this,
+        # every retry against a device that is not answering leaks one session
+        # and one reference, forever, and Home Assistant retries forever.
+        await coordinator.async_stop()
+        raise
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
@@ -144,7 +149,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             coordinator.platforms.append(platform)
             await hass.config_entries.async_forward_entry_setups(entry, [platform])
 
-    entry.add_update_listener(async_reload_entry)
+    # Wrapped, because unloading does not clear an entry's update listeners.
+    # A plain add_update_listener leaves one behind on every reload, and then a
+    # single options change fires as many reloads as the entry has ever had --
+    # against an NVR, exactly the burst that wedges it.
+    entry.async_on_unload(entry.add_update_listener(async_reload_entry))
 
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.async_stop)
@@ -324,7 +333,10 @@ def _acquire_connector(address: str) -> TCPConnector:
     address = normalize_address(address)
     holder = _HOST_CONNECTORS.get(address)
     if holder is None or holder[0].closed:
-        holder = [TCPConnector(enable_cleanup_closed=True, ssl=SSL_CONTEXT), 0]
+        # enable_cleanup_closed is deliberately not set: aiohttp ignores it on
+        # every Python that Home Assistant now runs on, and warns once per
+        # connector in the user's log for the trouble.
+        holder = [TCPConnector(ssl=SSL_CONTEXT), 0]
         _HOST_CONNECTORS[address] = holder
     holder[1] += 1
     return holder[0]

--- a/tests/dahua/probe2.py
+++ b/tests/dahua/probe2.py
@@ -1,0 +1,29 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from custom_components import dahua as dahua_module
+from custom_components.dahua.const import DOMAIN
+
+DATA = {"username": "u", "password": "p", "address": "10.9.9.9", "port": 80,
+        "rtsp_port": 554, "name": "Cam", "channel": 0, "events": ["VideoMotion"]}
+
+
+async def test_listeners_accumulate_across_reloads(hass):
+    entry = MockConfigEntry(domain=DOMAIN, data=DATA)
+    entry.add_to_hass(hass)
+
+    with patch.object(dahua_module.DahuaDataUpdateCoordinator, "_async_update_data",
+                      return_value={"serialNumber": "S1"}), \
+         patch.object(dahua_module.DahuaDataUpdateCoordinator, "async_start_event_listener"), \
+         patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()), \
+         patch.object(hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True)):
+        for cycle in range(4):
+            await dahua_module.async_setup_entry(hass, entry)
+            await dahua_module.async_unload_entry(hass, entry)
+            print("after reload %d: update_listeners=%d, connector_refcount=%d"
+                  % (cycle + 1, len(entry.update_listeners),
+                     dahua_module._HOST_CONNECTORS.get("10.9.9.9", [None, 0])[1]))
+
+    assert len(entry.update_listeners) <= 1, (
+        "%d listeners registered: one options change now fires %d reloads"
+        % (len(entry.update_listeners), len(entry.update_listeners)))

--- a/tests/dahua/probe_leak.py
+++ b/tests/dahua/probe_leak.py
@@ -1,0 +1,65 @@
+"""Does a failed setup give the shared connector back?"""
+import pytest
+from unittest.mock import patch
+
+from homeassistant.exceptions import ConfigEntryNotReady
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import dahua as dahua_module
+from custom_components.dahua.const import DOMAIN
+
+DATA = {
+    "username": "u", "password": "p", "address": "10.9.9.9",
+    "port": 80, "rtsp_port": 554, "name": "Cam", "channel": 0,
+    "events": ["VideoMotion"],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    dahua_module._HOST_CONNECTORS.clear()
+    yield
+    dahua_module._HOST_CONNECTORS.clear()
+
+
+def _refcount(address="10.9.9.9"):
+    holder = dahua_module._HOST_CONNECTORS.get(address)
+    return holder[1] if holder else 0
+
+
+async def test_a_failed_setup_gives_the_connector_back(hass):
+    entry = MockConfigEntry(domain=DOMAIN, data=DATA)
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        dahua_module.DahuaDataUpdateCoordinator, "_async_update_data",
+        side_effect=Exception("device is wedged"),
+    ):
+        for attempt in range(5):
+            try:
+                await dahua_module.async_setup_entry(hass, entry)
+            except (ConfigEntryNotReady, Exception):
+                pass
+            print("after attempt %d: refcount=%d" % (attempt + 1, _refcount()))
+
+    assert _refcount() == 0, "five failed setups leaked %d references" % _refcount()
+
+
+async def test_the_update_listener_is_removed_on_unload(hass):
+    entry = MockConfigEntry(domain=DOMAIN, data=DATA)
+    entry.add_to_hass(hass)
+
+    with patch.object(
+        dahua_module.DahuaDataUpdateCoordinator, "_async_update_data",
+        return_value={"serialNumber": "S1"},
+    ), patch.object(dahua_module.DahuaDataUpdateCoordinator, "async_start_event_listener"):
+        for cycle in range(4):
+            await dahua_module.async_setup_entry(hass, entry)
+            print("after setup %d: listeners=%d" % (cycle + 1, len(entry.update_listeners)))
+            await dahua_module.async_unload_entry(hass, entry)
+            print("after unload %d: listeners=%d" % (cycle + 1, len(entry.update_listeners)))
+
+    assert len(entry.update_listeners) <= 1, (
+        "%d listeners are registered; one options change fires that many reloads"
+        % len(entry.update_listeners)
+    )

--- a/tests/dahua/test_setup_lifecycle.py
+++ b/tests/dahua/test_setup_lifecycle.py
@@ -1,0 +1,248 @@
+"""Setting an entry up has to undo itself when it fails.
+
+The coordinator takes two things in its constructor -- an aiohttp session, and
+a reference on the connection pool shared by every entry for the host -- and
+only async_stop gives them back. Nothing reaches async_stop unless the
+coordinator makes it into hass.data, and a failed setup never gets that far.
+
+Home Assistant retries a failed setup forever, so anything not given back here
+is not leaked once. It is leaked once per retry, for as long as the device is
+down, which on an eleven-channel NVR is eleven times over.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.exceptions import ConfigEntryNotReady
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components import dahua as dahua_module
+from custom_components.dahua.const import DOMAIN
+
+ADDRESS = "10.9.9.9"
+DATA = {
+    "username": "u",
+    "password": "p",
+    "address": ADDRESS,
+    "port": 80,
+    "rtsp_port": 554,
+    "name": "Cam",
+    "channel": 0,
+    "events": ["VideoMotion"],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_connectors():
+    dahua_module._HOST_CONNECTORS.clear()
+    yield
+    dahua_module._HOST_CONNECTORS.clear()
+
+
+def _refcount(address=ADDRESS):
+    holder = dahua_module._HOST_CONNECTORS.get(address)
+    return holder[1] if holder else 0
+
+
+def _entry(hass, address=ADDRESS):
+    entry = MockConfigEntry(domain=DOMAIN, data={**DATA, "address": address})
+    entry.add_to_hass(hass)
+    return entry
+
+
+def _wedged():
+    """A device that answers nothing, which is what makes setup fail."""
+    return patch.object(
+        dahua_module.DahuaDataUpdateCoordinator,
+        "_async_update_data",
+        side_effect=Exception("device is not answering"),
+    )
+
+
+def _working():
+    return patch.object(
+        dahua_module.DahuaDataUpdateCoordinator,
+        "_async_update_data",
+        return_value={"serialNumber": "S1"},
+    )
+
+
+def _no_platforms(hass):
+    return (
+        patch.object(dahua_module.DahuaDataUpdateCoordinator, "async_start_event_listener"),
+        patch.object(hass.config_entries, "async_forward_entry_setups", AsyncMock()),
+        patch.object(
+            hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True)
+        ),
+    )
+
+
+async def _try_setup(hass, entry):
+    try:
+        await dahua_module.async_setup_entry(hass, entry)
+    except Exception:
+        return False
+    return True
+
+
+# --- the failed setup -------------------------------------------------------
+
+async def test_a_failed_setup_gives_the_connector_back(hass):
+    entry = _entry(hass)
+
+    with _wedged():
+        assert await _try_setup(hass, entry) is False
+
+    assert _refcount() == 0
+
+
+async def test_retrying_a_wedged_device_does_not_accumulate_references(hass):
+    """Home Assistant retries forever. This is the shape of the leak."""
+    entry = _entry(hass)
+
+    with _wedged():
+        for _ in range(20):
+            await _try_setup(hass, entry)
+
+    assert _refcount() == 0, "twenty retries held %d references" % _refcount()
+
+
+async def test_a_failed_setup_closes_its_session(hass):
+    """An unclosed session is not just memory -- aiohttp logs it, loudly."""
+    entry = _entry(hass)
+    sessions = []
+    real_init = dahua_module.DahuaDataUpdateCoordinator.__init__
+
+    def record(self, *args, **kwargs):
+        real_init(self, *args, **kwargs)
+        sessions.append(self._session)
+
+    with _wedged(), patch.object(
+        dahua_module.DahuaDataUpdateCoordinator, "__init__", record
+    ):
+        await _try_setup(hass, entry)
+
+    assert sessions and all(s.closed for s in sessions)
+
+
+async def test_a_failed_setup_leaves_no_pool_behind_for_the_host(hass):
+    entry = _entry(hass)
+
+    with _wedged():
+        await _try_setup(hass, entry)
+
+    assert ADDRESS not in dahua_module._HOST_CONNECTORS
+
+
+async def test_one_channel_failing_does_not_close_the_pool_for_the_others(hass):
+    """Ten channels of an NVR are up and the eleventh is not. The failure must
+    give back its own reference and nobody else's."""
+    working, failing = _entry(hass), _entry(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _working(), starts, forward, unload:
+        assert await _try_setup(hass, working) is True
+    assert _refcount() == 1
+
+    with _wedged():
+        assert await _try_setup(hass, failing) is False
+
+    assert _refcount() == 1
+    holder = dahua_module._HOST_CONNECTORS[ADDRESS]
+    assert not holder[0].closed, "the surviving channel lost its connection pool"
+
+
+async def test_the_error_still_reaches_home_assistant(hass):
+    """Cleaning up must not swallow the failure.
+
+    Naming the exception matters: asserting merely that something was raised
+    is satisfied by any incidental failure further down setup, and would pass
+    against a version that cleaned up and then carried on."""
+    entry = _entry(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _wedged(), starts, forward, unload:
+        with pytest.raises(ConfigEntryNotReady):
+            await dahua_module.async_setup_entry(hass, entry)
+
+
+async def test_a_failed_setup_is_not_published_to_hass_data(hass):
+    """A coordinator left in hass.data after cleanup is a stopped one that
+    every platform would then be handed."""
+    entry = _entry(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _wedged(), starts, forward, unload:
+        await _try_setup(hass, entry)
+
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
+
+
+# --- the successful setup, unchanged ---------------------------------------
+
+async def test_a_successful_setup_holds_its_reference(hass):
+    entry = _entry(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _working(), starts, forward, unload:
+        assert await _try_setup(hass, entry) is True
+
+    assert _refcount() == 1
+
+
+async def test_unloading_gives_it_back(hass):
+    entry = _entry(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _working(), starts, forward, unload:
+        await _try_setup(hass, entry)
+        await dahua_module.async_unload_entry(hass, entry)
+
+    assert _refcount() == 0
+
+
+# --- the update listener ----------------------------------------------------
+
+async def test_reloading_does_not_leave_a_listener_behind(hass, enable_custom_integrations):
+    """An entry's update listeners are not cleared on unload, so an unwrapped
+    add_update_listener leaves one on every reload -- and then one options
+    change fires as many reloads as the entry has ever had.
+
+    Driven through Home Assistant's own setup and unload rather than by calling
+    this integration's functions, because it is Home Assistant that runs the
+    async_on_unload callbacks and that is the half being tested."""
+    entry = _entry(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _working(), starts, forward, unload:
+        for _ in range(5):
+            assert await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+            assert await hass.config_entries.async_unload(entry.entry_id)
+            await hass.async_block_till_done()
+
+    assert len(entry.update_listeners) <= 1, (
+        "%d listeners registered: one options change would fire %d reloads"
+        % (len(entry.update_listeners), len(entry.update_listeners))
+    )
+
+
+async def test_a_loaded_entry_still_reloads_on_an_options_change(hass):
+    """The listener has to survive being wrapped."""
+    entry = _entry(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _working(), starts, forward, unload:
+        await _try_setup(hass, entry)
+
+    assert len(entry.update_listeners) == 1
+    assert entry.update_listeners[0] is dahua_module.async_reload_entry
+
+
+async def test_a_failed_setup_registers_no_listener_at_all(hass):
+    entry = _entry(hass)
+
+    with _wedged():
+        await _try_setup(hass, entry)
+
+    assert entry.update_listeners == []


### PR DESCRIPTION
A critique of the shared connector from #608, and the fix.

The pooling itself is sound — `connector_owner=False` with a refcount is the right shape, and on the successful path the count returns to zero exactly as intended. The problem is where the reference is taken.

### The reference is taken in a constructor and returned from `async_stop`

```python
coordinator = DahuaDataUpdateCoordinator(...)   # opens a session, +1 on the pool
await coordinator.async_config_entry_first_refresh()   # raises here
hass.data[DOMAIN][entry.entry_id] = coordinator        # never reached
```

`async_stop` is the only thing that gives either back, and nothing reaches `async_stop` unless the coordinator makes it into `hass.data` — which a failed setup never does. So the invariant "constructed ⇒ eventually stopped" simply does not hold.

Home Assistant retries a failed setup **forever**. So this is not one leak. It is one session and one pool reference per retry, for as long as the device is down, and an eleven-channel NVR is eleven entries all retrying together. The count never returns to zero, so the pool is never closed. Measured before the fix:

```
after attempt 1: refcount=1
after attempt 2: refcount=2
...
after attempt 5: refcount=5
ERROR:homeassistant:Error doing job: Unclosed client session   (x5)
```

Those `Unclosed client session` lines go to the user's real log. This is the exact scenario the pooling was built for — a device that stops answering — so the failure path is the one that matters most, and it is the one that was not covered.

### Two more, found looking for the first

**`add_update_listener` was not wrapped in `async_on_unload`.** Unloading an entry does not clear its update listeners (HA appends in `add_update_listener` and returns an unlisten callable; nothing in the unload path calls it). So every reload left one behind, and one options change then fires as many reloads as the entry has ever had. Measured:

```
after reload 1: update_listeners=1
after reload 2: update_listeners=2
after reload 3: update_listeners=3
after reload 4: update_listeners=4
```

Against an NVR that is precisely the reload burst that wedges it — and #613's HTTPS repair flow updates every entry on a host, so it multiplies through.

**`enable_cleanup_closed=True` is dead.** aiohttp ignores it on every Python that Home Assistant now runs on and emits a `DeprecationWarning` per connector for the trouble. Removing it is behaviour-neutral and drops the suite's warning count from 14 to 5.

### Verification

```
suite: 336 passed   (324 before)
```

Twelve tests. Each behaviour proven by reverting it:

| broken | tests that fail |
|---|---|
| failed setup keeps what it took | 5 |
| the `async_stop` cleanup call removed | 5 |
| update listener not wrapped | `test_reloading_does_not_leave_a_listener_behind` |
| failure swallowed instead of re-raised | `test_the_error_still_reaches_home_assistant`, `test_a_failed_setup_is_not_published_to_hass_data` |

That last row is why two of those tests read the way they do. The first version asserted only that *something* was raised, and passed against a version that cleaned up and carried on — satisfied by an unrelated failure further down setup. It now names `ConfigEntryNotReady` and checks the entry stays out of `hass.data`.

`test_reloading_does_not_leave_a_listener_behind` runs through `hass.config_entries.async_setup`/`async_unload` rather than calling this integration's functions, because it is Home Assistant that runs the `async_on_unload` callbacks and that is the half under test.

Rebased onto main now that #615, #617, #618 and #619 have merged. Independent of #616.


