### PR TITLE
Stop re-reading settings that nothing has changed

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -71,8 +71,38 @@ def _digest_state(address: str, username: str) -> dict:
 # carry a channel has a different URL per channel and is never shared. Only
 # reads are cached; anything else drops the host's entries, because a write is
 # how these values change.
+
+# How long a shared read answers for. Two lifetimes, because the reads fall
+# into two kinds.
+#
+# Status reads change on their own: where a PTZ camera is pointing, whether the
+# siren is sounding, which day/night profile the device has switched itself to.
+# Those have to be polled, so they get a lifetime short enough to only cover
+# one poll's fan-out.
+#
+# Config reads change only when something writes them -- and a write drops this
+# host's entries, so a change made through Home Assistant is reflected at once.
+# Re-asking the device every poll buys nothing except load. On hardware
+# measured for this, each of those calls costs two TCP connections, two HTTP
+# requests and one refused login in the device's own log, because the device
+# answers Connection: close and reissues its digest nonce every time. A camera
+# with no dashboard open was spending most of its request budget re-reading
+# settings nobody had touched.
+#
+# The cost is that a change made in the Dahua app or web UI, rather than
+# through Home Assistant, can take up to this long to appear.
 HOST_CACHE_TTL_SECONDS = 5
+CONFIG_CACHE_TTL_SECONDS = 300
+
+# getConfig is a settings read. getStatus and the rest report live state.
+CONFIG_READ_MARKER = "action=getConfig"
 _HOST_CACHE: dict = {}
+
+
+def _cache_lifetime(url: str) -> int:
+    """How long this URL's answer stays good for."""
+    return CONFIG_CACHE_TTL_SECONDS if CONFIG_READ_MARKER in url else HOST_CACHE_TTL_SECONDS
+
 
 # CGI reads are "action=getSomething". Everything else -- setConfig, reboot,
 # ptz control, door open -- is a write. Unrecognised is treated as a write,
@@ -1100,7 +1130,7 @@ class DahuaClient:
         # that dropped this entry while it was in flight has already replaced
         # it, so it settles for whoever is waiting without going back in.
         if _HOST_CACHE.get(key) is entry and entry.expires_at is None:
-            entry.expires_at = time.monotonic() + HOST_CACHE_TTL_SECONDS
+            entry.expires_at = time.monotonic() + _cache_lifetime(url)
 
         return dict(result)
 

--- a/tests/dahua/test_host_read_cache.py
+++ b/tests/dahua/test_host_read_cache.py
@@ -282,3 +282,93 @@ async def test_the_ttl_stays_under_the_shortest_poll_a_user_can_ask_for():
     from custom_components.dahua.const import MIN_SCAN_INTERVAL
 
     assert 0 < HOST_CACHE_TTL_SECONDS < MIN_SCAN_INTERVAL
