### PR TITLE
Set the platforms up together instead of one after another

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -203,10 +203,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     # https://developers.home-assistant.io/docs/config_entries_index/
-    for platform in PLATFORMS:
-        if entry.options.get(platform, True):
-            coordinator.platforms.append(platform)
-            await hass.config_entries.async_forward_entry_setups(entry, [platform])
+    # Forward every platform in one call. Home Assistant gathers them into
+    # concurrent tasks, so one call sets all of them up at once; calling it once
+    # per platform instead serialised them, and an entry's setup budget then had
+    # to cover the sum of six platforms rather than the slowest one. A device
+    # answering slowly could exhaust it and take the whole entry down with a
+    # CancelledError -- see #513.
+    coordinator.platforms.extend(p for p in PLATFORMS if entry.options.get(p, True))
+    if coordinator.platforms:
+        await hass.config_entries.async_forward_entry_setups(entry, coordinator.platforms)
 
     # Wrapped, because unloading does not clear an entry's update listeners.
     # A plain add_update_listener leaves one behind on every reload, and then a
@@ -1199,6 +1204,10 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         This callback will be called when the event fire """
         event_key = self.get_event_key(event_name)
         self._dahua_event_listeners[event_key] = listener
+
+    def supports_disarming_linkage(self) -> bool:
+        """Whether the device answered the disarming linkage read during setup."""
+        return self._supports_disarming_linkage
 
     def supports_siren(self) -> bool:
         """

--- a/custom_components/dahua/switch.py
+++ b/custom_components/dahua/switch.py
@@ -1,5 +1,4 @@
 """Switch platform for dahua."""
-from aiohttp import ClientError
 from homeassistant.core import HomeAssistant
 from homeassistant.components.switch import SwitchEntity
 from custom_components.dahua import DahuaDataUpdateCoordinator
@@ -24,12 +23,12 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     if coordinator.supports_smart_motion_detection() or coordinator.supports_smart_motion_detection_amcrest():
         devices.append(DahuaSmartMotionDetectionBinarySwitch(coordinator, entry))
 
-    try:
-        await coordinator.client.async_get_disarming_linkage()
+    # The coordinator already asked the device this during setup and kept the
+    # answer. Asking again here put a network round trip inside platform setup,
+    # where a device that is slow to answer eats the entry's setup budget.
+    if coordinator.supports_disarming_linkage():
         devices.append(DahuaDisarmingLinkageBinarySwitch(coordinator, entry))
         devices.append(DahuaDisarmingEventNotificationsLinkageBinarySwitch(coordinator, entry))
-    except ClientError as exception:
-        pass
 
     async_add_devices(devices)
 

