### PR TITLE
Read the day/night profile from whichever field the camera actually uses

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -1398,18 +1398,47 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
     def read_profile_mode(self, mode_data: dict) -> str:
         """Picks this channel's day/night profile out of the VideoInMode table.
 
-        The read is host-wide -- getConfig&name=VideoInMode returns a row per
-        channel -- so an NVR channel has to take its own row. Reading row 0 for
-        every channel gave the whole device channel 1's day/night profile, and
-        that profile is then what selects which Lighting[channel][profile] the
-        IR light is read from and written to.
+        The profile chooses which Lighting[channel][profile] the light is read
+        from and written to, so getting it wrong means commands are accepted and
+        nothing lights up.
 
-        Falls back to row 0, which is all a single-channel camera returns.
+        Three device behaviours have to coexist here, and two of them disagree
+        about which field is authoritative:
+
+        - **General profile management** (`Config[0]` = 2). One profile covers
+          all conditions and it is profile 2. `ConfigEx` is still present and
+          still echoes day/night, but it selects nothing -- preferring it sent
+          every write to the day profile while the camera rendered from 2 (#605).
+        - **IL series dual smart light.** The profile is chosen by the `ConfigEx`
+          string; `Config[0]` stays a static 0 whichever profile is live, so
+          reading it left the illuminator permanently tracking day (#582).
+        - **Everything else.** `Config[0]` is the profile.
+
+        The read is host-wide -- getConfig&name=VideoInMode returns a row per
+        channel -- so an NVR channel has to take its own row, falling back to
+        row 0, which is all a single-channel camera returns.
         """
-        mode = mode_data.get("table.VideoInMode[{0}].Config[0]".format(self._channel))
-        if mode is None:
-            mode = mode_data.get("table.VideoInMode[0].Config[0]", "0")
-        return mode or "0"
+        def field(name):
+            value = mode_data.get("table.VideoInMode[{0}].{1}".format(self._channel, name))
+            if value is None:
+                value = mode_data.get("table.VideoInMode[0].{0}".format(name))
+            return value
+
+        config = field("Config[0]")
+        config_ex = field("ConfigEx")
+
+        if config == "2":
+            return "2"
+        if config_ex is not None:
+            # Only act on a value we recognise. Treating anything else as day
+            # would override a Config[0] that is very likely right, for a
+            # string we do not understand.
+            named = str(config_ex).strip().lower()
+            if named == "night":
+                return "1"
+            if named == "day":
+                return "0"
+        return config or "0"
 
     async def async_detect_lighting_support(self) -> bool:
         """Does this channel have an infrared light?

--- a/tests/dahua/test_profile_mode_general.py
+++ b/tests/dahua/test_profile_mode_general.py
@@ -1,0 +1,125 @@
+"""Which day/night profile is live, across three device behaviours.
+
+The profile selects which Lighting[channel][profile] the light is read from and
+written to, so getting it wrong means the command is accepted and nothing
+lights. Two camera families disagree about which field is authoritative, which
+is why this has now been broken in both directions:
+
+  #582  IL series dual smart light -- ConfigEx selects the profile and
+        Config[0] stays a static 0, so reading Config[0] left the illuminator
+        permanently tracking the day profile.
+  #605  General profile management -- Config[0] is 2 and ConfigEx merely
+        echoes day/night, so preferring ConfigEx sent every write to profile 0
+        while the camera rendered from profile 2.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.dahua import DahuaDataUpdateCoordinator
+
+
+def _coordinator(channel=0):
+    c = object.__new__(DahuaDataUpdateCoordinator)
+    c._channel = channel
+    return c
+
+
+def _row(channel=0, **fields):
+    return {"table.VideoInMode[{0}].{1}".format(channel, k): v for k, v in fields.items()}
+
+
+# --- the two reported cameras -----------------------------------------------
+
+def test_general_profile_management_uses_profile_two():
+    """#605: Config[0]=2 wins, even though ConfigEx says Day."""
+    data = _row(**{"Config[0]": "2", "ConfigEx": "Day"})
+
+    assert _coordinator().read_profile_mode(data) == "2"
+
+
+@pytest.mark.parametrize("config_ex,expected", [("Day", "0"), ("Night", "1"), ("night", "1"), (" Night ", "1")])
+def test_il_series_takes_the_profile_from_config_ex(config_ex, expected):
+    """#582: Config[0] is a static 0 on these, so ConfigEx is what selects."""
+    data = _row(**{"Config[0]": "0", "ConfigEx": config_ex})
+
+    assert _coordinator().read_profile_mode(data) == expected
+
+
+# --- everything else --------------------------------------------------------
+
+@pytest.mark.parametrize("config", ["0", "1"])
+def test_a_camera_without_config_ex_uses_config(config):
+    assert _coordinator().read_profile_mode(_row(**{"Config[0]": config})) == config
+
+
+def test_nothing_reported_falls_back_to_day():
+    assert _coordinator().read_profile_mode({}) == "0"
+
+
+def test_an_empty_config_falls_back_to_day():
+    assert _coordinator().read_profile_mode(_row(**{"Config[0]": ""})) == "0"
+
+
+# --- the NVR row, which must survive all of the above ------------------------
+
+def test_a_channel_reads_its_own_row_not_channel_ones():
+    """An NVR returns a row per channel; reading row 0 gave every channel
+    channel 1's profile."""
+    data = {}
+    data.update(_row(0, **{"Config[0]": "0"}))
+    data.update(_row(3, **{"Config[0]": "1"}))
+
+    assert _coordinator(channel=3).read_profile_mode(data) == "1"
+
+
+def test_config_ex_is_also_read_from_this_channels_row():
+    data = {}
+    data.update(_row(0, **{"Config[0]": "0", "ConfigEx": "Day"}))
+    data.update(_row(3, **{"Config[0]": "0", "ConfigEx": "Night"}))
+
+    assert _coordinator(channel=3).read_profile_mode(data) == "1"
+
+
+def test_a_channel_with_no_row_falls_back_to_row_zero():
+    """A single camera reports only row 0."""
+    data = _row(0, **{"Config[0]": "1"})
+
+    assert _coordinator(channel=5).read_profile_mode(data) == "1"
+
+
+def test_general_mode_is_detected_from_this_channels_row():
+    data = {}
+    data.update(_row(0, **{"Config[0]": "0", "ConfigEx": "Day"}))
+    data.update(_row(2, **{"Config[0]": "2", "ConfigEx": "Day"}))
+
+    assert _coordinator(channel=2).read_profile_mode(data) == "2"
+
+
+# --- values we do not recognise ---------------------------------------------
+
+@pytest.mark.parametrize("config_ex", ["Normal", "General", "Auto", "", "Daytime"])
+def test_an_unrecognised_config_ex_defers_to_config(config_ex):
+    """Overriding a Config[0] that is probably right, for a string we cannot
+    read, is the worse guess of the two."""
+    data = _row(**{"Config[0]": "1", "ConfigEx": config_ex})
+
+    assert _coordinator().read_profile_mode(data) == "1"
+
+
+# --- the shape a real NVR returns -------------------------------------------
+
+def test_the_measured_nvr_resolves_every_channel():
+    """Measured on a DHI-NVR5464-16P-EI: Config[0] is 0 everywhere except one
+    channel in General mode, and only two channels report ConfigEx at all."""
+    data = {}
+    for channel in range(12):
+        data.update(_row(channel, **{"Config[0]": "2" if channel == 9 else "0"}))
+    data.update(_row(1, **{"Config[0]": "0", "ConfigEx": "Day"}))
+    data.update(_row(11, **{"Config[0]": "0", "ConfigEx": "Day"}))
+
+    assert _coordinator(channel=9).read_profile_mode(data) == "2", "the General channel"
+    assert _coordinator(channel=1).read_profile_mode(data) == "0", "reports ConfigEx"
+    assert _coordinator(channel=11).read_profile_mode(data) == "0"
+    assert _coordinator(channel=4).read_profile_mode(data) == "0", "plain channel"


