### PR TITLE
Report event stream failures instead of swallowing them

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -62,6 +62,21 @@ EVENT_STREAM_JITTER = 0.1
 # would otherwise be retried by every channel at once, sixty seconds later.
 EVENT_STREAM_RETRY_SECONDS = 60
 
+# A stream that lived this long was working, so reconnect at once. Anything
+# shorter gets backed off, because the fast path used to have no delay at all:
+# a device closing the socket at eleven seconds reconnected forever, silently.
+EVENT_STREAM_HEALTHY_SECONDS = 60
+EVENT_STREAM_SHORT_RETRY_SECONDS = 10
+
+
+def event_stream_retry_delay(lived_seconds: float) -> float:
+    """How long to wait before re-attaching, given how long the stream lasted."""
+    if lived_seconds < 10:
+        return jittered(EVENT_STREAM_RETRY_SECONDS)
+    if lived_seconds < EVENT_STREAM_HEALTHY_SECONDS:
+        return jittered(EVENT_STREAM_SHORT_RETRY_SECONDS)
+    return 0.0
+
 
 def jittered(seconds: float, fraction: float = EVENT_STREAM_JITTER) -> float:
     """Spread a shared interval so simultaneous callers stop being simultaneous."""
@@ -373,6 +388,8 @@ class DahuaHostEventStream:
         self._owner = None  # whose client the stream currently borrows
         self._events: frozenset = frozenset()
         self._task: asyncio.Task | None = None
+        # Whether the last attach failed, so an outage is reported once.
+        self._failing = False
 
     @property
     def coordinators(self) -> list:
@@ -449,16 +466,28 @@ class DahuaHostEventStream:
             except asyncio.CancelledError:
                 raise
             except asyncio.TimeoutError:
+                self._failing = False
                 _LOGGER.debug("Recycling event stream for %s", self._address)
             except Exception as ex:  # pylint: disable=broad-except
-                _LOGGER.warning(
-                    "Event stream for %s ended unexpectedly: %s", self._address, ex
-                )
+                # Say it once per outage, not once per retry. Silence was the
+                # old behaviour and it is why these failures went unreported;
+                # a warning every sixty seconds forever is the other extreme.
+                if not self._failing:
+                    self._failing = True
+                    _LOGGER.warning(
+                        "Event stream for %s ended unexpectedly: %s", self._address, ex
+                    )
+                else:
+                    _LOGGER.debug(
+                        "Event stream for %s still failing: %s", self._address, ex
+                    )
+            else:
+                self._failing = False
 
-            if time.monotonic() - start_time < 10:
-                retry_in = jittered(EVENT_STREAM_RETRY_SECONDS)
+            retry_in = event_stream_retry_delay(time.monotonic() - start_time)
+            if retry_in:
                 _LOGGER.debug(
-                    "Event stream for %s failed quickly, retrying in %.0fs",
+                    "Reconnecting to event stream for %s in %.0fs",
                     self._address,
                     retry_in,
                 )

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -113,6 +113,16 @@ class _SharedRead:
         return self.expires_at is not None and now < self.expires_at
 
 
+class EventStreamClosed(Exception):
+    """The device ended the event stream.
+
+    A long poll that returns is a failure, not a result: the connection is
+    meant to stay open until we recycle it. A device that refuses
+    action=attach by answering 200 and closing would otherwise leave no trace
+    anywhere.
+    """
+
+
 SECURITY_LIGHT_TYPE = 1
 SIREN_TYPE = 2
 
@@ -985,30 +995,36 @@ class DahuaClient:
         codes = ",".join(events)
         url = "{0}/cgi-bin/eventManager.cgi?action=attach&codes=[{1}]&heartbeat={2}".format(
             self._base, codes, EVENT_STREAM_HEARTBEAT_SECONDS)
