### PR TITLE
Put the configuration entities where configuration goes, and report firmware

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -1314,6 +1314,15 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         """ returns the device firmware e.g. """
         return self.data.get("version")
 
+    def get_device_serial_number(self) -> str:
+        """The serial the device reports, without the channel suffix.
+
+        get_serial_number below appends the channel so that every entry on an
+        NVR gets its own entity keys. That composite is not a serial number and
+        should not be shown to anyone as one.
+        """
+        return self._serial_number
+
     def get_serial_number(self) -> str:
         """ returns the device serial number. This is unique per device """
         if self._channel > 0:

--- a/custom_components/dahua/const.py
+++ b/custom_components/dahua/const.py
@@ -30,7 +30,8 @@ LIGHT = "light"
 CAMERA = "camera"
 SELECT = "select"
 BUTTON = "button"
-PLATFORMS = [BINARY_SENSOR, SWITCH, LIGHT, CAMERA, SELECT, BUTTON]
+SENSOR = "sensor"
+PLATFORMS = [BINARY_SENSOR, SWITCH, LIGHT, CAMERA, SELECT, BUTTON, SENSOR]
 
 
 # Configuration and options

--- a/custom_components/dahua/sensor.py
+++ b/custom_components/dahua/sensor.py
@@ -1,0 +1,68 @@
+"""Diagnostic sensors for Dahua devices.
+
+Both of these report values the coordinator already holds from setup, so the
+platform adds no requests at all. Anything that would need its own API call --
+storage use is the obvious one -- deliberately does not live here, because a
+diagnostic is not worth another login on a device that logs every one.
+"""
+
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+from .const import DOMAIN
+from .entity import DahuaBaseEntity
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
+    """Setup the sensor platform."""
+    coordinator: DahuaDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_devices([
+        DahuaFirmwareVersionSensor(coordinator, entry),
+        DahuaSerialNumberSensor(coordinator, entry),
+    ])
+
+
+class DahuaFirmwareVersionSensor(DahuaBaseEntity, SensorEntity):
+    """The firmware the device reports.
+
+    It is already in the device registry, but only as a label. As a sensor it
+    can be templated and compared, which is what makes "tell me when a camera
+    is behind" possible.
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def name(self):
+        return self._coordinator.get_device_name() + " Firmware Version"
+
+    @property
+    def unique_id(self):
+        return self._coordinator.get_serial_number() + "_firmware_version"
+
+    @property
+    def native_value(self):
+        return self._coordinator.get_firmware_version()
+
+
+class DahuaSerialNumberSensor(DahuaBaseEntity, SensorEntity):
+    """The serial the device reports."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def name(self):
+        return self._coordinator.get_device_name() + " Serial Number"
+
+    @property
+    def unique_id(self):
+        return self._coordinator.get_serial_number() + "_serial_number"
+
+    @property
+    def native_value(self):
+        # The device's own serial, not the channel-suffixed entity key: every
+        # channel of one NVR is the same physical box and should say so.
+        return self._coordinator.get_device_serial_number()

--- a/custom_components/dahua/switch.py
+++ b/custom_components/dahua/switch.py
@@ -2,6 +2,7 @@
 from aiohttp import ClientError
 from homeassistant.core import HomeAssistant
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory
 from custom_components.dahua import DahuaDataUpdateCoordinator
 
 from .const import DOMAIN, DISARMING_ICON, MOTION_DETECTION_ICON, SIREN_ICON, BELL_ICON
@@ -36,6 +37,13 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
 
 class DahuaMotionDetectionBinarySwitch(DahuaBaseEntity, SwitchEntity):
     """dahua motion detection switch class. Used to enable or disable motion detection"""
+
+    # Configuration, not a control: this changes how the camera behaves rather
+    # than doing something now, so it belongs in the device page's configuration
+    # section and out of auto-generated dashboards. The siren is deliberately
+    # left alone -- that one is an action someone wants on a dashboard.
+    _attr_entity_category = EntityCategory.CONFIG
+
 
     async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn on/enable motion detection."""
@@ -79,6 +87,9 @@ class DahuaMotionDetectionBinarySwitch(DahuaBaseEntity, SwitchEntity):
 class DahuaDisarmingLinkageBinarySwitch(DahuaBaseEntity, SwitchEntity):
     """will set the camera's disarming linkage (Event -> Disarming in the UI)"""
 
