### PR TITLE
Stop fetching answers no loaded platform will read

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -35,6 +35,10 @@ from .const import (
     CONF_NAME,
     DOMAIN,
     PLATFORMS,
+    CAMERA,
+    LIGHT,
+    SELECT,
+    SWITCH,
     CONF_RTSP_PORT,
     STARTUP_MESSAGE,
     CONF_CHANNEL,
@@ -758,6 +762,20 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             )
             self.update_interval = interval
 
+    def _wanted_by(self, *platforms: str) -> bool:
+        """Whether anything that reads this answer is actually loaded.
+
+        The poll used to fetch purely on what the device reported supporting,
+        so an entry with `select` switched off still paid for a PTZ position
+        read on every cycle to feed an entity that was never created. Each of
+        those costs the device a connection and a login it has to refuse.
+
+        Read from the entry options rather than `coordinator.platforms`: the
+        first refresh runs before the platforms are forwarded, so that list is
+        still empty then and everything would be skipped on the first poll.
+        """
+        return any(self.config_entry.options.get(platform, True) for platform in platforms)
+
     async def _async_update_data(self):
         """Reload the camera information"""
         data = {}
@@ -938,27 +956,32 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     return None
 
             # Figure out which APIs we need to call and then fan out and gather the results
-            coros = [
-                asyncio.ensure_future(self.client.async_get_config_motion_detection()),
-            ]
-            if self._supports_ptz_position:
+            # Motion detection state is read by the camera entity as well as
+            # the switch, so it survives either one being enabled.
+            coros = []
+            if self._wanted_by(CAMERA, SWITCH):
+                coros.append(asyncio.ensure_future(self.client.async_get_config_motion_detection()))
+            # Only the preset position select reads this, and it is one of the
+            # two per-poll calls the config cache does not cover.
+            if self._supports_ptz_position and self._wanted_by(SELECT):
                 coros.append(asyncio.ensure_future(_ptz_position()))
-            if self.supports_infrared_light():
+            if self.supports_infrared_light() and self._wanted_by(LIGHT):
                 coros.append(
                     asyncio.ensure_future(self.client.async_get_config_lighting(self._channel, self._profile_mode)))
-            if self._supports_disarming_linkage:
+            if self._supports_disarming_linkage and self._wanted_by(SWITCH):
                 coros.append(asyncio.ensure_future(self.client.async_get_disarming_linkage()))
-            if self._supports_event_notifications:
+            if self._supports_event_notifications and self._wanted_by(SWITCH):
                 coros.append(asyncio.ensure_future(self.client.async_get_event_notifications()))
-            if self._supports_coaxial_control:
+            # The siren switch and the security light both read this one.
+            if self._supports_coaxial_control and self._wanted_by(LIGHT, SWITCH):
                 coros.append(asyncio.ensure_future(self.client.async_get_coaxial_control_io_status()))
-            if self._supports_smart_motion_detection:
+            if self._supports_smart_motion_detection and self._wanted_by(SWITCH):
                 coros.append(asyncio.ensure_future(self.client.async_get_smart_motion_detection()))
-            if self.supports_smart_motion_detection_amcrest():
+            if self.supports_smart_motion_detection_amcrest() and self._wanted_by(SWITCH):
                 coros.append(asyncio.ensure_future(self.client.async_get_video_analyse_rules_for_amcrest()))
-            if self.is_amcrest_doorbell():
+            if self.is_amcrest_doorbell() and self._wanted_by(LIGHT):
                 coros.append(asyncio.ensure_future(self.client.async_get_light_global_enabled()))
-            if self._supports_lighting_v2:   #add lighing_v2 API if it is supported
+            if self._supports_lighting_v2 and self._wanted_by(LIGHT):   #add lighing_v2 API if it is supported
                 coros.append(asyncio.ensure_future(self.client.async_get_lighting_v2()))
 
 
@@ -974,7 +997,8 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             # Only if it was not already fetched above: on a camera that both
             # supports the v2 API and reports a security light, this was being
             # requested twice on every poll.