-        if self._username is not None and self._password is not None:
-            response = None
+        if self._username is None or self._password is None:
+            # Returning quietly here spun a silent sixty second retry loop that
+            # never did anything and never said so.
+            raise EventStreamClosed(
+                "Cannot subscribe to events on %s without credentials" % self._address)
 
-            try:
-                # A long poll must not inherit the session's default total
-                # timeout, which tears a healthy stream down every 5 minutes.
-                # Bound it on read instead, so a socket that stops delivering
-                # is detected but one that keeps heartbeating is left alone.
-                timeout = aiohttp.ClientTimeout(
-                    total=None, sock_read=EVENT_STREAM_READ_TIMEOUT_SECONDS)
-                auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
-                response = await auth.request("GET", url, timeout=timeout)
-                response.raise_for_status()
+        response = None
 
-                # https://docs.aiohttp.org/en/stable/streams.html
-                async for data, _ in response.content.iter_chunks():
-                    on_receive(data, channel)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exception:
-                _LOGGER.debug("Event stream ended: %s", exception)
-            finally:
-                if response is not None:
-                    response.close()
+        try:
+            # A long poll must not inherit the session's default total
+            # timeout, which tears a healthy stream down every 5 minutes.
+            # Bound it on read instead, so a socket that stops delivering
+            # is detected but one that keeps heartbeating is left alone.
+            timeout = aiohttp.ClientTimeout(
+                total=None, sock_read=EVENT_STREAM_READ_TIMEOUT_SECONDS)
+            auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
+            response = await auth.request("GET", url, timeout=timeout)
+            response.raise_for_status()
+
+            # https://docs.aiohttp.org/en/stable/streams.html
+            async for data, _ in response.content.iter_chunks():
+                on_receive(data, channel)
+        finally:
+            if response is not None:
+                response.close()
+
+        # Falling out of the loop means the device closed the stream on us.
+        # It raises no exception, so without this the caller cannot tell a
+        # refused subscription from a healthy one.
+        raise EventStreamClosed("Event stream to %s closed by the device" % self._address)
 
     @staticmethod
     async def parse_dahua_api_response(data: str) -> dict:

--- a/tests/dahua/test_event_stream.py
+++ b/tests/dahua/test_event_stream.py
@@ -6,7 +6,7 @@ from aiohttp import web
 import pytest
 
 from custom_components.dahua import client as client_module
-from custom_components.dahua.client import DahuaClient
+from custom_components.dahua.client import DahuaClient, EventStreamClosed
 
 
 class CapturingSession:
@@ -25,8 +25,10 @@ async def test_stream_request_is_bounded_on_read_not_total():
     session = CapturingSession()
     client = DahuaClient("u", "p", "d", 80, 554, session)
 
-    # stream_events swallows its own exceptions, so this returns normally.
-    await client.stream_events(lambda data, channel: None, ["All"], 0)
+    # The session raises to stop the call once it has the arguments, and
+    # stream_events no longer swallows that.
+    with pytest.raises(RuntimeError):
+        await client.stream_events(lambda data, channel: None, ["All"], 0)
 
     timeout = session.kwargs["timeout"]
     assert isinstance(timeout, aiohttp.ClientTimeout)
