### PR TITLE
Use asyncio.timeout instead of async_timeout

### DIFF
--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -4,7 +4,6 @@ import socket
 import asyncio
 import time
 import aiohttp
-import async_timeout
 
 from .digest import DigestAuth
 from .rpc2 import DahuaRpc2Client
@@ -496,7 +495,7 @@ class DahuaClient:
             self._rtsp_port, session, self._use_https
         )
         try:
-            async with async_timeout.timeout(5):
+            async with asyncio.timeout(5):
                 presets = await rpc2.async_get_ptz_presets(channel_index)
             ids = self.parse_ptz_preset_ids(presets)
             if presets and not ids:
@@ -504,7 +503,7 @@ class DahuaClient:
             return ids
         finally:
             try:
-                async with async_timeout.timeout(3):
+                async with asyncio.timeout(3):
                     logout_ok = await rpc2.logout()
                 if not logout_ok:
                     _LOGGER.debug(
@@ -521,11 +520,11 @@ class DahuaClient:
             self._rtsp_port, session, self._use_https
         )
         try:
-            async with async_timeout.timeout(5):
+            async with asyncio.timeout(5):
                 return await rpc2.async_goto_preset_position(channel, position)
         finally:
             try:
-                async with async_timeout.timeout(3):
+                async with asyncio.timeout(3):
                     logout_ok = await rpc2.logout()
                 if not logout_ok:
                     _LOGGER.debug("RPC2 logout reported failure after GotoPreset")
@@ -1041,7 +1040,7 @@ class DahuaClient:
         Raises the same errors async_get_snapshot would.
         """
         url = self._base + "/cgi-bin/snapshot.cgi?channel={0}".format(channel_number)
-        async with async_timeout.timeout(TIMEOUT_SECONDS), self._host_limit:
+        async with asyncio.timeout(TIMEOUT_SECONDS), self._host_limit:
             response = None
             try:
                 auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
@@ -1056,7 +1055,7 @@ class DahuaClient:
         """Get information from the API. This will return the raw response and not process it"""
         # The timeout covers the wait for a slot as well as the request, so a
         # busy host sheds load instead of building an unbounded queue.
-        async with async_timeout.timeout(TIMEOUT_SECONDS), self._host_limit:
+        async with asyncio.timeout(TIMEOUT_SECONDS), self._host_limit:
             response = None
             try:
                 auth = DigestAuth(self._username, self._password, self._session, self._digest_state)
@@ -1109,7 +1108,7 @@ class DahuaClient:
         """Make the request. One caller per shared read reaches here."""
         url = self._base + url
         try:
-            async with async_timeout.timeout(TIMEOUT_SECONDS), self._host_limit:
+            async with asyncio.timeout(TIMEOUT_SECONDS), self._host_limit:
                 response = None
                 try:
                     auth = DigestAuth(self._username, self._password, self._session, self._digest_state)


### PR DESCRIPTION
## The problem

`client.py` imports `async_timeout`, but **Home Assistant no longer ships it**. On a current Core it appears in none of:

- `requirements.txt`
- `homeassistant/package_constraints.txt`
- the requirements of any integration in `requirements_all.txt`

aiohttp dropped it as a dependency too, once Python 3.11 shipped `asyncio.timeout`.

This integration's `manifest.json` declares no `requirements`, so Home Assistant will not install it either. On a Core that no longer ships it, line 7 of `client.py` raises `ModuleNotFoundError` — and since `client.py` is imported by `__init__.py`, **the whole integration fails to load and every camera disappears**.

What makes it easy to miss: nothing warns beforehand. On a Core that still ships `async_timeout` the import succeeds, so the failure only appears the moment someone updates.

## How I found it

I was checking whether a 2025.3 installation with 20 Dahua channels could safely jump to a current Core. The logs pointed at something else — the `_attr_frontend_stream_type` deprecation — but that turned out to be inert (nothing in HA reads it, and entities have no `__slots__`, so setting it cannot raise). #624 has removed it since anyway.

Auditing every `homeassistant` and third-party import is what surfaced this one. Everything else is clean: the `light` platform already uses `LightEntityFeature`/`ColorMode`, `async_scan_tag` still exists with the same signature, `requests` is still shipped by HA, and no removed stdlib module is used.

## The change

`asyncio.timeout` has been in the standard library since Python 3.11 and is a drop-in replacement. `asyncio` was already imported in this file.

7 call sites, same timeouts, one import fewer — no functional change.

I checked the equivalence rather than assuming it, including the combined form that three of these call sites use:

```
expiry ..................... TimeoutError  (same as async_timeout)
inside the deadline ........ passes cleanly
`async with a, b:` ......... works combined
```

`hacs.json` declares a minimum of Home Assistant 2025.1.2, which requires Python 3.13, so this is safe for every version the integration supports.

## What I could not verify locally

I could not run the repo's test suite: `pytest-homeassistant-custom-component==0.13.286` needs a newer Python than the machine I had. The file compiles and the semantics are verified as above, but CI is the real check here.

Happy to adjust anything — and thanks for the recent burst of work on this integration.
