### PR TITLE
Judge infrared lighting support by the response, not an exception

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -739,12 +739,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
                 self._supports_floodlightmode = self.supports_floodlightmode()
 
-                try:
-                    await self.client.async_get_config_lighting(self._channel, self._profile_mode)
-                    self._supports_lighting = True
-                except ClientError:
-                    self._supports_lighting = False
-                    pass
+                self._supports_lighting = await self.async_detect_lighting_support()
                 _LOGGER.debug("Device supports infrared lighting=%s", self.supports_infrared_light())
 
 #Checking lighting_v2 support
@@ -1225,6 +1220,21 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         if mode is None:
             mode = mode_data.get("table.VideoInMode[0].Config[0]", "0")
         return mode or "0"
+
+    async def async_detect_lighting_support(self) -> bool:
+        """Does this channel have an infrared light?
+
+        Judged by what comes back, not by an exception. async_get_config
+        catches aiohttp.ClientResponseError and returns {}, so an
+        exception-only probe could never fail: every device was marked as
+        having an IR light and then fetched Lighting[channel][mode] on every
+        poll, forever. The profile mode probe reads its result the same way.
+        """
+        try:
+            conf = await self.client.async_get_config_lighting(self._channel, self._profile_mode)
+        except ClientError:
+            return False
+        return len(conf) > 0
 
     def get_profile_mode(self) -> str:
         # profile_mode 0=day, 1=night, 2=scene

--- a/tests/dahua/test_lighting_support.py
+++ b/tests/dahua/test_lighting_support.py
@@ -1,0 +1,89 @@
+"""The IR lighting probe could never fail, so every device claimed one.
+
+async_get_config catches aiohttp.ClientResponseError and returns {}, so the
+coordinator's `except ClientError` around the lighting probe was unreachable.
+_supports_lighting was therefore True on every device, and an NVR channel with
+no infrared light fetched Lighting[ch][mode] on every poll forever -- which on
+a device that closes the connection and reissues its digest nonce per request
+costs two TCP connections and a rejected login each time.
+"""
+
+import pytest
+from aiohttp import ClientError
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+LIGHTING_PRESENT = {
+    "table.Lighting[0][0].Correction": "50",
+    "table.Lighting[0][0].Mode": "Auto",
+    "table.Lighting[0][0].Sensitive": "3",
+}
+
+
+class _Client:
+    def __init__(self, result=None, raises=None):
+        self.result, self.raises = result, raises
+        self.calls = 0
+
+    async def async_get_config_lighting(self, channel, profile_mode):
+        self.calls += 1
+        if self.raises:
+            raise self.raises
+        return self.result
+
+
+async def _probe(client):
+    """Call the coordinator's own detection, not a copy of it.
+
+    The first version of this file reimplemented the probe here, so reverting
+    the production code to `= True` left four of five tests passing. Only the
+    source-inspection test noticed. Now it runs the real method.
+    """
+    c = object.__new__(DahuaDataUpdateCoordinator)
+    c._channel = 0
+    c._profile_mode = "0"
+    c.client = client
+    return await c.async_detect_lighting_support()
+
+
+async def test_a_device_that_reports_lighting_is_supported():
+    assert await _probe(_Client(result=LIGHTING_PRESENT)) is True
+
+
+async def test_a_device_that_returns_nothing_is_not_supported():
+    """This is the case that was broken: {} used to be read as success."""
+    assert await _probe(_Client(result={})) is False
+
+
+async def test_an_error_is_still_unsupported():
+    assert await _probe(_Client(raises=ClientError("boom"))) is False
+
+
+async def test_the_probe_is_what_the_coordinator_actually_uses():
+    """Guard against the detection being inlined again somewhere else."""
+    import inspect
+
+    from custom_components.dahua import DahuaDataUpdateCoordinator as C
+
+    src = inspect.getsource(C._async_update_data)
+    assert "async_detect_lighting_support()" in src
+    assert "self._supports_lighting = True" not in src
+
+
+async def test_it_asks_the_device_only_once():
+    client = _Client(result=LIGHTING_PRESENT)
+
+    await _probe(client)
+
+    assert client.calls == 1
+
+
+def test_async_get_config_still_swallows_so_the_probe_must_not_rely_on_it():
+    """If this ever changes, the probe above can be simplified -- and this
+    test is how you find out."""
+    import inspect
+
+    from custom_components.dahua.client import DahuaClient
+
+    src = inspect.getsource(DahuaClient.async_get_config)
+    assert "return {}" in src and "except aiohttp.ClientResponseError" in src


### PR DESCRIPTION
The infrared-light probe could never fail, so every device was recorded as having one.

```python
try:
    await self.client.async_get_config_lighting(...)
    self._supports_lighting = True
except ClientError:
    self._supports_lighting = False
```

`async_get_config` catches `aiohttp.ClientResponseError` and returns `{}` (`client.py`), so nothing ever reaches that `except`. `_supports_lighting` is unconditionally `True`, and any channel without an infrared light fetches `Lighting[channel][mode]` on **every poll, forever**.

The profile-mode probe immediately below already reads its result (`len(conf) > 1`) rather than waiting for an exception. This does the same.

### Why one wasted call per poll is worse than it sounds

Measured against a real NVR while diagnosing a report of once-a-second device log entries:

```
Connection: close                    on every response
call 1: [(401, 'none'), (200, 'AUTH')]
call 2: [(401, 'AUTH'), (200, 'AUTH')]   <- reused challenge rejected
call 3: [(401, 'AUTH'), (200, 'AUTH')]
```

The device closes the connection after every response and reissues its digest nonce every time, so a cached challenge is always refused. **Each logical CGI call costs two TCP connections, two HTTP requests, and one rejected login written to the device's own log.** Removing a call that can never return anything useful removes all of that.

### The probe is now a method, because the first version of these tests was wrong

`async_detect_lighting_support()` is extracted so the tests can call the real thing. The first version of this file reimplemented the probe inside the test helper — so reverting the production code to `= True` left **four of five tests passing**, and only a source-inspection test noticed. That is a test that tests itself.

| broken | tests that fail |
|---|---|
| `return len(conf) > 0` → `return True` | `test_a_device_that_returns_nothing_is_not_supported` |
| detection inlined back into `_async_update_data` | `test_the_probe_is_what_the_coordinator_actually_uses` |

```
suite: 330 passed   (324 before)
```

Independent of the other open PRs.