### PR TITLE
Stop polling a device that is refusing to answer

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -68,14 +68,54 @@ EVENT_STREAM_RETRY_SECONDS = 60
 EVENT_STREAM_HEALTHY_SECONDS = 60
 EVENT_STREAM_SHORT_RETRY_SECONDS = 10
 
+# A stream that dies on contact will keep dying on contact: the device is
+# refusing us, not hiccuping. Asking again every sixty seconds forever is how a
+# device that ran out of connections stays out of connections, because each
+# attempt costs it another one. Back off instead, to this ceiling.
+EVENT_STREAM_MAX_RETRY_SECONDS = 600
 
-def event_stream_retry_delay(lived_seconds: float) -> float:
+
+def event_stream_retry_delay(lived_seconds: float, consecutive_failures: int = 0) -> float:
     """How long to wait before re-attaching, given how long the stream lasted."""
     if lived_seconds < 10:
-        return jittered(EVENT_STREAM_RETRY_SECONDS)
+        # Double per successive instant death, so a device that is refusing
+        # attach gets asked less often the longer it keeps refusing.
+        doublings = max(0, consecutive_failures - 1)
+        backoff = EVENT_STREAM_RETRY_SECONDS * (2 ** min(doublings, MAX_BACKOFF_DOUBLINGS))
+        return jittered(min(backoff, EVENT_STREAM_MAX_RETRY_SECONDS))
     if lived_seconds < EVENT_STREAM_HEALTHY_SECONDS:
         return jittered(EVENT_STREAM_SHORT_RETRY_SECONDS)
     return 0.0
+
+
+# A single missed poll is a blip -- a snapshot timing out, a device busy writing
+# to disk -- and backing off on one would make the integration feel sluggish for
+# no reason. Past that, the device is not answering and polling it on the
+# configured cadence only adds to whatever is wrong.
+FAILURES_BEFORE_BACKOFF = 2
+
+# Guard on the exponent so the arithmetic stays sane for a device that has been
+# failing for a week. The time ceilings below are what actually bind.
+MAX_BACKOFF_DOUBLINGS = 6
+
+# However long the poll interval is, never leave a failing device unpolled for
+# longer than this, or a device that recovers stays missing for an afternoon.
+POLL_BACKOFF_CAP = timedelta(minutes=15)
+
+
+def failure_backoff(base: timedelta, consecutive: int) -> timedelta:
+    """The interval to poll at, given this many consecutive failures.
+
+    Returns the configured interval until the failures stop looking incidental,
+    then doubles per failure up to a ceiling.
+    """
+    if consecutive <= FAILURES_BEFORE_BACKOFF:
+        return base
+    doublings = min(consecutive - FAILURES_BEFORE_BACKOFF, MAX_BACKOFF_DOUBLINGS)
+    # Never shorter than the interval the user asked for: someone already
+    # polling every half hour is not the problem this is here to solve, and
+    # backing "off" to something faster would be worse than doing nothing.
+    return min(base * (2 ** doublings), max(POLL_BACKOFF_CAP, base))
 
 
 def jittered(seconds: float, fraction: float = EVENT_STREAM_JITTER) -> float:
@@ -310,8 +350,13 @@ async def _async_evaluate_host(hass: HomeAssistant, address: str) -> None:
 
 
 @callback