@@ -65,14 +67,106 @@ async def test_stalled_stream_ends_so_the_caller_can_reconnect(monkeypatch, sock
     received = []
 
     try:
-        await asyncio.wait_for(
-            client.stream_events(lambda data, channel: received.append(data), ["All"], 0),
-            timeout=10,
-        )
-    except asyncio.TimeoutError:
-        pytest.fail("stream did not end after the socket went quiet")
+        with pytest.raises(Exception) as caught:
+            await asyncio.wait_for(
+                client.stream_events(lambda data, channel: received.append(data), ["All"], 0),
+                timeout=10,
+            )
+        # aiohttp's read timeout subclasses asyncio.TimeoutError, so identify
+        # it precisely rather than by the base class the outer wait_for uses.
+        assert isinstance(caught.value, aiohttp.ServerTimeoutError),             "expected the socket read timeout, got %r" % (caught.value,)
     finally:
         await session.close()
         await runner.cleanup()
 
     assert received, "the heartbeat before the stall should have been delivered"
+
+
+# --- a stream that ends must say so ----------------------------------------
+#
+# Every failure used to be caught inside stream_events and logged at DEBUG, so
+# the caller's warning was unreachable and a device refusing the subscription
+# left no trace anywhere. That silence is why an affected user's Home Assistant
+# log contained nothing at all about their NVR.
+
+class _EndingSession:
+    """A device that accepts the subscription and then closes it."""
+
+    def __init__(self, status=200, chunks=()):
+        self.status = status
+        self.chunks = chunks
+        self.requested = False
+
+    async def request(self, method, url, headers=None, **kwargs):
+        self.requested = True
+        return _EndingResponse(self.status, self.chunks)
+
+
+class _EndingResponse:
+    def __init__(self, status, chunks):
+        self.status = status
+        self.headers = {}
+        self.content = _Content(chunks)
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise aiohttp.ClientResponseError(None, (), status=self.status)
+
+    def close(self):
+        return None
+
+
+class _Content:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    async def iter_chunks(self):
+        for c in self._chunks:
+            yield c, True
+
+
+async def test_a_device_that_closes_the_stream_raises():
+    """A long poll that returns is a failure, not a result."""
+    client = DahuaClient("u", "p", "d", 80, 554, _EndingSession(chunks=[b"Heartbeat"]))
+
+    with pytest.raises(EventStreamClosed):
+        await client.stream_events(lambda data, channel: None, ["All"], 0)
+
+
+async def test_an_empty_200_raises_too():
+    """The quietest failure of all: attach accepted, nothing ever sent."""
+    client = DahuaClient("u", "p", "d", 80, 554, _EndingSession(chunks=[]))
+
+    with pytest.raises(EventStreamClosed):
+        await client.stream_events(lambda data, channel: None, ["All"], 0)
+
+
+async def test_an_http_error_reaches_the_caller():
+    client = DahuaClient("u", "p", "d", 80, 554, _EndingSession(status=401))
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.stream_events(lambda data, channel: None, ["All"], 0)
+
+
+async def test_missing_credentials_raise_instead_of_looping_silently():
+    """Name the reason: without it this passes on the end-of-stream raise
+    instead, and the guard could be deleted with every test still green."""
+    session = _EndingSession()
+    client = DahuaClient(None, None, "d", 80, 554, session)
+
+    with pytest.raises(EventStreamClosed) as caught:
+        await client.stream_events(lambda data, channel: None, ["All"], 0)
+
+    assert "credentials" in str(caught.value)
+    assert session.requested is False, "it tried to talk to the device anyway"
+
+
+async def test_chunks_still_reach_the_handler_before_the_close():
+    got = []
+    client = DahuaClient("u", "p", "d", 80, 554,
+                         _EndingSession(chunks=[b"a", b"b", b"c"]))
+
+    with pytest.raises(EventStreamClosed):
+        await client.stream_events(lambda data, channel: got.append(data), ["All"], 0)
+
+    assert got == [b"a", b"b", b"c"]

--- a/tests/dahua/test_stream_jitter.py
+++ b/tests/dahua/test_stream_jitter.py
@@ -77,3 +77,45 @@ def test_jitter_can_be_switched_off():
 
 def test_a_zero_interval_is_left_alone():
     assert jittered(0) == 0
+
+
+# --- backoff after a stream ends --------------------------------------------
+#
+# The old loop had exactly two branches: under ten seconds wait sixty, otherwise
+# reconnect with no delay at all. A device that closes the socket at eleven
+# seconds therefore reconnected forever, as fast as it could, in silence.
+
+from custom_components.dahua import (
+    EVENT_STREAM_HEALTHY_SECONDS,
+    EVENT_STREAM_SHORT_RETRY_SECONDS,
+    event_stream_retry_delay,
+)
+
+
+def test_a_stream_that_died_at_once_waits_a_minute():
+    assert 50 <= event_stream_retry_delay(0.5) <= 70
+
+
+def test_a_stream_that_lasted_eleven_seconds_is_not_retried_instantly():
+    """This is the case that used to spin with no delay whatsoever."""
+    assert event_stream_retry_delay(11) > 0
+
+
+def test_the_middle_band_waits_about_ten_seconds():
+    for lived in (10, 20, 45, 59):
+        assert 8 <= event_stream_retry_delay(lived) <= 12
+
+
+def test_a_healthy_stream_reconnects_immediately():
+    """An hour-long stream being recycled must not pause the subscription."""
+    assert event_stream_retry_delay(EVENT_STREAM_HEALTHY_SECONDS) == 0.0
+    assert event_stream_retry_delay(3600) == 0.0
+
+
+def test_the_worst_case_reconnect_rate_is_bounded():
+    """Cheapest expression of the fix: how often can we possibly re-attach?"""
+    worst = min(lived + event_stream_retry_delay(lived) for lived in range(0, 60))
+
+    assert worst >= EVENT_STREAM_SHORT_RETRY_SECONDS, (
+        "a device can still be re-attached every %.1fs" % worst
+    )


### PR DESCRIPTION
`stream_events` caught every exception, logged it at **DEBUG**, and returned normally. So the caller's warning —

```python
_LOGGER.warning("Event stream for %s ended unexpectedly: %s", ...)
```

— was unreachable for every network, HTTP, auth and timeout failure it was written to report.

That silence is not theoretical. Someone reporting constant device-side activity from their NVR had **literally nothing** in their Home Assistant log about it, which made the problem look like it wasn't the integration at all. It cost a lot of diagnosis time.

### Three ways the stream could end leaving no trace anywhere

| | before | now |
|---|---|---|
| any exception | DEBUG, inside `stream_events` | propagates; caller warns |
| **clean close** — device answers 200 and ends the response | raises *nothing*; not even the DEBUG line ran | `EventStreamClosed` |
| no credentials | returned instantly, caller then spun a silent 60s retry loop forever | `EventStreamClosed` |

The middle one is the worst: a device that refuses `action=attach` by accepting it and immediately closing produced **no output at any log level**, forever. A long poll that returns is a failure, not a result.

### Once per outage, not once per retry

Silence was one extreme; a warning every sixty seconds forever is the other. The host stream tracks whether it is already failing and logs the transition — WARNING on the first failure, DEBUG while it persists.

### The retry delay had a branch with no delay at all

```python
if elapsed < 10:  ->  sleep(60)
else:             ->  reconnect immediately
```

A device closing the socket at eleven seconds hit the `else` every time and reconnected as fast as it could, forever, silently. Now graduated:

```
< 10s   -> ~60s     (unchanged)
< 60s   -> ~10s     (new; this band had no delay)
>= 60s  -> immediate (a healthy stream being recycled must not pause)
```

Worst-case re-attach rate is now one per ten seconds instead of unbounded.

### Verification

```
suite: 334 passed   (324 before)
```

| broken | tests that fail |
|---|---|
| clean close goes back to silent | 3 |
| credentials guard removed | `test_missing_credentials_raise_instead_of_looping_silently` |
| back to the no-delay branch | 2 |

That middle row is there on the second attempt. The first version of that test only asserted `EventStreamClosed` was raised — which the *end-of-stream* raise also satisfies, so the guard could be deleted with every test still green. It now asserts the reason and that no request was made.

Two existing tests in `test_event_stream.py` are updated: they pinned the old swallow-everything contract. One of them needed `aiohttp.ServerTimeoutError` rather than `asyncio.TimeoutError`, since the read timeout subclasses the latter and was indistinguishable from the outer `wait_for`.