### PR TITLE
Point smart motion detection at the channel it belongs to

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -1129,11 +1129,21 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         return self.data.get("table.DisableEventNotify.Enable", "").lower() == "false"
 
     def is_smart_motion_detection_enabled(self) -> bool:
-        """ Returns true if smart motion detection is enabled """
+        """ Returns true if smart motion detection is enabled
+
+        SmartMotionDetect is a host-wide read that returns a row per channel,
+        and the rows are sparse: a device only reports the channels the option
+        is configured on. Reading row 0 for every channel reported one camera's
+        setting for all of them, and reported false for the whole NVR when
+        there is no row 0 at all.
+        """
         if self.supports_smart_motion_detection_amcrest():
             return self.data.get("table.VideoAnalyseRule[0][0].Enable", "").lower() == "true"
-        else:
-            return self.data.get("table.SmartMotionDetect[0].Enable", "").lower() == "true"
+        value = self.data.get("table.SmartMotionDetect[{0}].Enable".format(self._channel))
+        if value is None:
+            # A single camera reports one row, and that row is row 0.
+            value = self.data.get("table.SmartMotionDetect[0].Enable", "")
+        return value.lower() == "true"
 
     def is_siren_on(self) -> bool:
         """ Returns true if the camera siren is on """

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -346,9 +346,15 @@ class DahuaClient:
         )
         return await self.get(url, True)
 
-    async def async_enabled_smart_motion_detection(self, enabled: bool):
-        """ Enables or disabled smart motion detection for Dahua devices (doesn't work for Amcrest)"""
-        url = "/cgi-bin/configManager.cgi?action=setConfig&SmartMotionDetect[0].Enable={0}".format(str(enabled).lower())
+    async def async_enabled_smart_motion_detection(self, channel: int, enabled: bool):
+        """ Enables or disabled smart motion detection for Dahua devices (doesn't work for Amcrest)
+
+        SmartMotionDetect is indexed by channel, like MotionDetect. Writing to
+        [0] from every channel of an NVR set channel one's option no matter
+        which camera the switch belonged to.
+        """
+        url = "/cgi-bin/configManager.cgi?action=setConfig&SmartMotionDetect[{0}].Enable={1}".format(
+            channel, str(enabled).lower())
         return await self.get(url, True)
 
     async def async_set_light_global_enabled(self, enabled: bool):

--- a/custom_components/dahua/switch.py
+++ b/custom_components/dahua/switch.py
@@ -167,7 +167,8 @@ class DahuaSmartMotionDetectionBinarySwitch(DahuaBaseEntity, SwitchEntity):
         if self._coordinator.supports_smart_motion_detection_amcrest():
             await self._coordinator.client.async_set_ivs_rule(0, 0, True)
         else:
-            await self._coordinator.client.async_enabled_smart_motion_detection(True)
+            await self._coordinator.client.async_enabled_smart_motion_detection(
+                self._coordinator.get_channel(), True)
         await self._coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs):  # pylint: disable=unused-argument
@@ -175,7 +176,8 @@ class DahuaSmartMotionDetectionBinarySwitch(DahuaBaseEntity, SwitchEntity):
         if self._coordinator.supports_smart_motion_detection_amcrest():
             await self._coordinator.client.async_set_ivs_rule(0, 0, False)
         else:
-            await self._coordinator.client.async_enabled_smart_motion_detection(False)
+            await self._coordinator.client.async_enabled_smart_motion_detection(
+                self._coordinator.get_channel(), False)
         await self._coordinator.async_refresh()
 
     @property

