### PR TITLE
Give the smart motion switch only to channels that have it

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -1286,22 +1286,30 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         """ Returns true if event notifications is enable """
         return self.data.get("table.DisableEventNotify.Enable", "").lower() == "false"
 
-    def is_smart_motion_detection_enabled(self) -> bool:
-        """ Returns true if smart motion detection is enabled
+    def _smart_motion_row(self):
+        """This channel's row in the SmartMotionDetect table, or None.
 
         SmartMotionDetect is a host-wide read that returns a row per channel,
-        and the rows are sparse: a device only reports the channels the option
-        is configured on. Reading row 0 for every channel reported one camera's
-        setting for all of them, and reported false for the whole NVR when
-        there is no row 0 at all.
+        and the rows are sparse: a device only reports the channels that can
+        actually do it. The row is therefore the per-channel capability signal
+        as well as the state -- measured on an NVR, disabling it leaves the row
+        in place reading false, and writing a row that does not exist is
+        accepted with 200 and silently discarded.
+
+        Both the capability check and the state read go through here so they
+        cannot disagree about which row belongs to this channel.
         """
-        if self.supports_smart_motion_detection_amcrest():
-            return self.data.get("table.VideoAnalyseRule[0][0].Enable", "").lower() == "true"
         value = self.data.get("table.SmartMotionDetect[{0}].Enable".format(self._channel))
         if value is None:
             # A single camera reports one row, and that row is row 0.
-            value = self.data.get("table.SmartMotionDetect[0].Enable", "")
-        return value.lower() == "true"
+            value = self.data.get("table.SmartMotionDetect[0].Enable")
+        return value
+
+    def is_smart_motion_detection_enabled(self) -> bool:
+        """ Returns true if smart motion detection is enabled """
+        if self.supports_smart_motion_detection_amcrest():
+            return self.data.get("table.VideoAnalyseRule[0][0].Enable", "").lower() == "true"
+        return (self._smart_motion_row() or "").lower() == "true"
 
     def is_siren_on(self) -> bool:
         """ Returns true if the camera siren is on """
@@ -1443,8 +1451,20 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         return self._max_streams
 
     def supports_smart_motion_detection(self) -> bool:
-        """ True if smart motion detection is supported"""
-        return self._supports_smart_motion_detection
+        """True if *this channel* can do smart motion detection.
+
+        The probe behind _supports_smart_motion_detection fetches the whole
+        host-wide table with no channel argument, so it succeeds for every
+        channel of an NVR whether or not that channel has the feature. On a
+        sixteen channel recorder measured for this, ten channels had cameras
+        and two had rows -- the other eight carried a switch that was
+        permanently off and whose writes the device accepted and ignored.
+
+        The row is the real signal, and it is already in data we fetch.
+        """
+        if not self._supports_smart_motion_detection:
+            return False
+        return self._smart_motion_row() is not None
 
     def supports_smart_motion_detection_amcrest(self) -> bool:
         """ True if smart motion detection is supported for an amcrest device"""

--- a/tests/dahua/test_smart_motion_capability.py
+++ b/tests/dahua/test_smart_motion_capability.py
@@ -1,0 +1,98 @@
+"""Smart motion detection is per channel, but the probe for it is not.
+
+The probe fetches the whole host-wide SmartMotionDetect table with no channel
+argument, so it succeeds for every channel of an NVR regardless of whether that
+channel can do anything. The table is sparse -- only channels that support it
+get a row -- so the row is the real signal.
+
+Measured on a DHI-NVR5464-16P-EI: ten channels had cameras, two had rows.
+Disabling one left its row in place reading "false", so the row tracks support
+and not state. Writing a row that does not exist returned 200 and changed
+nothing.
+"""
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+
+def _coordinator(channel, rows, probe_ok=True, model=""):
+    c = object.__new__(DahuaDataUpdateCoordinator)
+    c._channel = channel
+    c._supports_smart_motion_detection = probe_ok
+    c.model = model
+    c.data = {
+        "table.SmartMotionDetect[{0}].Enable".format(idx): value
+        for idx, value in rows.items()
+    }
+    return c
+
+
+# --- the capability follows the row -----------------------------------------
+
+def test_a_channel_with_a_row_supports_it():
+    assert _coordinator(1, {1: "true"}).supports_smart_motion_detection()
+
+
+def test_a_channel_with_a_row_supports_it_even_when_switched_off():
+    """The row persists reading false, which is how we know it means support."""
+    assert _coordinator(1, {1: "false"}).supports_smart_motion_detection()
+
+
+def test_a_channel_with_no_row_does_not_support_it():
+    """This is the phantom switch: permanently off, writes silently ignored."""
+    assert not _coordinator(2, {1: "true", 11: "true"}).supports_smart_motion_detection()
+
+
+def test_the_measured_nvr_supports_exactly_the_channels_with_rows():
+    rows = {1: "true", 11: "true"}          # what the real NVR reports
+    supported = [ch for ch in range(10) if _coordinator(ch, rows).supports_smart_motion_detection()]
+
+    assert supported == [1], "expected only the one configured channel of ten"
+
+
+# --- the single camera case, which must not regress -------------------------
+
+def test_a_single_camera_reporting_only_row_zero_still_supports_it():
+    """A lone camera reports one row and that row is row 0."""
+    assert _coordinator(0, {0: "true"}).supports_smart_motion_detection()
+
+
+def test_a_camera_whose_channel_does_not_match_row_zero_still_supports_it():
+    """The pre-existing fallback: entry channel and table row need not agree."""
+    assert _coordinator(3, {0: "true"}).supports_smart_motion_detection()
+
+
+# --- the probe still has a veto ---------------------------------------------
+
+def test_a_device_without_the_api_at_all_supports_nothing():
+    assert not _coordinator(0, {0: "true"}, probe_ok=False).supports_smart_motion_detection()
+
+
+# --- state and capability must agree ----------------------------------------
+
+def test_state_reads_the_same_row_the_capability_used():
+    on = _coordinator(1, {1: "true"})
+    off = _coordinator(1, {1: "false"})
+
+    assert on.supports_smart_motion_detection() and on.is_smart_motion_detection_enabled()
+    assert off.supports_smart_motion_detection() and not off.is_smart_motion_detection_enabled()
+
+
+def test_an_unsupported_channel_never_reports_itself_enabled():
+    c = _coordinator(2, {1: "true"})
+
+    assert not c.supports_smart_motion_detection()
+    assert not c.is_smart_motion_detection_enabled(), "it was reading another channel's row"
+
+
+def test_a_missing_row_does_not_raise():
+    """The old reader defaulted to '' -- None must not reach .lower()."""
+    assert _coordinator(4, {}).is_smart_motion_detection_enabled() is False
+
+
+# --- amcrest is a separate path and must be untouched ------------------------
+
+def test_amcrest_state_ignores_the_smart_motion_table():
+    c = _coordinator(0, {}, model="AD410")
+    c.data["table.VideoAnalyseRule[0][0].Enable"] = "true"
+
+    assert c.is_smart_motion_detection_enabled(), "amcrest reads its own rule table"


### PR DESCRIPTION
The capability probe calls `async_get_smart_motion_detection()`, which fetches the whole `SmartMotionDetect` table **with no channel argument**. It succeeds on any device that has the API, so `_supports_smart_motion_detection` becomes true for every channel of an NVR — and every channel gets a switch.

The table is sparse. Only channels that can actually do smart motion get a row.

Measured on a DHI-NVR5464-16P-EI: sixteen channels, ten with cameras, **two with rows**. The other eight carried a switch that read `off` forever and whose writes the device accepted with `200` and discarded — the same silent acceptance the coaxial control shows on this hardware.

```
table.SmartMotionDetect[1].Enable=true      <- CH2
table.SmartMotionDetect[11].Enable=true     <- CH12
                                            (no other channel has a row)
```

### Why the row is trustworthy

Two things were checked on real hardware before relying on it, because "capability signal that looks right and isn't" has bitten this integration before:

- **It tracks support, not state.** Disabling smart motion on a channel that has it left the row in place reading `false`, rather than removing it. So gating on the row can't strip the switch from someone who merely has the feature turned off.
- **It can't be conjured by asking.** `setConfig` on a row that doesn't exist returns `200` and changes nothing — verified against a channel with a camera but no row.

Also worth noting for anyone wondering whether this is an NVR channel budget rather than camera capability: every AI-capacity endpoint on this recorder answers `501 Not Implemented`, and the two channels with rows are exactly the two that report `LightType=WhiteLight`. It tracks the cameras, not the recorder.

### Two traps this deliberately avoids

**The poll gate still uses the raw flag.** Gating the *fetch* on the row existing would mean never fetching the table that says whether the row exists. That one is chicken-and-egg and the code says so.

**The row-0 fallback is preserved.** `is_smart_motion_detection_enabled` already falls back to row 0 for a single camera whose entry channel doesn't match the table row. Gating on the channel's own row alone would have dropped the switch on exactly those devices. Both the capability check and the state read now go through `_smart_motion_row()`, so they can't drift apart about which row belongs to this channel.

### Which reintroduced bug fails which test

| mutation | tests that fail |
|---|---|
| capability returns the raw probe flag (the behaviour being fixed) | a channel with no row does not support it; the measured NVR supports exactly the channels with rows |
| drop the row-0 fallback | a camera whose channel does not match row 0 still supports it |
| drop the `None` guard in the state read | an unsupported channel never reports itself enabled; a missing row does not raise — both via `AttributeError` |

### The downside, stated plainly

NVR users will see these switches disappear from channels where they never worked. Home Assistant keeps the registry entries and shows them unavailable until deleted, which is the normal result of a device losing a capability — but it is visible, and it is worth a release note. Anything referencing one of those entities was already referencing a switch that did nothing.