### PR TITLE
Stop the jitter test failing one CI run in thirteen

### DIFF
--- a/tests/dahua/test_stream_jitter.py
+++ b/tests/dahua/test_stream_jitter.py
@@ -39,11 +39,21 @@ def test_the_average_is_still_the_interval_asked_for():
     )
 
 
-def test_eleven_streams_land_in_different_seconds():
-    """The case this exists for: one NVR, one entry per channel."""
+def test_eleven_streams_do_not_reconnect_together():
+    """The case this exists for: one NVR, one entry per channel.
+
+    Not "all eleven differ". Eleven draws over the ~720 seconds this spreads
+    them across collide by the birthday problem 7.5% of the time, so asserting
+    eleven distinct values failed one CI run in thirteen -- on every pull
+    request in the repository, not just ones touching this code.
+
+    What matters is that they are spread at all: without jitter all eleven land
+    in the same second, forever. Ten or more distinct is the normal case, and
+    over 20000 trials the fewest ever seen was eight.
+    """
     seconds = {int(jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS)) for _ in range(11)}
 
-    assert len(seconds) == 11
+    assert len(seconds) >= 8, "eleven channels are still reconnecting in lockstep"
 
 
 def test_the_retry_after_a_failure_is_spread_too():


### PR DESCRIPTION
A flaky test I introduced in #614. It is on main now and fails **7.5% of all CI runs on the repository** — on every pull request, not only ones touching the event stream. #621's CI failure is this, not that PR's change.

### The arithmetic I never did

```python
seconds = {int(jittered(EVENT_STREAM_MAX_LIFETIME_SECONDS)) for _ in range(11)}
assert len(seconds) == 11
```

`jittered` spreads 3600s by ±10%, so eleven draws land in roughly 720 possible integer seconds. That is the birthday problem: expected collisions are `C(11,2)/721 ≈ 0.076`, giving `P(collision) ≈ 7.4%`. Measured over 20,000 trials:

```
P(a CI run fails)       : 7.52%
fewest distinct seen    : 8 of 11
P(fewer than 8 distinct): 0.0000%
```

The observed CI failure was `assert 10 == 11` — exactly one collision, the most likely way for it to go wrong.

### What the test should say

Not "all eleven differ" — that was never true and was never the point. The property is that the reconnections are **spread at all**: without jitter every channel of an NVR re-attaches in the same second, forever, which is what #614 exists to prevent. Eight or more distinct out of eleven states that, and eight is the worst outcome in 20,000 trials.

Zero failures in 2,000 trials of the new assertion. The remaining tests in the file compare floats rather than truncated integers, so they have no collision surface and are unchanged.

```
suite: 324 passed
```

Worth merging ahead of #616, #620 and #621 — it is currently making all three look intermittently broken.