+
+
+# --- settings reads outlive a poll cycle ------------------------------------
+#
+# A single camera shares nothing with anybody, so the coalescing above does not
+# help it at all. What helps is not re-asking the device for settings that only
+# change when something writes them -- and a write already drops the cache.
+
+STATUS = "/cgi-bin/coaxialControlIO.cgi?action=getStatus&channel=1"
+PTZ_STATUS = "/cgi-bin/ptz.cgi?action=getStatus"
+
+
+def test_a_settings_read_outlives_a_poll_interval():
+    from custom_components.dahua.client import _cache_lifetime
+    from custom_components.dahua.const import DEFAULT_SCAN_INTERVAL
+
+    assert _cache_lifetime(MOTION) > DEFAULT_SCAN_INTERVAL
+
+
+def test_a_status_read_does_not():
+    """PTZ position and siren state change without anyone writing them."""
+    from custom_components.dahua.client import _cache_lifetime
+    from custom_components.dahua.const import MIN_SCAN_INTERVAL
+
+    assert _cache_lifetime(PTZ_STATUS) < MIN_SCAN_INTERVAL
+    assert _cache_lifetime(STATUS) < MIN_SCAN_INTERVAL
+
+
+async def test_one_camera_stops_re_reading_its_settings_every_poll(monkeypatch):
+    """The case a single-entry install actually has.
+
+    Time is advanced by a poll interval between cycles, otherwise five calls in
+    a row fit inside any TTL and the test proves nothing.
+    """
+    from custom_components.dahua.const import DEFAULT_SCAN_INTERVAL
+
+    now = [1000.0]
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: now[0])
+    probe = _Probe(hold=0)
+    c = _client(probe)
+
+    for _ in range(5):                      # five poll cycles, 30s apart
+        await c.get(MOTION)
+        await c.get(LINKAGE)
+        now[0] += DEFAULT_SCAN_INTERVAL
+
+    assert probe.calls == 2, (
+        "settings were re-read across %d poll cycles (%d requests)"
+        % (5, probe.calls)
+    )
+
+
+async def test_status_is_re_read_across_those_same_cycles(monkeypatch):
+    """The other half: the long TTL must not silently freeze live state."""
+    from custom_components.dahua.const import DEFAULT_SCAN_INTERVAL
+
+    now = [1000.0]
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: now[0])
+    probe = _Probe(hold=0)
+    c = _client(probe)
+
+    for _ in range(5):
+        await c.get(PTZ_STATUS)
+        now[0] += DEFAULT_SCAN_INTERVAL
+
+    assert probe.calls == 5, "a status read was served stale across polls"
+
+
+async def test_status_is_still_polled_every_cycle():
+    probe = _Probe(hold=0)
+    c = _client(probe)
+
+    await c.get(PTZ_STATUS)
+    client_module._HOST_CACHE[(c._address, "u", PTZ_STATUS)].expires_at = 0
+    await c.get(PTZ_STATUS)
+
+    assert probe.calls == 2, "a status read was served stale"
+
+
+async def test_a_write_still_refreshes_settings_immediately():
+    """Toggling a switch in Home Assistant must not wait out the long TTL."""
+    probe = _Probe(hold=0)
+    c = _client(probe)
+    await c.get(MOTION)
+
+    await c.get(WRITE)
+    await c.get(MOTION)
+
+    assert probe.calls == 3
+    assert probe.urls[-1].endswith(MOTION)


### PR DESCRIPTION
**Stacked on #616** — that PR adds the shared read cache; this one gives it two lifetimes. The diff shows both until #616 merges.

Reads fall into two kinds and were treated as one.

**Status reads** change on their own — where a PTZ camera points, whether the siren is sounding, which day/night profile the device switched itself to. Those must be polled.

**Config reads** change only when something writes them. A write already drops this host's cached entries, so a change made through Home Assistant is reflected immediately. Re-asking the device every poll buys nothing but load.

```
getConfig  ->  300s   MotionDetect, DisableLinkage, DisableEventNotify,
                      SmartMotionDetect, Lighting, Lighting_V2, VideoInMode
everything ->    5s   ptz.cgi getStatus, coaxialControlIO getStatus
```

### Why this is worth more than one request per poll

Measured against a real NVR while diagnosing a report of once-a-second device log entries:

```
Connection: close                        on every response
call 1: [(401, 'none'), (200, 'AUTH')]
call 2: [(401, 'AUTH'), (200, 'AUTH')]   <- cached challenge refused
call 3: [(401, 'AUTH'), (200, 'AUTH')]
```

The device closes the connection after every response **and** reissues its digest nonce every time, so the cached challenge is always rejected — it sends no `stale="true"` and no `Authentication-Info: nextnonce`. **Each logical call therefore costs two TCP connections, two HTTP requests, and one refused login written to the device's own log.**

Seven of the ten calls in a poll cycle are settings reads. Removing them removes about two-thirds of that.

### This is the part that helps a single camera

Worth being explicit, because it is the gap in the recent work: #615, #616 and #617 all reduce load by sharing between config entries, which does **nothing** for someone with one camera. That is exactly the configuration in the report that prompted this. One camera shares nothing with anybody; what helps it is not asking twice.

### The trade

A change made in the Dahua app or web UI, rather than through Home Assistant, can take up to five minutes to appear. Changes made through Home Assistant are immediate, because the write invalidates the host's cache — there is a test for that.

### Verification

```
suite: 348 passed   (324 before)
```

| broken | tests that fail |
|---|---|
| one lifetime for everything again | 2 |
| status cached as long as settings | 2 |

Both behavioural tests advance a fake clock by a poll interval between cycles. Without that, five calls in a row fit inside any TTL and the test proves nothing — the first version passed against both mutations for exactly that reason.