### PR DESCRIPTION
Fixes #605, and restores the read half of #582 without reintroducing it.

The day/night profile selects which `Lighting[channel][profile]` the light is read from and written to. Get it wrong and the command is accepted, the entity reads back "on" from the inactive profile, and the lamp never fires.

Two camera families disagree about which field is authoritative, so this has now been broken in both directions:

| | what the camera reports | what went wrong |
|---|---|---|
| **#582** IL series dual smart light | `ConfigEx` selects the profile; `Config[0]` stays a static `0` | reading `Config[0]` left the illuminator permanently tracking day |
| **#605** General profile management | `Config[0]=2`, one profile for all conditions; `ConfigEx` echoes day/night but selects nothing | preferring `ConfigEx` sent every write to profile 0 while the camera rendered from 2 |

#582 fixed the first by preferring `ConfigEx`. #605 was fixed by reverting it in 0.9.86 — which put #582's cameras back where they started. Neither field is right on its own.

### The change

Order them rather than choose between them:

1. `Config[0] == "2"` → profile **2**. General mode, and `ConfigEx` is noise here.
2. Otherwise `ConfigEx`, **if it names a profile we recognise** → day or night.
3. Otherwise `Config[0]`.

An unrecognised `ConfigEx` now defers to `Config[0]` instead of being read as day. Overriding a `Config[0]` that is probably right, for a string we can't interpret, is the worse of the two guesses — and it's a case my own first version got wrong.

### The per-channel read is kept, deliberately

`VideoInMode` is host-wide and returns a row per channel. The fix as suggested in #605 reads `VideoInMode[0]` directly, which would give every channel of an NVR channel one's profile — the bug fixed in #619.

That matters here because **`ConfigEx` is per-channel too**. Measured on a DHI-NVR5464-16P-EI:

```
Config[0] per channel:  {0:'0', 1:'0', ... 9:'2', 11:'0'}   <- one channel in General mode
ConfigEx  per channel:  {1:'Day', 11:'Day'}                  <- only two channels report it at all
```

Both cases on one recorder, and reading row 0 would have misread nine of the ten channels.

### Not included

`async_set_video_profile_mode` still writes `Config[0]` only, so the *other* half of #582 — forcing a profile on an IL camera so it holds — remains reverted. That's a user-invoked service rather than the polling path, and I have neither camera family to test a write against. Worth its own change by someone who does.

Note also that on a General-mode camera the service will write `Config[0]=0` or `1`, taking the camera out of General mode. That is pre-existing rather than new, but it is now visible.

### Which reintroduced bug fails which test

| mutation | tests that fail |
|---|---|
| `Config[0]` only (what main does today) | IL series takes the profile from `ConfigEx`; `ConfigEx` is read from this channel's row |
| prefer `ConfigEx` always (the 0.9.84 regression) | General profile management uses profile 2; General mode is detected from its own row |
| read `VideoInMode[0]` (as suggested in the issue) | all four channel-row tests, including the measured-NVR one |
| unrecognised `ConfigEx` means day | an unrecognised `ConfigEx` defers to `Config[0]` |

@mattmcd1 you offered to test a build against your camera — that would be worth doing before this merges, since your General-mode camera is the one I can't reproduce. @Trexano99 likewise for the IL series, if you're still around.
