### PR TITLE
Add reboot and open door buttons

### DIFF
--- a/custom_components/dahua/button.py
+++ b/custom_components/dahua/button.py
@@ -1,12 +1,73 @@
 """
 Button entity platform for Dahua.
 https://developers.home-assistant.io/docs/core/entity/button
-Buttons require HomeAssistant 2021.12 or greater
 """
+import logging
+
+from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+from .const import DOMAIN
+from .entity import DahuaBaseEntity
+
+_LOGGER = logging.getLogger(__package__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Setup the button platform."""
-    # TODO: Add some buttons. This requires a pretty recent version of HomeAssistant so I'm waiting a bit longer
-    # before adding buttons
+    coordinator: DahuaDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    buttons = [DahuaRebootButton(coordinator, entry)]
+
+    # Opening a door is a VTO operation. On anything else the endpoint is not
+    # there, and a button that always errors is worse than no button.
+    if coordinator.is_doorbell():
+        buttons.append(DahuaOpenDoorButton(coordinator, entry))
+
+    async_add_devices(buttons)
+
+
+class DahuaRebootButton(DahuaBaseEntity, ButtonEntity):
+    """Reboots the device."""
+
+    _attr_device_class = ButtonDeviceClass.RESTART
+    # Diagnostic would hide it from the device page controls; this is an action
+    # the user takes deliberately, so it belongs with the configuration.
+    _attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def name(self):
+        return self._coordinator.get_device_name() + " Reboot"
+
+    @property
+    def unique_id(self):
+        return self._coordinator.get_serial_number() + "_reboot"
+
+    async def async_press(self) -> None:
+        """Reboot the device.
+
+        Deliberately no refresh afterwards: the device is on its way down, so
+        polling it here would only turn a successful press into an error.
+        """
+        _LOGGER.debug("Rebooting %s", self._coordinator.get_address())
+        await self._coordinator.client.reboot()
+
+
+class DahuaOpenDoorButton(DahuaBaseEntity, ButtonEntity):
+    """Opens the door on a VTO."""
+
+    @property
+    def name(self):
+        return self._coordinator.get_device_name() + " Open Door"
+
+    @property
+    def unique_id(self):
+        return self._coordinator.get_serial_number() + "_open_door"
+
+    async def async_press(self) -> None:
+        """Open the door. The VTO relocks itself on its own timer."""
+        _LOGGER.debug("Opening door on %s", self._coordinator.get_address())
+        await self._coordinator.client.async_access_control_open_door(1)

--- a/custom_components/dahua/const.py
+++ b/custom_components/dahua/const.py
@@ -29,7 +29,8 @@ SWITCH = "switch"
 LIGHT = "light"
 CAMERA = "camera"
 SELECT = "select"
-PLATFORMS = [BINARY_SENSOR, SWITCH, LIGHT, CAMERA, SELECT]
+BUTTON = "button"
+PLATFORMS = [BINARY_SENSOR, SWITCH, LIGHT, CAMERA, SELECT, BUTTON]
 
 
 # Configuration and options

--- a/custom_components/dahua/translations/en.json
+++ b/custom_components/dahua/translations/en.json
@@ -62,6 +62,7 @@
                     "light": "Light enabled",
                     "select": "Select enabled",
                     "camera": "Camera enabled",
+                    "button": "Button enabled",
                     "auto_detect_channel": "Auto-detect channel index (disable if HTTP snapshot at channel=0 works but RTSP only streams on channel=1)",
                     "events": "Events to subscribe to",
                     "scan_interval": "Seconds between device polls (events are not affected)"

--- a/tests/dahua/test_button.py
+++ b/tests/dahua/test_button.py
@@ -1,0 +1,188 @@
+"""button.py shipped as an empty stub with a TODO about HomeAssistant 2021.12.
+
+Closes #552, which benchmarks this integration against the HA-certified Reolink
+one. Two buttons, not the three that issue asks for -- see the PR for why
+Cancel Call is deliberately left out.
+"""
+
+import pytest
+
+from custom_components.dahua import button as button_module
+from custom_components.dahua.button import DahuaOpenDoorButton, DahuaRebootButton
+from custom_components.dahua.const import BUTTON, PLATFORMS
+
+
+class _Client:
+    def __init__(self):
+        self.calls = []
+
+    def _record(self, name):
+        async def call(*args, **kwargs):
+            self.calls.append((name,) + args)
+        return call
+
+    def __getattr__(self, name):
+        return self._record(name)
+
+
+class _Coordinator:
+    def __init__(self, doorbell=False, channel=0):
+        self.client = _Client()
+        self._doorbell = doorbell
+        self._channel = channel
+        self.refreshed = 0
+
+    def is_doorbell(self):
+        return self._doorbell
+
+    def get_serial_number(self):
+        return "SERIAL1" if self._channel == 0 else "SERIAL1_%d" % self._channel
+
+    def get_device_name(self):
+        return "Front Door"
+
+    def get_address(self):
+        return "10.0.0.1"
+
+    async def async_refresh(self):
+        self.refreshed += 1
+
+
+@pytest.fixture(autouse=True)
+def _skip_ha_plumbing(monkeypatch):
+    monkeypatch.setattr(button_module.DahuaBaseEntity, "__init__", lambda self, c, e: None)
+
+
+def _button(cls, coordinator=None):
+    entity = object.__new__(cls)
+    entity._coordinator = coordinator or _Coordinator()
+    return entity
+
+
+# --- the platform actually loads now ---------------------------------------
+
+def test_the_button_platform_is_registered():
+    """button.py existed on disk but was never in PLATFORMS, so it never ran."""
+    assert BUTTON in PLATFORMS
+
+
+async def test_the_setup_adds_a_reboot_button_for_a_camera():
+    added = []
+    coordinator = _Coordinator(doorbell=False)
+    hass = type("H", (), {"data": {"dahua": {"e1": coordinator}}})()
+    entry = type("E", (), {"entry_id": "e1"})()
+
+    await button_module.async_setup_entry(hass, entry, added.extend)
+
+    assert [type(b).__name__ for b in added] == ["DahuaRebootButton"]
+
+
+async def test_a_doorbell_also_gets_an_open_door_button():
+    added = []
+    coordinator = _Coordinator(doorbell=True)
+    hass = type("H", (), {"data": {"dahua": {"e1": coordinator}}})()
+    entry = type("E", (), {"entry_id": "e1"})()
+
+    await button_module.async_setup_entry(hass, entry, added.extend)
+
+    assert [type(b).__name__ for b in added] == [
+        "DahuaRebootButton", "DahuaOpenDoorButton",
+    ]
+
+
+async def test_a_camera_gets_no_open_door_button():
+    """The endpoint is a VTO operation. A button that always errors is worse
+    than no button."""
+    added = []
+    hass = type("H", (), {"data": {"dahua": {"e1": _Coordinator(doorbell=False)}}})()
+    entry = type("E", (), {"entry_id": "e1"})()
+
+    await button_module.async_setup_entry(hass, entry, added.extend)
+
+    assert not any(isinstance(b, DahuaOpenDoorButton) for b in added)
+
+
+# --- what each button actually calls ---------------------------------------
+
+async def test_reboot_calls_reboot():
+    b = _button(DahuaRebootButton)
+
+    await b.async_press()
+
+    assert b._coordinator.client.calls == [("reboot",)]
+
+
+async def test_reboot_does_not_poll_the_device_afterwards():
+    """It is on its way down; a refresh would turn a good press into an error."""
+    b = _button(DahuaRebootButton)
+
+    await b.async_press()
+
+    assert b._coordinator.refreshed == 0
+
+
+async def test_open_door_names_the_door():
+    b = _button(DahuaOpenDoorButton, _Coordinator(doorbell=True))
+
+    await b.async_press()
+
+    assert b._coordinator.client.calls == [("async_access_control_open_door", 1)]
+
+
+# --- identity ---------------------------------------------------------------
+
+def test_the_unique_ids():
+    assert _button(DahuaRebootButton).unique_id == "SERIAL1_reboot"
+    assert _button(DahuaOpenDoorButton).unique_id == "SERIAL1_open_door"
+
+
+def test_the_ids_follow_the_channel_like_every_other_entity():
+    c = _Coordinator(channel=4)
+    assert _button(DahuaRebootButton, c).unique_id == "SERIAL1_4_reboot"
+    assert _button(DahuaOpenDoorButton, c).unique_id == "SERIAL1_4_open_door"
+
+
+def test_the_two_buttons_do_not_collide():
+    c = _Coordinator(doorbell=True)
+    assert _button(DahuaRebootButton, c).unique_id != _button(DahuaOpenDoorButton, c).unique_id
+
+
+def test_the_names():
+    assert _button(DahuaRebootButton).name == "Front Door Reboot"
+    assert _button(DahuaOpenDoorButton).name == "Front Door Open Door"
+
+
+def test_reboot_is_a_restart_button_under_config():
+    """So it lands in the device page controls, not among the sensors.
+
+    Read off an instance, not the class: Home Assistant rewrites class-level
+    _attr_ assignments into cached properties, so the class attribute is a
+    descriptor rather than the value.
+    """
+    from homeassistant.components.button import ButtonDeviceClass
+    from homeassistant.const import EntityCategory
+
+    b = _button(DahuaRebootButton)
+
+    assert b.device_class is ButtonDeviceClass.RESTART
+    assert b.entity_category is EntityCategory.CONFIG
+
+
+def test_open_door_is_not_a_restart_button():
+    assert _button(DahuaOpenDoorButton).device_class is None
+
+
+# --- the option toggle ------------------------------------------------------
+
+def test_the_new_platform_has_a_label_on_the_options_screen():
+    """The screen is built from sorted(PLATFORMS); a platform with no
+    translation shows as a bare key."""
+    import json
+    from pathlib import Path
+
+    path = Path(button_module.__file__).parent / "translations" / "en.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    labels = data["options"]["step"]["user"]["data"]
+
+    for platform in PLATFORMS:
+        assert platform in labels, "%s has no label on the options screen" % platform

--- a/tests/dahua/test_entity_identity.py
+++ b/tests/dahua/test_entity_identity.py
@@ -19,11 +19,13 @@ import pytest
 
 from custom_components.dahua import DahuaDataUpdateCoordinator
 from custom_components.dahua import binary_sensor as bs_module
+from custom_components.dahua import button as button_module
 from custom_components.dahua import camera as camera_module
 from custom_components.dahua import light as light_module
 from custom_components.dahua import select as select_module
 from custom_components.dahua import switch as switch_module
 from custom_components.dahua.binary_sensor import DahuaEventSensor
+from custom_components.dahua.button import DahuaOpenDoorButton, DahuaRebootButton
 from custom_components.dahua.camera import DahuaCamera
 from custom_components.dahua.entity import DahuaBaseEntity
 from custom_components.dahua.light import (
@@ -121,7 +123,8 @@ class _Entry:
 @pytest.fixture(autouse=True)
 def _skip_ha_plumbing(monkeypatch):
     """Build the real entities, skipping only Home Assistant's own __init__."""
-    for module in (bs_module, camera_module, light_module, select_module, switch_module):
+    for module in (bs_module, button_module, camera_module, light_module,
+                   select_module, switch_module):
         monkeypatch.setattr(module.DahuaBaseEntity, "__init__", lambda self, c, e: None)
     monkeypatch.setattr(bs_module.BinarySensorEntity, "__init__", lambda self: None)
     monkeypatch.setattr(select_module.SelectEntity, "__init__", lambda self: None)
@@ -164,6 +167,9 @@ GOLDEN_SUFFIXES = [
     ("_ring_light", lambda c: AmcrestRingLight(c, _Entry(), "Ring Light")),
     ("_flood_light", lambda c: FloodLight(c, _Entry(), "Flood Light")),
     ("_security", lambda c: DahuaSecurityLight(c, _Entry(), "Security")),
+    # button.py
+    ("_reboot", lambda c: _bare(DahuaRebootButton, c)),
+    ("_open_door", lambda c: _bare(DahuaOpenDoorButton, c)),
     # select.py
     ("_security_light", lambda c: DahuaDoorbellLightSelect(c, _Entry())),
     ("_preset_position", lambda c: DahuaCameraPresetPositionSelect(c, _Entry())),
@@ -208,6 +214,8 @@ def test_the_whole_set_for_one_nvr_channel_spelled_out():
         "4L03CB4PAZC9E8F_2_ring_light",
         "4L03CB4PAZC9E8F_2_flood_light",
         "4L03CB4PAZC9E8F_2_security",
+        "4L03CB4PAZC9E8F_2_reboot",
+        "4L03CB4PAZC9E8F_2_open_door",
         "4L03CB4PAZC9E8F_2_security_light",
         "4L03CB4PAZC9E8F_2_preset_position",
         "4L03CB4PAZC9E8F_2_1_preset_position",


### PR DESCRIPTION
Closes #552, which explicitly benchmarks this integration against the HA-certified Reolink one.

`button.py` has been on disk since 2021 containing an empty `async_setup_entry` and this:

> `# TODO: Add some buttons. This requires a pretty recent version of HomeAssistant so I'm waiting a bit longer before adding buttons`

That refers to **2021.12**. It was also never listed in `PLATFORMS`, so the file never loaded regardless.

### Two buttons

| Button | Call | Added when |
|---|---|---|
| Reboot | `magicBox.cgi?action=reboot` | always — `RESTART` device class, `CONFIG` category |
| Open Door | `accessControl.cgi?action=openDoor` | `coordinator.is_doorbell()` |

**Reboot does not refresh afterwards.** The device is on its way down; polling it there would turn a successful press into an error in the log.

**Open Door is gated on the doorbell check.** The endpoint is a VTO operation, and a button that always errors is worse than no button.

### Cancel Call is deliberately not here

It looks like the obvious third button `#552` asks for, and it isn't:

```python
async def cancel_call(self):        # vto.py
    def cancel(message): ...
    self.send("console.runCmd", cancel, {"command": "hc"})
    return True
```

- `async` with no `await` — it pushes a message onto the VTO socket and returns `True` unconditionally. Awaiting it confirms nothing.
- Different transport: the VTO protocol on port 5000, not the HTTP CGI client the other buttons use, through `_vto_client` which is `None` until that socket connects.
- **`#526` "cancel_call stop working in VTO2211G-WP" is the most-commented open bug in this repository.** Wrapping a known-broken call in a new entity would attract reports blaming the button.

It needs a real success signal from the VTO response and a `HomeAssistantError` rather than an `AttributeError` when there is no client, and that is a separate change.

### Two consequences worth flagging

Adding a platform adds a toggle to the options screen, which is built from `sorted(PLATFORMS)` — so `en.json` gains a `button` label, and a test asserts every platform has one rather than showing as a bare key.

The identity table from #618 gains `_reboot` and `_open_door`. It is the only place these strings exist as literals, so a new platform has to be recorded there; renaming either suffix now fails it in five places.

### Verification

```
suite: 346 passed   (324 before)
```

Renaming `_reboot` to `_restart` fails 5 identity-table assertions and 2 button tests.

One of the new tests was wrong on the first pass: it asserted `DahuaRebootButton._attr_device_class is ButtonDeviceClass.RESTART` on the class. Home Assistant rewrites class-level `_attr_` assignments into cached properties, so that read returns a descriptor, not the value. It now reads `device_class` off an instance, which is what HA actually uses.

Independent of #616, #620, #621 and #622.