--- a/tests/dahua/test_setup_lifecycle.py
+++ b/tests/dahua/test_setup_lifecycle.py
@@ -17,7 +17,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components import dahua as dahua_module
-from custom_components.dahua.const import DOMAIN
+from custom_components.dahua.const import DOMAIN, PLATFORMS
 
 ADDRESS = "10.9.9.9"
 DATA = {
@@ -246,3 +246,43 @@ async def test_a_failed_setup_registers_no_listener_at_all(hass):
         await _try_setup(hass, entry)
 
     assert entry.update_listeners == []
+
+
+# --- how the platforms get forwarded ----------------------------------------
+
+async def test_every_platform_is_forwarded_in_a_single_call(hass):
+    """One call per platform serialises setup.
+
+    Home Assistant gathers the platforms it is handed into concurrent tasks, so
+    handing them over one at a time makes an entry's setup budget cover the sum
+    of every platform instead of the slowest one. A device answering slowly then
+    takes the whole entry down with a CancelledError -- issue #513.
+    """
+    entry = _entry(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _working(), starts, forward as forwarded, unload:
+        assert await _try_setup(hass, entry)
+
+    assert forwarded.await_count == 1, (
+        "platforms are still being forwarded one at a time (%s calls)"
+        % forwarded.await_count
+    )
+    assert set(forwarded.await_args.args[1]) == set(PLATFORMS)
+
+
+async def test_a_platform_switched_off_is_not_forwarded(hass):
+    """The single call must still respect the per-entry platform options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=DATA, options={"select": False, "light": False}
+    )
+    entry.add_to_hass(hass)
+    starts, forward, unload = _no_platforms(hass)
+
+    with _working(), starts, forward as forwarded, unload:
+        assert await _try_setup(hass, entry)
+
+    forwarded_platforms = set(forwarded.await_args.args[1])
+    assert "select" not in forwarded_platforms
+    assert "light" not in forwarded_platforms
+    assert "camera" in forwarded_platforms, "the others must still load"

--- a/tests/dahua/test_switch.py
+++ b/tests/dahua/test_switch.py
@@ -175,3 +175,73 @@ def test_is_on_reflects_the_coordinator(cls, key):
     assert s.is_on is False
     c.states[key] = True
     assert s.is_on is True
+
+
+# --- platform setup must not talk to the device -----------------------------
+
+async def test_setup_asks_the_device_nothing():
+    """A network call here spends the entry's setup budget.
+
+    The coordinator already read the disarming linkage during its own setup and
+    kept the answer; asking again put a round trip inside platform setup, where
+    a slow device could take the whole entry down (issue #513).
+    """
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from custom_components.dahua import switch as switch_module
+    from custom_components.dahua.const import DOMAIN
+
+    coordinator = _Coordinator()
+    coordinator.supports_siren = lambda: False
+    coordinator.supports_smart_motion_detection = lambda: False
+    coordinator.supports_disarming_linkage = lambda: True
+
+    hass = SimpleNamespace(data={DOMAIN: {"e1": coordinator}})
+    entry = SimpleNamespace(entry_id="e1", options={})
+    added = []
+
+    # The decision is what changed here, not how the entities are built.
+    with patch.multiple(
+        switch_module,
+        DahuaMotionDetectionBinarySwitch=lambda *a, **k: "motion",
+        DahuaDisarmingLinkageBinarySwitch=lambda *a, **k: "disarming",
+        DahuaDisarmingEventNotificationsLinkageBinarySwitch=lambda *a, **k: "notifications",
+    ):
+        await switch_module.async_setup_entry(hass, entry, added.extend)
+
+    assert coordinator.client.calls == [], (
+        "platform setup made a network call: %s" % coordinator.client.calls
+    )
+    assert "disarming" in added and "notifications" in added
+
+
+async def test_the_disarming_switches_follow_what_the_device_answered():
+    """A device that refused the read must not get switches it cannot serve."""
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from custom_components.dahua import switch as switch_module
+    from custom_components.dahua.const import DOMAIN
+
+    coordinator = _Coordinator()
+    coordinator.supports_siren = lambda: False
+    coordinator.supports_smart_motion_detection = lambda: False
+    coordinator.supports_disarming_linkage = lambda: False
+
+    hass = SimpleNamespace(data={DOMAIN: {"e1": coordinator}})
+    added = []
+
+    with patch.multiple(
+        switch_module,
+        DahuaMotionDetectionBinarySwitch=lambda *a, **k: "motion",
+        DahuaDisarmingLinkageBinarySwitch=lambda *a, **k: "disarming",
+        DahuaDisarmingEventNotificationsLinkageBinarySwitch=lambda *a, **k: "notifications",
+    ):
+        await switch_module.async_setup_entry(
+            hass, SimpleNamespace(entry_id="e1", options={}), added.extend
+        )
+
+    assert "disarming" not in added
+    assert "notifications" not in added
+    assert coordinator.client.calls == []


### PR DESCRIPTION
Fixes #513.

`async_setup_entry` forwarded each platform in its own call:

```python
for platform in PLATFORMS:
    if entry.options.get(platform, True):
        await hass.config_entries.async_forward_entry_setups(entry, [platform])
```

Home Assistant gathers whatever it is handed into concurrent tasks — `_async_forward_entry_setups_locked` is an `asyncio.gather` over the list it receives — so handing it a single platform at a time throws that away and runs six setups back to back.

The consequence is that an entry's setup budget has to cover the **sum** of every platform rather than the slowest one. A device answering slowly exhausts it and takes the whole entry down. That is #513: the traceback lands in `_async_forward_entry_setups_locked` with `switch` part-way through, and the entry fails with a `CancelledError`.

Forwarding them in one call restores the concurrency.

### The other half

`switch.py` was asking the device a question the coordinator had already asked:

```python
try:
    await coordinator.client.async_get_disarming_linkage()
    devices.append(DahuaDisarmingLinkageBinarySwitch(coordinator, entry))
    devices.append(DahuaDisarmingEventNotificationsLinkageBinarySwitch(coordinator, entry))
except ClientError:
    pass
```

The coordinator runs that same read during its own setup, catching the same `aiohttp.ClientError`, and keeps the result in `_supports_disarming_linkage`. So this was a second round trip for a value already known — and it sat inside platform setup, which is exactly where being slow is expensive. It now reads the stored capability through a public accessor, matching `supports_siren()` beside it.

Worth being precise about the size of that one: since #628 this is a `getConfig` with a 300s TTL and the coordinator's probe runs first, so on the happy path it was already a cache hit. The point is removing a **network dependency** from platform setup, not removing a request — it only became a real call when the coordinator's probe had failed or a write had cleared the cache, which is precisely the situation where setup is already struggling.

The exception classes are identical on both sides (`aiohttp.ClientError`), so which devices get those two switches is unchanged.

### Scope

Neither change addresses whatever made a platform slow enough to exhaust the budget in the first place. What it stops is one slow platform being able to spend every other platform's share of it.

### Tests

- every platform arrives in a **single** call, carrying all of them
- a platform switched off in the options is still absent from that call
- switch setup makes no client call at all, and its two disarming switches follow the stored capability in both directions

`test_setup_lifecycle.py` already mocks `async_forward_entry_setups`, so these assert on how it was called rather than on entities appearing.

### Credit

Diagnosed from #513 and #514, both by @NirBY, which sat unreviewed since October 2025. #514 also proposed exception handling around the PTZ probe — main has since grown that independently, including a model carve-out for the SDT4E425 — and separately proposed not loading platforms the device supports nothing on, which is still undone and orthogonal to this.