-def async_record_host_failure(hass: HomeAssistant, address: str, entry_id: str) -> None:
-    """Note a failed refresh, raising a card once it stops looking like a blip."""
+def async_record_host_failure(hass: HomeAssistant, address: str, entry_id: str) -> int:
+    """Note a failed refresh, raising a card once it stops looking like a blip.
+
+    Returns how many consecutive failures this host has now had, which is what
+    the caller backs off on. Keyed by host rather than by entry: eleven channels
+    of one NVR are eleven witnesses to a single outage, not eleven outages.
+    """
     address = normalize_address(address)
     state = _HOST_FAILURES.setdefault(
         address,
@@ -321,13 +366,14 @@ def async_record_host_failure(hass: HomeAssistant, address: str, entry_id: str) 
     state["entry_ids"].add(entry_id)
 
     if state["consecutive"] < UNREACHABLE_AFTER_FAILURES:
-        return
+        return state["consecutive"]
     # Re-evaluate on the threshold, then only as often as the probe interval
     # allows, so a wedged host does not get probed on every poll.
     if state["consecutive"] == UNREACHABLE_AFTER_FAILURES or (
         time.time() - state.get("last_probe", 0) >= HTTPS_PROBE_MIN_INTERVAL
     ):
         hass.async_create_task(_async_evaluate_host(hass, address))
+    return state["consecutive"]
 
 
 @callback
@@ -390,6 +436,9 @@ class DahuaHostEventStream:
         self._task: asyncio.Task | None = None
         # Whether the last attach failed, so an outage is reported once.
         self._failing = False
+        # How many times running the stream has died on contact, which is what
+        # the retry delay backs off on.
+        self._consecutive_failures = 0
 
     @property
     def coordinators(self) -> list:
@@ -467,11 +516,13 @@ class DahuaHostEventStream:
                 raise
             except asyncio.TimeoutError:
                 self._failing = False
+                self._consecutive_failures = 0
                 _LOGGER.debug("Recycling event stream for %s", self._address)
             except Exception as ex:  # pylint: disable=broad-except
                 # Say it once per outage, not once per retry. Silence was the
                 # old behaviour and it is why these failures went unreported;
                 # a warning every sixty seconds forever is the other extreme.
+                self._consecutive_failures += 1
                 if not self._failing:
                     self._failing = True
                     _LOGGER.warning(
@@ -483,8 +534,11 @@ class DahuaHostEventStream:
                     )
             else:
                 self._failing = False
+                self._consecutive_failures = 0
 
-            retry_in = event_stream_retry_delay(time.monotonic() - start_time)
+            retry_in = event_stream_retry_delay(
+                time.monotonic() - start_time, self._consecutive_failures
+            )
             if retry_in:
                 _LOGGER.debug(
                     "Reconnecting to event stream for %s in %.0fs",
@@ -676,6 +730,34 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             finally:
                 await _release_connector(self._address)
 
+    def _restore_poll_interval(self) -> None:
+        """Put the configured interval back after a device starts answering."""
+        # Read it back from the entry rather than remembering it: the user may
+        # have changed the option while we were backed off, and their new value
+        # should win over whatever we were doubling from.
+        configured = get_configured_scan_interval(self.config_entry)
+        if self.update_interval != configured:
+            _LOGGER.debug(
+                "%s is answering again, polling every %ss", self._address, configured.total_seconds()
+            )
+            self.update_interval = configured
+
+    def _back_off_poll_interval(self, consecutive: int) -> None:
+        """Poll a device that is not answering less often, not just as often.
+
+        Every request costs the device a connection and a login it has to
+        refuse. Keeping the configured cadence against a device that is already
+        refusing is what turns a device that ran out of connections into one
+        that stays out of them until it is power cycled.
+        """
+        interval = failure_backoff(get_configured_scan_interval(self.config_entry), consecutive)
+        if self.update_interval != interval:
+            _LOGGER.debug(
+                "%s has failed %s times, backing off to %ss",
+                self._address, consecutive, interval.total_seconds(),
+            )
+            self.update_interval = interval
+
     async def _async_update_data(self):
         """Reload the camera information"""
         data = {}
@@ -820,11 +902,15 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     self.config_entry.async_start_reauth(self.hass)
                     raise UpdateFailed("Authentication failed") from exception
                 _LOGGER.warning("Failed to initialize device at %s: %s", self._address, exception)
-                async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
+                self._back_off_poll_interval(
+                    async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
+                )
                 raise UpdateFailed("Dahua device at " + self._address + " isn't fully initialized yet")
             except Exception as exception:
                 _LOGGER.warning("Failed to initialize device at %s: %s", self._address, exception)
-                async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
+                self._back_off_poll_interval(
+                    async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
+                )
                 raise UpdateFailed("Dahua device at " + self._address + " isn't fully initialized yet")
 
         # This is the event loop code that's called every n seconds
@@ -894,12 +980,14 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     data.update(light_v2)
 
             async_record_host_success(self.hass, self._address)
+            self._restore_poll_interval()
             return data
         except Exception as exception:
             _LOGGER.warning("Failed to sync device state for %s. See README to enable debug logs to get full exception",
                             self._address)
             _LOGGER.debug("Failed to sync device state for %s", self._address, exc_info=exception)
-            async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
+            consecutive = async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
+            self._back_off_poll_interval(consecutive)
             raise UpdateFailed() from exception
 
     def on_receive_vto_event(self, event: dict):

--- a/tests/dahua/test_failure_backoff.py
+++ b/tests/dahua/test_failure_backoff.py
@@ -1,0 +1,144 @@
+"""A device that is not answering must be asked less often, not just as often.
+
+Every request costs a Dahua device a connection and a login it has to refuse.
+Polling a device that has run out of connections on the configured cadence is
+what keeps it out of connections, so these pin the backoff.
+"""
+
+import statistics
+from datetime import timedelta
+from types import SimpleNamespace
+
+from custom_components.dahua import (
+    EVENT_STREAM_RETRY_SECONDS,
+    FAILURES_BEFORE_BACKOFF,
+    POLL_BACKOFF_CAP,
+    DahuaDataUpdateCoordinator,
+    event_stream_retry_delay,
+    failure_backoff,
+)
+
+BASE = timedelta(seconds=30)
+
+
+def _coordinator(**options):
+    """A coordinator with only what the interval helpers touch."""
+    c = object.__new__(DahuaDataUpdateCoordinator)
+    c.config_entry = SimpleNamespace(data={}, options=dict(options))
+    c.update_interval = BASE
+    c._address = "192.168.0.99"
+    return c
+
+
+# --- a blip is not an outage --------------------------------------------------
+
+def test_a_single_failure_does_not_change_the_interval():
+    """Backing off on one timeout would make everything feel sluggish."""
+    assert failure_backoff(BASE, 1) == BASE
+
+
+def test_failures_up_to_the_threshold_keep_the_configured_interval():
+    for n in range(1, FAILURES_BEFORE_BACKOFF + 1):
+        assert failure_backoff(BASE, n) == BASE, f"{n} failures already backed off"
+
+
+# --- past that, ask less often ------------------------------------------------
+
+def test_the_interval_grows_once_the_failures_persist():
+    first = failure_backoff(BASE, FAILURES_BEFORE_BACKOFF + 1)
+    second = failure_backoff(BASE, FAILURES_BEFORE_BACKOFF + 2)
+
+    assert first > BASE, "a device that keeps failing is still polled as often"
+    assert second > first, "the interval is not growing with the failures"
+
+
+def test_the_interval_is_capped():
+    """A device that recovers must not stay missing for an afternoon."""
+    assert failure_backoff(BASE, 500) == POLL_BACKOFF_CAP
+
+
+def test_a_long_configured_interval_is_never_shortened():
+    """The cap is a ceiling on backoff, not an override of the user's choice."""
+    base = POLL_BACKOFF_CAP * 2
+    assert failure_backoff(base, 500) >= base
+
+
+def test_an_outage_costs_the_device_far_fewer_requests():
+    """The point of all this: count the polls a wedged device actually gets."""
+    window = timedelta(hours=1).total_seconds()
+
+    def polls_in_window():
+        elapsed, count = 0.0, 0
+        while elapsed < window:
+            count += 1
+            elapsed += failure_backoff(BASE, count).total_seconds()
+        return count
+
+    without_backoff = window / BASE.total_seconds()  # what it used to do
+
+    assert polls_in_window() * 4 < without_backoff, (
+        "backing off is not meaningfully reducing the load on a failing device"
+    )
+
+
+# --- recovery -----------------------------------------------------------------
+
+def test_answering_again_restores_the_configured_interval():
+    c = _coordinator()
+    c._back_off_poll_interval(FAILURES_BEFORE_BACKOFF + 3)
+    assert c.update_interval > BASE
+
+    c._restore_poll_interval()
+
+    assert c.update_interval == BASE
+
+
+def test_recovery_honours_an_interval_changed_during_the_outage():
+    """The user's new value wins over whatever we were doubling from."""
+    c = _coordinator()
+    c._back_off_poll_interval(FAILURES_BEFORE_BACKOFF + 3)
+
+    c.config_entry.options["scan_interval"] = 300
+    c._restore_poll_interval()
+
+    assert c.update_interval == timedelta(seconds=300)
+
+
+def test_backing_off_doubles_the_users_interval_not_the_default():
+    c = _coordinator(scan_interval=120)
+    c._back_off_poll_interval(FAILURES_BEFORE_BACKOFF + 1)
+
+    assert c.update_interval > timedelta(seconds=120)
+
+
+# --- the event stream ---------------------------------------------------------
+
+def _mean_delay(lived, failures, samples=300):
+    """The delay is jittered, so a single sample compares two coin flips."""
+    return statistics.fmean(
+        event_stream_retry_delay(lived, failures) for _ in range(samples)
+    )
+
+
+def test_a_stream_that_dies_on_contact_is_retried_less_often():
+    """Attaching costs a connection too, so a refused attach must back off."""
+    once = _mean_delay(0.5, 1)
+    twice = _mean_delay(0.5, 2)
+    later = _mean_delay(0.5, 5)
+
+    # Each step doubles and the jitter is a tenth, so a real doubling clears
+    # 1.5x comfortably while an unchanged delay cannot reach it.
+    assert twice > once * 1.5, "a stream refused twice is retried just as fast"
+    assert later > twice * 1.5
+
+
+def test_the_first_failure_still_waits_the_old_delay():
+    """Behaviour for a one-off failure should be unchanged."""
+    spread = EVENT_STREAM_RETRY_SECONDS * 0.2
+    assert abs(event_stream_retry_delay(0.5, 1) - EVENT_STREAM_RETRY_SECONDS) <= spread
+
+
+def test_a_stream_that_lived_is_still_reconnected_at_once():
+    """Backoff must not slow down the healthy hourly recycle."""
+    assert event_stream_retry_delay(3600, 0) == 0.0
+    assert event_stream_retry_delay(3600, 9) == 0.0


### PR DESCRIPTION
A Dahua device answers `401` when it has run out of connections, not only when a password is wrong — and every request costs it another connection plus a login it has to refuse.

Nothing backs off today. A failing entry keeps being polled on its configured interval, and the event stream keeps re-attaching every sixty seconds, for as long as the failure lasts. Each retry spends the connection the device needs in order to recover.

That is the loop in #603. @DeveloperSzkodziu has two cameras that work for days and then fail until they are physically power cycled. Their log shows the same seven `action=getConfig` reads failing every thirty seconds, plus an event stream re-attach every sixty, indefinitely. #628 cut how many requests a healthy poll makes; this stops a device that has already tripped from being held down by the retries.

### What changes

Two missed polls are still a blip and change nothing — a snapshot timing out or a device busy writing to disk shouldn't make the integration feel sluggish. Past that the interval doubles per failure to a fifteen minute ceiling, and a stream that dies on contact doubles to a ten minute ceiling. Answering once restores the configured interval immediately.

Three details worth calling out:

- **The interval is read back from the config entry on recovery** rather than remembered. If the user changes the option during an outage, their new value wins over whatever we were doubling from.
- **Backoff never returns something shorter than the configured interval.** Without that guard, an entry already polling every half hour would have been *sped up* by failing.
- **Backoff is keyed by host,** reusing the counter the repair flow already keeps. Eleven channels of one NVR are eleven witnesses to one outage, not eleven outages, and they should ease off together rather than each on its own count.

### Which reintroduced bug fails which test

| mutation | tests that fail |
|---|---|
| `failure_backoff` returns `base` (the behaviour being fixed) | the interval grows once the failures persist; the interval is capped; an outage costs the device far fewer requests |
| event stream ignores the failure count (the behaviour being fixed) | a stream that dies on contact is retried less often |
| drop the `max(cap, base)` guard | a long configured interval is never shortened |

The stream test compares means over 300 samples rather than single values. The delay is jittered by a tenth, and a single comparison passed against the *unfixed* code about half the time — it caught the missing backoff only by luck until it was averaged.

### Not in this PR

A `401` after startup is still swallowed. `async_start_reauth` is only reachable inside the `if not self.initialized` branch, so once an entry is up an auth failure becomes a generic "Failed to sync device state" with nothing in the UI to say credentials are being refused. That wants fixing too, but the signal for it is ambiguous — on Dahua a `401` means both "wrong password" and "out of connections", and prompting for a password because a camera is busy would be worse than the current silence. I'd rather settle how to tell those apart than guess, so it follows separately.