--- a/tests/dahua/test_smart_motion_channel.py
+++ b/tests/dahua/test_smart_motion_channel.py
@@ -1,0 +1,145 @@
+"""SmartMotionDetect is indexed by channel, and the rows are sparse.
+
+Taken from a real DHI-NVR5464-16P-EI, which reports rows for channels 1 and 11
+only -- the channels the option is actually configured on. There is no row 0.
+Reading row 0 for every channel therefore reported false for the whole NVR,
+including for the one channel that had it switched on.
+"""
+
+import pytest
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+# getConfig&name=SmartMotionDetect, as the NVR returns it.
+NVR_TABLE = {
+    "table.SmartMotionDetect[1].Enable": "true",
+    "table.SmartMotionDetect[1].ObjectTypes.Human": "true",
+    "table.SmartMotionDetect[1].ObjectTypes.Vehicle": "true",
+    "table.SmartMotionDetect[1].Sensitivity": "Middle",
+    "table.SmartMotionDetect[11].Enable": "true",
+    "table.SmartMotionDetect[11].ObjectTypes.Human": "true",
+    "table.SmartMotionDetect[11].ObjectTypes.Vehicle": "true",
+    "table.SmartMotionDetect[11].Sensitivity": "Middle",
+}
+
+SINGLE_CAMERA_TABLE = {
+    "table.SmartMotionDetect[0].Enable": "true",
+    "table.SmartMotionDetect[0].Sensitivity": "Middle",
+}
+
+
+def _coordinator(channel, data, amcrest=False):
+    c = object.__new__(DahuaDataUpdateCoordinator)
+    c._channel = channel
+    c.data = data
+    c.model = "AD410" if amcrest else "DHI-NVR5464-16P-EI"
+    return c
+
+
+@pytest.mark.parametrize("channel,expected", [
+    (1, True),
+    (11, True),
+    (0, False),
+    (2, False),
+    (9, False),
+])
+def test_each_channel_reads_its_own_row(channel, expected):
+    assert _coordinator(channel, NVR_TABLE).is_smart_motion_detection_enabled() is expected
+
+
+def test_the_channel_that_has_it_on_is_not_reported_off():
+    """The live symptom: one channel enabled, every switch showing off."""
+    assert _coordinator(1, NVR_TABLE).is_smart_motion_detection_enabled() is True
+
+
+def test_a_table_with_no_row_zero_does_not_make_every_channel_false():
+    """Reading row 0 against this table is false for all eleven channels."""
+    states = {_coordinator(c, NVR_TABLE).is_smart_motion_detection_enabled()
+              for c in (0, 1, 2, 9, 11)}
+
+    assert states == {True, False}, "every channel reported the same state"
+
+
+# --- a single camera is untouched ------------------------------------------
+
+def test_a_single_camera_still_reads_row_zero():
+    assert _coordinator(0, SINGLE_CAMERA_TABLE).is_smart_motion_detection_enabled() is True
+
+
+def test_a_channel_with_no_row_of_its_own_falls_back_to_row_zero():
+    assert _coordinator(3, SINGLE_CAMERA_TABLE).is_smart_motion_detection_enabled() is True
+
+
+def test_an_empty_table_is_off():
+    assert _coordinator(0, {}).is_smart_motion_detection_enabled() is False
+    assert _coordinator(7, {}).is_smart_motion_detection_enabled() is False
+
+
+def test_a_missing_value_does_not_raise():
+    """The row can exist with no Enable key at all."""
+    assert _coordinator(1, {"table.SmartMotionDetect[1].Sensitivity": "Middle"}
+                        ).is_smart_motion_detection_enabled() is False
+
+
+# --- the write side ---------------------------------------------------------
+#
+# test_switch.py asserts the arguments the switch passes to the client. Nothing
+# asserted the URL the client then builds, so the hardcoded index survived
+# there unnoticed. This closes that.
+
+class _Session:
+    def __init__(self):
+        self.urls = []
+
+    async def request(self, method, url, headers=None, **kwargs):
+        self.urls.append(url)
+        return _Resp()
+
+
+class _Resp:
+    status = 200
+    headers = {}
+
+    def raise_for_status(self):
+        return None
+
+    async def text(self):
+        return "OK"
+
+    def close(self):
+        return None
+
+
+def _client(session):
+    from custom_components.dahua.client import DahuaClient
+    return DahuaClient("u", "p", "10.0.0.1", 80, 554, session)
+
+
+@pytest.mark.parametrize("channel", [0, 1, 4, 11])
+async def test_the_write_names_the_channel(channel):
+    session = _Session()
+
+    await _client(session).async_enabled_smart_motion_detection(channel, True)
+
+    assert "SmartMotionDetect[%d].Enable=true" % channel in session.urls[-1]
+
+
+async def test_channel_zero_writes_exactly_what_it_always_did():
+    session = _Session()
+
+    await _client(session).async_enabled_smart_motion_detection(0, False)
+
+    assert session.urls[-1] == (
+        "http://10.0.0.1:80/cgi-bin/configManager.cgi"
+        "?action=setConfig&SmartMotionDetect[0].Enable=false"
+    )
+
+
+async def test_two_channels_do_not_write_to_the_same_row():
+    session = _Session()
+    c = _client(session)
+
+    await c.async_enabled_smart_motion_detection(3, True)
+    await c.async_enabled_smart_motion_detection(7, True)
+
+    assert session.urls[-2] != session.urls[-1]