+    _attr_entity_category = EntityCategory.CONFIG
+
+
     async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn on/enable linkage"""
         channel = self._coordinator.get_channel()
@@ -121,6 +132,9 @@ class DahuaDisarmingLinkageBinarySwitch(DahuaBaseEntity, SwitchEntity):
 class DahuaDisarmingEventNotificationsLinkageBinarySwitch(DahuaBaseEntity, SwitchEntity):
     """will set the camera's event notifications when device is disarmed (Event -> Disarming -> Event Notifications in the UI)"""
 
+    _attr_entity_category = EntityCategory.CONFIG
+
+
     async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn on/enable event notifications"""
         channel = self._coordinator.get_channel()
@@ -161,6 +175,9 @@ class DahuaDisarmingEventNotificationsLinkageBinarySwitch(DahuaBaseEntity, Switc
 
 class DahuaSmartMotionDetectionBinarySwitch(DahuaBaseEntity, SwitchEntity):
     """Enables or disables the Smart Motion Detection option in the camera"""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
 
     async def async_turn_on(self, **kwargs):  # pylint: disable=unused-argument
         """Turn on SmartMotionDetect"""

--- a/tests/dahua/test_entity_categories.py
+++ b/tests/dahua/test_entity_categories.py
@@ -1,0 +1,100 @@
+"""Configuration entities should not be dressed up as controls.
+
+An entity with no category is a primary control: it lands in auto-generated
+dashboards and sits at the top of the device page. On an eleven channel NVR that
+put dozens of "disarming linkage" style toggles in front of the cameras someone
+actually wanted to look at.
+"""
+
+from types import SimpleNamespace
+
+from homeassistant.const import EntityCategory
+
+from custom_components.dahua.sensor import (
+    DahuaFirmwareVersionSensor,
+    DahuaSerialNumberSensor,
+)
+from custom_components.dahua.switch import (
+    DahuaDisarmingEventNotificationsLinkageBinarySwitch,
+    DahuaDisarmingLinkageBinarySwitch,
+    DahuaMotionDetectionBinarySwitch,
+    DahuaSirenBinarySwitch,
+    DahuaSmartMotionDetectionBinarySwitch,
+)
+
+CONFIGURATION_SWITCHES = [
+    DahuaMotionDetectionBinarySwitch,
+    DahuaDisarmingLinkageBinarySwitch,
+    DahuaDisarmingEventNotificationsLinkageBinarySwitch,
+    DahuaSmartMotionDetectionBinarySwitch,
+]
+
+
+def _declared_category(cls):
+    """What the class itself declares, not what it inherits."""
+    return cls.__dict__.get("_attr_entity_category")
+
+
+# --- switches ---------------------------------------------------------------
+
+def test_the_configuration_switches_say_they_are_configuration():
+    for cls in CONFIGURATION_SWITCHES:
+        assert _declared_category(cls) is EntityCategory.CONFIG, cls.__name__
+
+
+def test_the_siren_is_left_as_a_control():
+    """Sounding a siren is an action someone wants on a dashboard."""
+    assert _declared_category(DahuaSirenBinarySwitch) is None
+
+
+# --- diagnostic sensors -----------------------------------------------------
+
+def _coordinator():
+    c = SimpleNamespace(
+        get_device_name=lambda: "Garage",
+        get_serial_number=lambda: "SERIAL1_4",   # channel-suffixed entity key
+        get_device_serial_number=lambda: "SERIAL1",  # what the device reports
+        get_firmware_version=lambda: "2.800.0",
+    )
+    return c
+
+
+def _sensor(cls, coordinator):
+    entity = object.__new__(cls)
+    entity._coordinator = coordinator
+    entity.coordinator = coordinator
+    return entity
+
+
+def test_both_sensors_are_diagnostics():
+    for cls in (DahuaFirmwareVersionSensor, DahuaSerialNumberSensor):
+        assert _declared_category(cls) is EntityCategory.DIAGNOSTIC, cls.__name__
+
+
+def test_the_firmware_sensor_reports_the_firmware():
+    assert _sensor(DahuaFirmwareVersionSensor, _coordinator()).native_value == "2.800.0"
+
+
+def test_the_serial_sensor_reports_the_device_serial_not_the_entity_key():
+    """Every channel of one NVR is the same box and must say the same serial."""
+    value = _sensor(DahuaSerialNumberSensor, _coordinator()).native_value
+
+    assert value == "SERIAL1"
+    assert not value.endswith("_4"), "this is the entity key, not a serial number"
+
+
+def test_the_sensors_do_not_collide():
+    c = _coordinator()
+    ids = [
+        _sensor(cls, c).unique_id
+        for cls in (DahuaFirmwareVersionSensor, DahuaSerialNumberSensor)
+    ]
+
+    assert len(set(ids)) == len(ids)
+    assert all(i.startswith("SERIAL1_4_") for i in ids)
+
+
+def test_the_sensors_are_named_after_the_device():
+    c = _coordinator()
+    for cls in (DahuaFirmwareVersionSensor, DahuaSerialNumberSensor):
+        assert _sensor(cls, c).name.startswith("Garage "), cls.__name__

--- a/tests/dahua/test_entity_categories.py
+++ b/tests/dahua/test_entity_categories.py
@@ -30,21 +30,26 @@ CONFIGURATION_SWITCHES = [
 ]
 
 
-def _declared_category(cls):
-    """What the class itself declares, not what it inherits."""
-    return cls.__dict__.get("_attr_entity_category")
+def _category(cls):
+    """The category an instance of this class actually reports.
+
+    Read from an instance rather than the class dict: Home Assistant's
+    CachedProperties metaclass turns an `_attr_` class attribute into a property
+    object, so the class dict holds the descriptor and not the value.
+    """
+    return object.__new__(cls).entity_category
 
 
 # --- switches ---------------------------------------------------------------
 
 def test_the_configuration_switches_say_they_are_configuration():
     for cls in CONFIGURATION_SWITCHES:
-        assert _declared_category(cls) is EntityCategory.CONFIG, cls.__name__
+        assert _category(cls) is EntityCategory.CONFIG, cls.__name__
 
 
 def test_the_siren_is_left_as_a_control():
     """Sounding a siren is an action someone wants on a dashboard."""
-    assert _declared_category(DahuaSirenBinarySwitch) is None
+    assert _category(DahuaSirenBinarySwitch) is None
 
 
 # --- diagnostic sensors -----------------------------------------------------
@@ -68,7 +73,7 @@ def _sensor(cls, coordinator):
 
 def test_both_sensors_are_diagnostics():
     for cls in (DahuaFirmwareVersionSensor, DahuaSerialNumberSensor):
-        assert _declared_category(cls) is EntityCategory.DIAGNOSTIC, cls.__name__
+        assert _category(cls) is EntityCategory.DIAGNOSTIC, cls.__name__
 
 
 def test_the_firmware_sensor_reports_the_firmware():


### PR DESCRIPTION
An entity with no `entity_category` is a primary control: Home Assistant puts it in auto-generated dashboards and at the top of the device page.

Every switch this integration creates was uncategorised. On the install I checked this against — an eleven channel NVR plus a doorbell, **231 entities, 11 of them categorised** (the buttons from #623) — that means dozens of "Disarming Linkage" and "Event Notifications" toggles sitting in front of the cameras someone actually wanted to look at.

### What changes

Four switches are marked `EntityCategory.CONFIG`, because they configure how the camera behaves rather than doing something now:

- Motion Detection
- Smart Motion Detection
- Disarming Linkage
- Disarming Event Notifications

**The siren is deliberately left alone.** Sounding a siren is an action, and an action belongs on a dashboard.

Nothing changes about how any of them work. They move into the device page's configuration section and drop out of auto-generated dashboards. A dashboard someone built by hand still has them — Home Assistant doesn't remove placed cards.

### The sensor platform

Two diagnostics, both reporting values the coordinator **already holds from setup**, so the platform costs no requests at all:

- **Firmware Version** — already in the device registry, but only as a label. As a sensor it can be templated and compared, which is what makes "tell me when a camera is behind" possible.
- **Serial Number**

Anything needing its own API call is deliberately absent. Storage use is the obvious candidate and the obvious request, but a diagnostic is not worth another login on a device that writes one to its log for every call — which is the thing #628, #630 and #632 have all been reducing.

One detail worth flagging: the serial sensor reports what the *device* reports. `get_serial_number()` appends the channel so each entry on an NVR gets its own entity keys, and that composite is not a serial number — every channel of one NVR is the same physical box and should say so. Added `get_device_serial_number()` for the real value.

`PLATFORMS` gains `sensor`, and since the options flow enumerates `sorted(PLATFORMS)` the new platform is switchable per entry like every other one.

### Tests

- the four configuration switches declare `CONFIG`, and the siren declares nothing
- both sensors declare `DIAGNOSTIC`
- the firmware sensor reports the firmware
- the serial sensor reports the device serial and **not** the channel-suffixed entity key
- the two sensors don't collide on unique_id and are named after the device