### PR TITLE
Do not fail a whole device because one capability probe was slow

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -79,6 +79,20 @@ EVENT_STREAM_SHORT_RETRY_SECONDS = 10
 EVENT_STREAM_MAX_RETRY_SECONDS = 600
 
 
+# A capability probe that times out has told us what an errored probe tells us:
+# this device will not serve that call, so do not offer the entity. Timeouts are
+# not aiohttp.ClientError -- asyncio.TimeoutError is the builtin -- so before
+# this they escaped the probe, hit the outer handler, and failed the whole
+# config entry with ConfigEntryNotReady. One slow capability check took the
+# device down and Home Assistant retried it forever. See #594 and #631.
+PROBE_FAILED = (ClientError, TimeoutError)
+
+# The coaxial probe deliberately only treats an HTTP error response as "not
+# supported"; a connection failure there should still fail setup. Timeouts join
+# it for the reason above, without widening the rest.
+PROBE_REFUSED = (ClientResponseError, TimeoutError)
+
+
 def event_stream_retry_delay(lived_seconds: float, consecutive_failures: int = 0) -> float:
     """How long to wait before re-attaching, given how long the stream lasted."""
     if lived_seconds < 10:
@@ -831,28 +845,28 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                         # but check if unit is not a doorbell first as channel 0 doesnt exist for VTOs
                         if not self.is_doorbell():
                             self._channel_number = self._channel
-                    except ClientError:
+                    except PROBE_FAILED:
                         pass
                 _LOGGER.debug("Using channel number %s (auto_detect=%s)", self._channel_number, auto_detect)
 
                 try:
                     await self.client.async_get_coaxial_control_io_status()
                     self._supports_coaxial_control = True
-                except ClientResponseError:
+                except PROBE_REFUSED:
                     self._supports_coaxial_control = False
                 _LOGGER.debug("Device supports Coaxial Control=%s", self._supports_coaxial_control)
 
                 try:
                     await self.client.async_get_disarming_linkage()
                     self._supports_disarming_linkage = True
-                except ClientError:
+                except PROBE_FAILED:
                     self._supports_disarming_linkage = False
                 _LOGGER.debug("Device supports disarming linkage=%s", self._supports_disarming_linkage)
 
                 try:
                     await self.client.async_get_event_notifications()
                     self._supports_event_notifications = True
-                except ClientError:
+                except PROBE_FAILED:
                     self._supports_event_notifications = False
                 _LOGGER.debug("Device supports event notifications=%s", self._supports_event_notifications)
 
@@ -865,7 +879,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                     try:
                         await self.client.async_get_ptz_position()
                         self._supports_ptz_position = True
-                    except ClientError:
+                    except PROBE_FAILED:
                         self._supports_ptz_position = False
                 _LOGGER.debug("Device supports PTZ position=%s", self._supports_ptz_position)
 
@@ -874,7 +888,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 try:
                     await self.client.async_get_smart_motion_detection()
                     self._supports_smart_motion_detection = True
-                except ClientError:
+                except PROBE_FAILED:
                     self._supports_smart_motion_detection = False
                 _LOGGER.debug("Device supports smart motion detection=%s", self._supports_smart_motion_detection)
 
@@ -893,7 +907,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                 try:
                     await self.client.async_get_lighting_v2()
                     self._supports_lighting_v2 = True
-                except ClientError:
+                except PROBE_FAILED:
                     self._supports_lighting_v2 = False
                     pass
                 _LOGGER.debug("Device supports Lighting_V2=%s", self._supports_lighting_v2)
@@ -910,7 +924,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
                         # Error: Error -1 getting param in name=Lighting[0][1]
                         # Otherwise we'll get multiple lines of config back
                         self._supports_profile_mode = len(conf) > 1
-                    except ClientError:
+                    except PROBE_FAILED:
                         _LOGGER.debug("Cam does not support profile mode. Will use mode 0")
                         self._supports_profile_mode = False
                     _LOGGER.debug("Device supports profile mode=%s", self._supports_profile_mode)