--- a/tests/dahua/test_switch.py
+++ b/tests/dahua/test_switch.py
@@ -124,9 +124,11 @@ async def test_smart_motion_uses_the_dahua_api_by_default():
     await s.async_turn_on()
     await s.async_turn_off()
 
+    # The channel goes with it. Without it every channel of an NVR wrote
+    # SmartMotionDetect[0], setting channel one's option from any camera.
     assert c.client.calls == [
-        ("async_enabled_smart_motion_detection", True),
-        ("async_enabled_smart_motion_detection", False),
+        ("async_enabled_smart_motion_detection", 4, True),
+        ("async_enabled_smart_motion_detection", 4, False),
     ]
 
 


### PR DESCRIPTION
Same family as #619, but confirmed against real hardware rather than reasoned from the response shape — and unlike #619 it is wrong on **both** sides.

```
read:  table.SmartMotionDetect[0].Enable        __init__.py
write: setConfig&SmartMotionDetect[0].Enable    client.py
```

`SmartMotionDetect` is indexed by channel, exactly like `MotionDetect` — which the coordinator already reads correctly with `table.MotionDetect[{channel}].Enable`. Only this one was left at `[0]`.

### What the device actually returns

`getConfig&name=SmartMotionDetect` on a `DHI-NVR5464-16P-EI` with ten channels configured:

```
table.SmartMotionDetect[1].Enable=true
table.SmartMotionDetect[1].ObjectTypes.Human=true
table.SmartMotionDetect[1].ObjectTypes.Vehicle=true
table.SmartMotionDetect[1].Sensitivity=Middle
table.SmartMotionDetect[11].Enable=true
...
```

**The rows are sparse** — only the channels the option is configured on — and **there is no row 0**. So on that NVR:

- every one of the ten switches read `false`, permanently, including channel 1 which is genuinely `true`
- toggling any of them wrote channel one's option, not the camera the switch belonged to

`MotionDetect` on the same device returns rows `0-9, 11, 14`, and `VideoInMode` returns `0-9, 11`, so sparse indices are normal here and not particular to this table.

### Single cameras are untouched

One row is all a single camera reports, and that row is row 0. A camera on channel 0 produces a byte-identical URL on the write and reads the same key it always did:

```
http://host:80/cgi-bin/configManager.cgi?action=setConfig&SmartMotionDetect[0].Enable=false
```

That is asserted directly, not inferred.

### Verification

```
suite: 341 passed   (324 before)
```

| broken | tests that fail |
|---|---|
| read back to row 0 | 4 |
| write back to row 0 | 4 |
| single-camera fallback removed | `test_a_channel_with_no_row_of_its_own_falls_back_to_row_zero` |

The write row is there because of a gap this PR found in its own tests. On the first pass, reverting the write to `[0]` **passed everything** — `test_switch.py` asserts the arguments the switch hands to the client, and nothing asserted the URL the client then builds, so a hardcoded index was invisible at that layer. The new tests drive the real `DahuaClient` against a recording session and assert the URL. `test_switch.py` is updated to expect the channel argument.

Independent of #616 and #620.