-            if (self.supports_security_light() or self.is_flood_light()) and not self._supports_lighting_v2:
+            if ((self.supports_security_light() or self.is_flood_light())
+                    and not self._supports_lighting_v2 and self._wanted_by(LIGHT)):
                 light_v2 = await self.client.async_get_lighting_v2()
                 if light_v2 is not None:
                     data.update(light_v2)

--- a/tests/dahua/test_poll_skips_unused.py
+++ b/tests/dahua/test_poll_skips_unused.py
@@ -1,0 +1,131 @@
+"""The poll must not fetch answers nothing is going to read.
+
+Each request costs the device a connection and a login it has to refuse, so an
+entry with a platform switched off should stop paying for the reads that only
+that platform consumes. These pin each request to the platform that reads it.
+"""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+
+class _Client:
+    """Records which API each poll actually calls."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, name):
+        async def call(*args, **kwargs):
+            self.calls.append(name)
+            return {}
+        return call
+
+
+def _coordinator(**options):
+    c = object.__new__(DahuaDataUpdateCoordinator)
+    c.client = _Client()
+    c.hass = SimpleNamespace()
+    c._address = "10.0.0.5"
+    c._channel = 0
+    c.initialized = True
+    c.model = ""            # keeps every model-string capability out of the way
+    c._profile_mode = 0
+    c._supports_profile_mode = False
+    c._supports_ptz_position = True
+    c._supports_disarming_linkage = True
+    c._supports_event_notifications = True
+    c._supports_coaxial_control = True
+    c._supports_smart_motion_detection = True
+    c._supports_lighting_v2 = True
+    c._supports_lighting = True          # gates supports_infrared_light()
+    c._supports_floodlightmode = False
+    c._channel_number = 1
+    c._max_streams = 3
+    c._serial_number = "SER1"
+    c.machine_name = "cam"
+    c._preset_position = "0"
+    c.config_entry = SimpleNamespace(data={}, options=dict(options), entry_id="e1")
+    c.update_interval = timedelta(seconds=30)
+    return c
+
+
+async def _poll(**options):
+    c = _coordinator(**options)
+    await c._async_update_data()
+    return c.client.calls
+
+
+PTZ = "async_get_ptz_position"
+COAXIAL = "async_get_coaxial_control_io_status"
+MOTION = "async_get_config_motion_detection"
+LIGHTING_V2 = "async_get_lighting_v2"
+INFRARED = "async_get_config_lighting"
+DISARMING = "async_get_disarming_linkage"
+NOTIFICATIONS = "async_get_event_notifications"
+SMART_MOTION = "async_get_smart_motion_detection"
+
+
+async def test_everything_is_fetched_when_every_platform_is_on():
+    """The default must not change: this is what an untouched entry does."""
+    calls = await _poll()
+
+    for api in (PTZ, COAXIAL, MOTION, LIGHTING_V2, INFRARED, DISARMING,
+                NOTIFICATIONS, SMART_MOTION):
+        assert api in calls, f"{api} stopped being fetched by default"
+
+
+# --- each request follows the platform that reads it -------------------------
+
+async def test_ptz_position_is_skipped_without_the_select_platform():
+    """Only the preset position select reads it, and it is uncached."""
+    assert PTZ not in await _poll(select=False)
+
+
+async def test_switch_reads_are_skipped_without_the_switch_platform():
+    calls = await _poll(switch=False)
+
+    for api in (DISARMING, NOTIFICATIONS, SMART_MOTION):
+        assert api not in calls, f"{api} is only read by a switch"
+
+
+async def test_light_reads_are_skipped_without_the_light_platform():
+    calls = await _poll(light=False)
+
+    assert LIGHTING_V2 not in calls
+    assert INFRARED not in calls
+
+
+# --- a request with two readers survives losing one of them ------------------
+
+async def test_coaxial_status_survives_either_reader():
+    """The siren switch and the security light both read this."""
+    assert COAXIAL in await _poll(light=False), "the siren switch still needs it"
+    assert COAXIAL in await _poll(switch=False), "the security light still needs it"
+    assert COAXIAL not in await _poll(light=False, switch=False)
+
+
+async def test_motion_detection_survives_either_reader():
+    """The camera entity reads this as well as the switch."""
+    assert MOTION in await _poll(switch=False), "the camera entity still needs it"
+    assert MOTION in await _poll(camera=False), "the motion switch still needs it"
+    assert MOTION not in await _poll(camera=False, switch=False)
+
+
+# --- turning one platform off must not take another's reads with it ----------
+
+@pytest.mark.parametrize("disabled,still_wanted", [
+    ("select", [COAXIAL, MOTION, LIGHTING_V2, DISARMING]),
+    ("light", [PTZ, COAXIAL, MOTION, DISARMING, SMART_MOTION]),
+    ("switch", [PTZ, COAXIAL, MOTION, LIGHTING_V2, INFRARED]),
+    ("binary_sensor", [PTZ, COAXIAL, MOTION, LIGHTING_V2, DISARMING]),
+])
+async def test_disabling_one_platform_leaves_the_others_alone(disabled, still_wanted):
+    calls = await _poll(**{disabled: False})
+
+    for api in still_wanted:
+        assert api in calls, f"disabling {disabled} wrongly dropped {api}"


### PR DESCRIPTION
Every entry can already switch off `camera`, `switch`, `light`, `select` and `binary_sensor`. Those toggles gate `async_forward_entry_setups` — entity creation — and nothing else. The poll decides what to request purely from what the device reports supporting and never looks at them.

So an entry with `select` switched off still calls `ptz.cgi?action=getStatus` on every single cycle, to populate a preset position entity that was never created.

That isn't free. Measured on a Dahua NVR, every logical CGI call costs **two TCP connections, two HTTP requests and one refused login**, because the device answers `Connection: close` and reissues its digest nonce each time, so a cached challenge is always rejected. PTZ status and coaxial status are also the two per-poll reads that #628's config cache does not cover, so they are paid in full on every cycle.

### The change

Follow the toggles that already exist rather than adding a dozen new "poll this?" options. Each request is gated on the platform that reads its answer:

| request | gated on |
|---|---|
| `ptz.cgi getStatus` | `select` |
| `coaxialControlIO getStatus` | `light` **or** `switch` |
| `MotionDetect` | `camera` **or** `switch` |
| `Lighting_V2`, infrared, `LightGlobal` | `light` |
| `DisableLinkage`, `DisableEventNotify`, `SmartMotionDetect` | `switch` |

The mapping was derived by finding each accessor's callers rather than by assuming — `is_siren_on` in `switch.py`, `is_security_light_on` in `light.py`, and so on. The two requests with a second reader keep working when either platform alone is enabled, which is what the `or` cases pin. Binary sensors read the event stream rather than the poll, so they gate nothing.

**The profile mode read is deliberately left alone.** `diagnostics.py` reports it as well as the light platform, and it is a `getConfig`, so #628 already caches it — gating it would risk a stale diagnostics field for no real saving.

**Read from the entry options, not `coordinator.platforms`.** The first refresh runs before the platforms are forwarded, so that list is still empty at that point and gating on it would skip every read on the first poll.

### Tests

The failure mode here is silent — map a request to the wrong reader and an entity quietly shows a default instead of erroring — so the tests pin the mapping rather than the mechanism:

- every request is still fetched with all platforms on, so the default is unchanged
- each request disappears when the platform that reads it is switched off
- the two shared requests survive losing *either* reader, and stop only when both are off
- switching off one platform doesn't drop another platform's reads

### Where it came from

@DeveloperSzkodziu suggested this in #603, having noticed their PF8-PV generates far more traffic than their other cameras. It does: it is PTZ **and** active deterrence, so it qualifies for both of the uncached per-poll reads, while a fixed camera makes neither. They don't use PTZ in Home Assistant at all and are currently paying for it every cycle.

Related to #514, which approaches this from the capability side — don't load a platform at all when the device supports nothing on it. Worth noting that PR has been untouched since 2025-10-11 and no longer merges, and its other half (exception handling around the PTZ probe) is already in main. The part still undone is orthogonal to this change rather than overlapping: it decides which *platforms* to load, this decides which *requests* to make for the platforms that did load.

