### PR TITLE
Stop the camera claiming WebRTC it cannot serve

### DIFF
--- a/custom_components/dahua/camera.py
+++ b/custom_components/dahua/camera.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
-from homeassistant.components.camera import Camera, CameraEntityFeature, StreamType
+from homeassistant.components.camera import Camera, CameraEntityFeature
 
 from custom_components.dahua import DahuaDataUpdateCoordinator
 from custom_components.dahua.entity import DahuaBaseEntity
@@ -293,7 +293,6 @@ class DahuaCamera(DahuaBaseEntity, Camera):
         self._stream_source = coordinator.client.get_rtsp_stream_url(
             self._channel_number, stream_index
         )
-        self._attr_frontend_stream_type = StreamType.WEB_RTC
 
     @property
     def unique_id(self):

--- a/tests/dahua/test_camera_stream_type.py
+++ b/tests/dahua/test_camera_stream_type.py
@@ -1,0 +1,46 @@
+"""The camera serves RTSP through the stream component, so HLS, not WebRTC."""
+
+from homeassistant.components.camera import CameraEntityFeature, StreamType
+
+from custom_components.dahua.camera import DahuaCamera
+
+
+def _camera():
+    """A camera with only the plumbing camera_capabilities reads.
+
+    Home Assistant sets these in Camera.__init__, which needs the full entity
+    machinery; this asks the real capability logic the same question it is
+    asked at runtime.
+    """
+    c = object.__new__(DahuaCamera)
+    c._attr_supported_features = CameraEntityFeature.STREAM
+    c._supports_native_async_webrtc = False
+    c._webrtc_provider = None
+    c._cache = {}
+    return c
+
+
+def test_the_camera_advertises_hls():
+    assert StreamType.HLS in _camera().camera_capabilities.frontend_stream_types
+
+
+def test_the_camera_does_not_claim_webrtc_it_cannot_serve():
+    """There is no async_handle_async_webrtc_offer here. Advertising WebRTC
+    would leave the frontend negotiating with something that never answers.
+
+    camera.py used to set _attr_frontend_stream_type = StreamType.WEB_RTC.
+    Home Assistant derives capabilities from _supports_native_async_webrtc and
+    _webrtc_provider instead and never reads that attribute, so the line did
+    nothing -- but it said the opposite of what this integration does.
+    """
+    caps = _camera().camera_capabilities
+
+    assert StreamType.WEB_RTC not in caps.frontend_stream_types
+
+
+def test_the_module_no_longer_mentions_the_unused_import():
+    import inspect
+
+    from custom_components.dahua import camera as camera_module
+
+    assert "StreamType" not in inspect.getsource(camera_module)


### PR DESCRIPTION
`camera.py` set this on every camera:

```python
self._attr_frontend_stream_type = StreamType.WEB_RTC
```

This integration serves RTSP through the stream component and has no `async_handle_async_webrtc_offer`. The claim says the opposite of what it does.

It is also **dead**. Home Assistant derives `camera_capabilities` from `_supports_native_async_webrtc` and `_webrtc_provider`; nothing reads `_attr_frontend_stream_type`:

```python
if CameraEntityFeature.STREAM in self.supported_features:
    if self._supports_native_async_webrtc:
        frontend_stream_types.add(StreamType.WEB_RTC)
    else:
        frontend_stream_types.add(StreamType.HLS)
        if self._webrtc_provider:
            frontend_stream_types.add(StreamType.WEB_RTC)
```

Asking the real capability logic both ways returns the same answer:

```
with the WEB_RTC line : CameraCapabilities(frontend_stream_types={<StreamType.HLS: 'hls'>})
without it            : CameraCapabilities(frontend_stream_types={<StreamType.HLS: 'hls'>})
```

So this changes no behaviour on any Home Assistant version the integration supports — it removes a line that misstates the transport, and the now-unused `StreamType` import with it.

The three new tests pin the answer rather than just asserting the deletion, so a future WebRTC claim has to arrive with an offer handler behind it.

```
suite: 327 passed   (324 before)
```

Independent of #616, #620, #621, #622 and #623.