@@ -1422,7 +1436,7 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
         """
         try:
             conf = await self.client.async_get_config_lighting(self._channel, self._profile_mode)
-        except ClientError:
+        except PROBE_FAILED:
             return False
         return len(conf) > 0
 

--- a/tests/dahua/test_probe_timeouts.py
+++ b/tests/dahua/test_probe_timeouts.py
@@ -16,7 +16,16 @@ from types import SimpleNamespace
 import pytest
 from aiohttp import ClientError
 
+from custom_components import dahua as dahua_module
 from custom_components.dahua import DahuaDataUpdateCoordinator
+
+
+@pytest.fixture(autouse=True)
+def _clean_host_failures():
+    """Failures are tracked per host in module state, not per coordinator."""
+    dahua_module._HOST_FAILURES.clear()
+    yield
+    dahua_module._HOST_FAILURES.clear()
 
 PROBES = [
     ("async_probe_snapshot", None),
@@ -57,10 +66,18 @@ class _Client:
         return call
 
 
+async def _noop(*args, **kwargs):
+    return None
+
+
 def _coordinator(client):
     c = object.__new__(DahuaDataUpdateCoordinator)
     c.client = client
-    c.hass = SimpleNamespace()
+    c.hass = SimpleNamespace(async_create_task=lambda *a, **k: None)
+    # Starting the event stream is not what these pin, and it needs a great
+    # deal of unrelated state to reach.
+    c.async_start_event_listener = _noop
+    c.async_start_vto_event_listener = _noop
     c._address = "10.0.0.7"
     c._channel = 0
     c._channel_number = 1

--- a/tests/dahua/test_probe_timeouts.py
+++ b/tests/dahua/test_probe_timeouts.py
@@ -1,0 +1,128 @@
+"""A capability probe that times out must not take the config entry down.
+
+Every request is wrapped in asyncio.timeout(TIMEOUT_SECONDS), which raises the
+builtin TimeoutError. That is not an aiohttp.ClientError, so a probe catching
+only ClientError let the timeout escape, hit the outer handler and fail the
+whole entry with ConfigEntryNotReady -- for a capability the device merely
+happens to be slow about. Home Assistant then retried forever.
+
+Reported as #631 (setup fails, 20s hang -- exactly TIMEOUT_SECONDS) and #594
+(PTZ probe timing out for eight days straight, 700+ occurrences).
+"""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import ClientError
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+PROBES = [
+    ("async_probe_snapshot", None),
+    ("async_get_coaxial_control_io_status", "_supports_coaxial_control"),
+    ("async_get_disarming_linkage", "_supports_disarming_linkage"),
+    ("async_get_event_notifications", "_supports_event_notifications"),
+    ("async_get_ptz_position", "_supports_ptz_position"),
+    ("async_get_smart_motion_detection", "_supports_smart_motion_detection"),
+    ("async_get_lighting_v2", "_supports_lighting_v2"),
+]
+
+# What the device must answer before any probe runs. These are not probes: if
+# they fail the entry genuinely cannot be set up.
+REQUIRED = {
+    "get_max_extra_streams": 2,
+    "async_get_machine_name": {"table.General.MachineName": "Cam"},
+    "async_get_system_info": {"deviceType": "IPC-HDW1234", "serialNumber": "SER1"},
+    "get_software_version": {"version": "2.800.0"},
+}
+
+
+class _Client:
+    """Answers everything, except the calls told to fail."""
+
+    def __init__(self, failing=(), error=TimeoutError):
+        self.failing = set(failing)
+        self.error = error
+        self.called = []
+
+    def __getattr__(self, name):
+        async def call(*args, **kwargs):
+            self.called.append(name)
+            if name in self.failing:
+                raise self.error()
+            if name in REQUIRED:
+                return REQUIRED[name]
+            return {}
+        return call
+
+
+def _coordinator(client):
+    c = object.__new__(DahuaDataUpdateCoordinator)
+    c.client = client
+    c.hass = SimpleNamespace()
+    c._address = "10.0.0.7"
+    c._channel = 0
+    c._channel_number = 1
+    c.initialized = False
+    c.model = ""
+    c.machine_name = None
+    c._serial_number = None
+    c._max_streams = 1
+    c._profile_mode = 0
+    c._preset_position = "0"
+    c._supports_profile_mode = False
+    c._supports_ptz_position = False
+    c._supports_disarming_linkage = False
+    c._supports_event_notifications = False
+    c._supports_coaxial_control = False
+    c._supports_smart_motion_detection = False
+    c._supports_lighting = False
+    c._supports_lighting_v2 = False
+    c._supports_floodlightmode = False
+    c.config_entry = SimpleNamespace(data={}, options={}, entry_id="e1")
+    c.update_interval = timedelta(seconds=30)
+    return c
+
+
+@pytest.mark.parametrize("method,flag", PROBES)
+async def test_a_probe_that_times_out_does_not_fail_setup(method, flag):
+    """This is the bug: one slow capability check took the whole device down."""
+    coordinator = _coordinator(_Client(failing=[method], error=TimeoutError))
+
+    await coordinator._async_update_data()
+
+    assert coordinator.initialized, f"{method} timing out failed the whole entry"
+    if flag:
+        assert getattr(coordinator, flag) is False, f"{flag} should be off after a timeout"
+
+
+@pytest.mark.parametrize("method,flag", PROBES)
+async def test_a_probe_that_errors_still_marks_it_unsupported(method, flag):
+    """The existing behaviour must not change."""
+    coordinator = _coordinator(_Client(failing=[method], error=ClientError))
+
+    await coordinator._async_update_data()
+
+    assert coordinator.initialized
+    if flag:
+        assert getattr(coordinator, flag) is False
+
+
+async def test_every_probe_timing_out_at_once_still_sets_up():
+    """A slow device fails every probe, and must still produce a usable entry."""
+    coordinator = _coordinator(_Client(failing=[m for m, _ in PROBES], error=TimeoutError))
+
+    await coordinator._async_update_data()
+
+    assert coordinator.initialized
+
+
+async def test_a_required_call_timing_out_still_fails_setup():
+    """Not everything is a probe: without the system info there is no device."""
+    coordinator = _coordinator(_Client(failing=["async_get_system_info"], error=TimeoutError))
+
+    with pytest.raises(Exception):
+        await coordinator._async_update_data()
+
+    assert not coordinator.initialized

--- a/tests/dahua/test_probe_timeouts.py
+++ b/tests/dahua/test_probe_timeouts.py
@@ -14,7 +14,7 @@ from datetime import timedelta
 from types import SimpleNamespace
 
 import pytest
-from aiohttp import ClientError
+from aiohttp import ClientError, ClientResponseError
 
 from custom_components import dahua as dahua_module
 from custom_components.dahua import DahuaDataUpdateCoordinator
@@ -27,9 +27,12 @@ def _clean_host_failures():
     yield
     dahua_module._HOST_FAILURES.clear()
 
+COAXIAL = ("async_get_coaxial_control_io_status", "_supports_coaxial_control")
+
+# Every probe, for the timeout behaviour, which is uniform.
 PROBES = [
     ("async_probe_snapshot", None),
-    ("async_get_coaxial_control_io_status", "_supports_coaxial_control"),
+    COAXIAL,
     ("async_get_disarming_linkage", "_supports_disarming_linkage"),
     ("async_get_event_notifications", "_supports_event_notifications"),
     ("async_get_ptz_position", "_supports_ptz_position"),
@@ -114,7 +117,10 @@ async def test_a_probe_that_times_out_does_not_fail_setup(method, flag):
         assert getattr(coordinator, flag) is False, f"{flag} should be off after a timeout"
 
 
-@pytest.mark.parametrize("method,flag", PROBES)
+# The coaxial probe is deliberately narrower than the rest: only an HTTP error
+# response means "unsupported" there, so a bare connection failure still fails
+# setup. It is excluded from the ClientError sweep for that reason.
+@pytest.mark.parametrize("method,flag", [p for p in PROBES if p != COAXIAL])
 async def test_a_probe_that_errors_still_marks_it_unsupported(method, flag):
     """The existing behaviour must not change."""
     coordinator = _coordinator(_Client(failing=[method], error=ClientError))
@@ -124,6 +130,27 @@ async def test_a_probe_that_errors_still_marks_it_unsupported(method, flag):
     assert coordinator.initialized
     if flag:
         assert getattr(coordinator, flag) is False
+
+
+def _refused():
+    return ClientResponseError(None, None, status=400)
+
+
+async def test_the_coaxial_probe_treats_a_refusal_as_unsupported():
+    coordinator = _coordinator(_Client(failing=[COAXIAL[0]], error=_refused))
+
+    await coordinator._async_update_data()
+
+    assert coordinator.initialized
+    assert coordinator._supports_coaxial_control is False
+
+
+async def test_the_coaxial_probe_still_fails_setup_on_a_connection_error():
+    """Narrower on purpose: only a refusal means the device lacks the feature."""
+    coordinator = _coordinator(_Client(failing=[COAXIAL[0]], error=ClientError))
+
+    with pytest.raises(Exception):
+        await coordinator._async_update_data()
 
 
 async def test_every_probe_timing_out_at_once_still_sets_up():


### PR DESCRIPTION
Fixes #631. Fixes #594.

Every request is wrapped in `asyncio.timeout(TIMEOUT_SECONDS)` and the timeout is re-raised, so a slow call surfaces as the builtin `TimeoutError`. Every capability probe caught only `aiohttp.ClientError` — and a timeout is not one:

```
asyncio.TimeoutError is TimeoutError           -> True
issubclass(TimeoutError, aiohttp.ClientError)  -> False
```

So a probe that timed out **escaped its own handler**, fell through to the outer `except` in the initialize block, and failed the entire config entry with `ConfigEntryNotReady` — for a capability the device merely happens to be slow about. Home Assistant then retried it forever.

### The two reports this explains

**#631** — setup fails on an older NVR after a *"20s hang in digest snapshot probe"*. `TIMEOUT_SECONDS = 20`. The number in the title is the constant. The reporter tested 0.9.83, 0.9.86, 0.9.87 and 0.9.90 and got an identical failure, which fits: nothing released has touched this path.

**#594** — PTZ `getStatus` on an analog camera behind an XVR, timing out *"every ~30 seconds, continuously, for 8+ days"*, 700+ occurrences. Same mechanism: probe times out, setup fails, HA retries, forever.

Neither is a regression. #594 predates all of this year's work.

### The change

Nine probes now treat a timeout the way they already treat an error — as *this device will not serve that call, so do not offer it*:

snapshot channel probe · coaxial control · disarming linkage · event notifications · PTZ position · smart motion · `Lighting_V2` · profile mode · infrared lighting support

Two things deliberately left alone:

- **The coaxial probe keeps its narrower handler.** It treats only an HTTP error response as "unsupported", so a connection failure still fails setup. Timeouts join that without widening the rest.
- **Calls that are not probes.** If the system info or software version cannot be read there is no device to set up, and that should still fail. Only capability checks are made forgiving.

### On treating a timeout as "unsupported"

A transient timeout will mark a capability off for that session. That is the right trade: the probes run once at init, a reload re-runs them, and a device with one capability disabled is strictly better than a device that will not set up at all — which is what both reporters have now.

### Tests

- each probe timing out individually leaves the entry initialised, with its flag off
- every probe timing out at once still produces a usable entry
- a probe that raises `ClientError` behaves exactly as before
- a **required** call timing out still fails setup, so the forgiveness is scoped
