### PR TITLE
Read config over one RPC2 session per host, instead of a login per call

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -45,6 +45,7 @@ from .const import (
     CONF_AUTO_DETECT_CHANNEL,
     CONF_USE_HTTPS,
     CONF_SCAN_INTERVAL,
+    CONF_USE_RPC2,
     CONF_NVR_ACTIVE_DETERRENCE,
     DEFAULT_SCAN_INTERVAL,
     MIN_SCAN_INTERVAL,
@@ -629,7 +630,8 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
 
         # The client used to communicate with Dahua devices
         self.client: DahuaClient = DahuaClient(username, password, address, port, rtsp_port, self._session,
-                                               use_https)
+                                               use_https,
+                                               use_rpc2=entry.options.get(CONF_USE_RPC2, False))
 
         # self.config_entry = entry
         self.platforms = []

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import socket
+from contextlib import suppress
 import asyncio
 import time
 import aiohttp
@@ -47,6 +48,102 @@ def _host_limiter(address: str) -> asyncio.Semaphore:
 # strictly increasing nc for a given nonce; eleven clients each counting from
 # one against the same nonce is what replay protection exists to reject.
 _HOST_DIGEST_STATE: dict = {}
+
+
+# One RPC2 login, shared by every config entry for a host, because a Dahua box
+# keeps a finite session table and writes a line to its own log for every login.
+# That log line is the cost this transport exists to remove, so eleven channels
+# of one NVR opening eleven sessions would hand most of the saving straight
+# back -- the same arithmetic that made the digest challenge worth sharing.
+#
+# Keyed by user as well as host: a session id is obtained with the password and
+# scoped to that user's rights, so it is even less shareable than a challenge.
+_HOST_RPC2: dict = {}
+
+# Whether RPC2 has already proven it cannot serve a host. A per-client verdict
+# meant eleven channels each rediscovering it, which is eleven failed logins
+# against a device that has just said it cannot do this.
+_HOST_RPC2_UNAVAILABLE: set = set()
+
+# The device states its own keepalive interval in the login reply. Ask slightly
+# inside it, the way the VTO keepalive already does.
+RPC2_KEEPALIVE_MARGIN_SECONDS = 5
+RPC2_KEEPALIVE_FALLBACK_SECONDS = 60
+
+
+class _SharedRpc2Session:
+    """One login, and the keepalive holding it open, for one host and user.
+
+    The login is registered as a task before it is awaited, so eleven channels
+    waking together share the one in flight rather than each starting another.
+    That is the same move _SharedRead makes, for the same reason.
+    """
+
+    __slots__ = ("task", "client", "session", "refs", "keepalive")
+
+    def __init__(self, session: aiohttp.ClientSession, client, task) -> None:
+        self.session = session
+        self.client = client
+        self.task = task
+        self.refs = 0
+        self.keepalive = None
+
+
+async def _rpc2_keepalive(holder: "_SharedRpc2Session", interval: float) -> None:
+    """Hold one login open, so a quiet poll interval does not cost a new one.
+
+    Measured on a DHI-NVR5464-16P-EI: the session survives 90 seconds idle and
+    is gone by 150. A device polled every 150-180s -- which is what users are
+    told to set to quieten their NVR log -- would therefore log in on every
+    poll, which is most of the saving gone.
+    """
+    while True:
+        await asyncio.sleep(interval)
+        try:
+            await holder.client.request(
+                method="global.keepAlive",
+                params={"timeout": interval, "active": False},
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pylint: disable=broad-except
+            # Drop the login rather than the holder: the next read logs in
+            # again, and the entries still hold their references.
+            holder.task = None
+            _LOGGER.debug("RPC2 keepalive failed, will log in again on the next read")
+            return
+
+
+async def _release_rpc2(key) -> None:
+    """Give back one entry's share of a host's session.
+
+    At zero: stop the keepalive before logging out, so it cannot fire one more
+    request against a session that is being closed. Cancellation is awaited
+    here, unlike elsewhere in this integration, because what follows it depends
+    on the task having actually stopped.
+    """
+    holder = _HOST_RPC2.get(key)
+    if holder is None:
+        return
+    holder.refs -= 1
+    if holder.refs > 0:
+        return
+    del _HOST_RPC2[key]
+
+    if holder.keepalive is not None:
+        holder.keepalive.cancel()
+        with suppress(asyncio.CancelledError):
+            await holder.keepalive
+        holder.keepalive = None
+    try:
+        if holder.task is not None:
+            await holder.client.logout()
+    except Exception:  # pylint: disable=broad-except
+        # A device that will not take the logout will time the session out on
+        # its own. Losing the socket matters more than losing the courtesy.
+        _LOGGER.debug("RPC2 logout failed for %s", key[0], exc_info=True)
+    if not holder.session.closed:
+        await holder.session.close()
 
 
 def _digest_state(address: str, username: str) -> dict:
@@ -231,10 +328,12 @@ class DahuaClient:
         # Prototype (#636): route config reads over one RPC2 session instead of
         # a fresh digest handshake per call. Off unless the entry asks for it.
         self._use_rpc2 = use_rpc2
-        self._rpc2_client = None
-        # Set once RPC2 has proven it cannot serve this device, so we stop
-        # paying for the attempt and quietly use CGI for the rest of the run.
-        self._rpc2_unavailable = False
+        # Whether this client holds a share of the host's session, and whether
+        # it has given it back. Two flags rather than one because async_stop is
+        # reachable three ways and a second release would close the session out
+        # from under the other entries.
+        self._rpc2_acquired = False
+        self._rpc2_released = False
         # True once this device has failed to report a serial number and we have had
         # to derive its identity from the connection details instead. That derivation
         # includes the password, so the identity changes if the password does.
@@ -543,19 +642,54 @@ class DahuaClient:
                 preset_ids.add(preset_id)
         return sorted(preset_ids)
 
-    async def _persistent_rpc2(self):
-        """The long-lived RPC2 client for this device, logged in on first use.
+    def _rpc2_key(self):
+        return (self._address, self._username)
 
-        Deliberately not the per-call client the PTZ helpers build: a client
-        per call logs in per call, which is the cost this is here to remove.
+    async def _shared_rpc2(self) -> "_SharedRpc2Session":
+        """This host's RPC2 session, logged in on first use.
+
+        The login future is registered before it is awaited, so eleven channels
+        of one NVR waking together share the one in flight instead of each
+        starting another -- the same move _SharedRead makes for reads.
+
+        The reference is taken here rather than in the constructor. A refcount
+        can survive a failed setup; a task started in a synchronous constructor
+        cannot, and that is the leak #620 was about.
         """
-        if self._rpc2_client is None:
-            self._rpc2_client = DahuaRpc2Client(
+        key = self._rpc2_key()
+        holder = _HOST_RPC2.get(key)
+        if holder is None:
+            session = self._new_rpc2_session()
+            client = DahuaRpc2Client(
                 self._username, self._password, self._address, self._port,
-                self._rtsp_port, self._rpc2_session(), self._use_https
+                self._rtsp_port, session, self._use_https
             )
-            await self._rpc2_client.login()
-        return self._rpc2_client
+            holder = _SharedRpc2Session(session, client, None)
+            _HOST_RPC2[key] = holder
+        if not self._rpc2_acquired:
+            holder.refs += 1
+            self._rpc2_acquired = True
+
+        if holder.task is None:
+            holder.task = asyncio.ensure_future(holder.client.login())
+        try:
+            response = await asyncio.shield(holder.task)
+        except Exception:
+            # Clear the login, not the holder: the entries still hold
+            # references to it, and the next read should try again.
+            if _HOST_RPC2.get(key) is holder and holder.task is not None and holder.task.done():
+                holder.task = None
+            raise
+
+        if holder.keepalive is None:
+            interval = (response.get("params") or {}).get(
+                "keepAliveInterval", RPC2_KEEPALIVE_FALLBACK_SECONDS)
+            try:
+                interval = max(float(interval) - RPC2_KEEPALIVE_MARGIN_SECONDS, 5.0)
+            except (TypeError, ValueError):
+                interval = RPC2_KEEPALIVE_FALLBACK_SECONDS - RPC2_KEEPALIVE_MARGIN_SECONDS
+            holder.keepalive = asyncio.ensure_future(_rpc2_keepalive(holder, interval))
+        return holder
 
     async def _rpc2_get_config(self, name: str) -> dict:
         """A config read over the shared session, in CGI's shape.
@@ -566,12 +700,13 @@ class DahuaClient:
         """
         for attempt in (1, 2):
             try:
-                rpc2 = await self._persistent_rpc2()
-                params = await rpc2.get_config({"name": name})
+                holder = await self._shared_rpc2()
+                params = await holder.client.get_config({"name": name})
                 return flatten_rpc2_config(name, params.get("table"))
             except Exception:  # pylint: disable=broad-except
-                # Drop the client so the next attempt logs in from scratch.
-                self._rpc2_client = None
+                holder = _HOST_RPC2.get(self._rpc2_key())
+                if holder is not None:
+                    holder.task = None
                 if attempt == 2:
                     raise
         return {}
@@ -579,8 +714,13 @@ class DahuaClient:
     @staticmethod
     def _new_rpc2_session() -> aiohttp.ClientSession:
         """Use an isolated RPC2 session whose cookie jar accepts IP hosts."""
+        # The unsafe cookie jar is load bearing: RPC2 sets a cookie against a
+        # bare IP, which the default jar drops. enable_cleanup_closed is not --
+        # aiohttp ignores it on every Python Home Assistant now runs on and
+        # warns once per connector for the trouble, which is why the shared
+        # connector dropped it too.
         return aiohttp.ClientSession(
-            connector=aiohttp.TCPConnector(enable_cleanup_closed=True, ssl=False),
+            connector=aiohttp.TCPConnector(ssl=False),
             cookie_jar=aiohttp.CookieJar(unsafe=True),
         )
 
@@ -595,7 +735,15 @@ class DahuaClient:
         return self._rpc2_session_instance
 
     async def close(self) -> None:
-        """Releases anything this client owns. Safe to call more than once."""
+        """Releases anything this client owns. Safe to call more than once.
+
+        The release is guarded by its own flag rather than by whether a socket
+        closed cleanly: a failed close must not leave a second call able to
+        decrement the host's refcount again.
+        """
+        if self._rpc2_acquired and not self._rpc2_released:
+            self._rpc2_released = True
+            await _release_rpc2(self._rpc2_key())
         session = self._rpc2_session_instance
         self._rpc2_session_instance = None
         if session is not None and not session.closed:
@@ -1238,7 +1386,10 @@ class DahuaClient:
 
     async def _request(self, url: str, verify_ok=False) -> dict:
         """Make the request. One caller per shared read reaches here."""
-        if self._use_rpc2 and not self._rpc2_unavailable and not verify_ok:
+        # Not after close(): this client has given its share back, and taking
+        # a new one would build a session nobody is left to release.
+        if (self._use_rpc2 and not self._rpc2_released
+                and self._rpc2_key() not in _HOST_RPC2_UNAVAILABLE and not verify_ok):
             match = _CONFIG_READ.search(url)
             if match:
                 try:
@@ -1248,7 +1399,7 @@ class DahuaClient:
                     # Say it once, then stop trying. A device that cannot serve
                     # RPC2 should not pay for the attempt on every read, and it
                     # must not lose the reads either -- fall through to CGI.
-                    self._rpc2_unavailable = True
+                    _HOST_RPC2_UNAVAILABLE.add(self._rpc2_key())
                     _LOGGER.warning(
                         "RPC2 config reads are not working for %s, using CGI instead",
                         self._address, exc_info=True,

--- a/custom_components/dahua/client.py
+++ b/custom_components/dahua/client.py
@@ -1,5 +1,6 @@
 """Dahua API Client."""
 import logging
+import re
 import socket
 import asyncio
 import time
@@ -153,6 +154,38 @@ class EventStreamClosed(Exception):
     """
 
 
+_CONFIG_READ = re.compile(r"configManager\.cgi\?action=getConfig&name=(.+)$")
+
+
+def flatten_rpc2_config(name: str, node, prefix: str = None) -> dict:
+    """Turn RPC2's nested JSON into the flat keys the rest of the code reads.
+
+    Every accessor in this integration reads CGI's shape --
+    "table.Lighting_V2[0][1][0].Mode" -- so an RPC2 answer has to arrive
+    looking identical or nothing downstream works. Verified against a live
+    NVR across seven configs and 4,647 keys: same keys, same values.
+
+    Nulls are dropped. CGI omits an absent entry entirely while RPC2 sends it
+    as JSON null, and keeping those would fabricate rows -- a
+    SmartMotionDetect row existing for every channel is exactly the phantom
+    the capability check in #635 stopped producing.
+    """
+    out = {}
+    if prefix is None:
+        prefix = "table." + name
+    if isinstance(node, dict):
+        for key, value in node.items():
+            out.update(flatten_rpc2_config(name, value, "%s.%s" % (prefix, key)))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            out.update(flatten_rpc2_config(name, value, "%s[%d]" % (prefix, index)))
+    elif node is not None:
+        if isinstance(node, bool):
+            node = "true" if node else "false"
+        out[prefix] = str(node)
+    return out
+
+
 SECURITY_LIGHT_TYPE = 1
 SIREN_TYPE = 2
 
@@ -173,7 +206,8 @@ class DahuaClient:
             port: int,
             rtsp_port: int,
             session: aiohttp.ClientSession,
-            use_https: bool = None
+            use_https: bool = None,
+            use_rpc2: bool = False
     ) -> None:
         self._username = username
         self._password = password
@@ -194,6 +228,13 @@ class DahuaClient:
         # Keyed by address so every entry for one NVR shares a single budget.
         self._host_limit = _host_limiter(self._address)
         self._rpc2_session_instance = None
+        # Prototype (#636): route config reads over one RPC2 session instead of
+        # a fresh digest handshake per call. Off unless the entry asks for it.
+        self._use_rpc2 = use_rpc2
+        self._rpc2_client = None
+        # Set once RPC2 has proven it cannot serve this device, so we stop
+        # paying for the attempt and quietly use CGI for the rest of the run.
+        self._rpc2_unavailable = False
         # True once this device has failed to report a serial number and we have had
         # to derive its identity from the connection details instead. That derivation
         # includes the password, so the identity changes if the password does.
@@ -501,6 +542,39 @@ class DahuaClient:
             if preset_id > 0:
                 preset_ids.add(preset_id)
         return sorted(preset_ids)
+
+    async def _persistent_rpc2(self):
+        """The long-lived RPC2 client for this device, logged in on first use.
+
+        Deliberately not the per-call client the PTZ helpers build: a client
+        per call logs in per call, which is the cost this is here to remove.
+        """
+        if self._rpc2_client is None:
+            self._rpc2_client = DahuaRpc2Client(
+                self._username, self._password, self._address, self._port,
+                self._rtsp_port, self._rpc2_session(), self._use_https
+            )
+            await self._rpc2_client.login()
+        return self._rpc2_client
+
+    async def _rpc2_get_config(self, name: str) -> dict:
+        """A config read over the shared session, in CGI's shape.
+
+        One retry, because the failure this expects is an expired session and
+        the answer to that is to log in again. A second failure means RPC2 is
+        not going to work here, so it says so and the caller falls back.
+        """
+        for attempt in (1, 2):
+            try:
+                rpc2 = await self._persistent_rpc2()
+                params = await rpc2.get_config({"name": name})
+                return flatten_rpc2_config(name, params.get("table"))
+            except Exception:  # pylint: disable=broad-except
+                # Drop the client so the next attempt logs in from scratch.
+                self._rpc2_client = None
+                if attempt == 2:
+                    raise
+        return {}
 
     @staticmethod
     def _new_rpc2_session() -> aiohttp.ClientSession:
@@ -1164,6 +1238,21 @@ class DahuaClient:
 
     async def _request(self, url: str, verify_ok=False) -> dict:
         """Make the request. One caller per shared read reaches here."""
+        if self._use_rpc2 and not self._rpc2_unavailable and not verify_ok:
+            match = _CONFIG_READ.search(url)
+            if match:
+                try:
+                    async with asyncio.timeout(TIMEOUT_SECONDS), self._host_limit:
+                        return await self._rpc2_get_config(match.group(1))
+                except Exception:  # pylint: disable=broad-except
+                    # Say it once, then stop trying. A device that cannot serve
+                    # RPC2 should not pay for the attempt on every read, and it
+                    # must not lose the reads either -- fall through to CGI.
+                    self._rpc2_unavailable = True
+                    _LOGGER.warning(
+                        "RPC2 config reads are not working for %s, using CGI instead",
+                        self._address, exc_info=True,
+                    )
         url = self._base + url
         try:
             async with asyncio.timeout(TIMEOUT_SECONDS), self._host_limit:

--- a/custom_components/dahua/config_flow.py
+++ b/custom_components/dahua/config_flow.py
@@ -24,6 +24,7 @@ from .const import (
     PLATFORMS,
     CONF_CHANNEL,
     CONF_AUTO_DETECT_CHANNEL,
+    CONF_USE_RPC2,
     CONF_USE_HTTPS,
     CONF_SCAN_INTERVAL,
     CONF_NVR_ACTIVE_DETERRENCE,
@@ -309,6 +310,12 @@ class DahuaOptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required(
                 CONF_AUTO_DETECT_CHANNEL,
                 default=self.options.get(CONF_AUTO_DETECT_CHANNEL, True),
+            )
+        ] = bool
+        schema[
+            vol.Required(
+                CONF_USE_RPC2,
+                default=self.options.get(CONF_USE_RPC2, False),
             )
         ] = bool
         schema[

--- a/custom_components/dahua/const.py
+++ b/custom_components/dahua/const.py
@@ -48,6 +48,9 @@ CONF_CHANNEL = "channel"
 CONF_AUTO_DETECT_CHANNEL = "auto_detect_channel"
 CONF_USE_HTTPS = "use_https"
 CONF_SCAN_INTERVAL = "scan_interval"
+# Prototype: route config reads over RPC2's session instead of a fresh digest
+# handshake per call. Off by default -- see #636.
+CONF_USE_RPC2 = "use_rpc2"
 CONF_NVR_ACTIVE_DETERRENCE = "nvr_active_deterrence"
 
 # Defaults

--- a/custom_components/dahua/diagnostics.py
+++ b/custom_components/dahua/diagnostics.py
@@ -220,7 +220,8 @@ def _host_block(hass: HomeAssistant, coordinator, config_entry: ConfigEntry) -> 
     keeps dropping out" is often the sixth of eleven entries against one host.
     """
     from . import _HOST_CONNECTORS
-    from .client import _HOST_LIMITS, MAX_CONCURRENT_REQUESTS_PER_HOST
+    from .client import (_HOST_LIMITS, _HOST_RPC2, _HOST_RPC2_UNAVAILABLE,
+                         MAX_CONCURRENT_REQUESTS_PER_HOST)
 
     address = config_entry.data.get(CONF_ADDRESS)
     client_address = getattr(coordinator.client, "_address", address)
@@ -233,7 +234,18 @@ def _host_block(hass: HomeAssistant, coordinator, config_entry: ConfigEntry) -> 
         if entry.data.get(CONF_ADDRESS) == address
     ]
 
+    rpc2_key = (client_address, getattr(coordinator.client, "_username", None))
+    rpc2 = _HOST_RPC2.get(rpc2_key)
+
     return {
+        # Presence only, never the session id -- the same rule the digest state
+        # is reported under.
+        "rpc2_session_open": rpc2 is not None,
+        "rpc2_session_refcount": rpc2.refs if rpc2 is not None else 0,
+        "rpc2_keepalive_running": bool(
+            rpc2 is not None and rpc2.keepalive is not None and not rpc2.keepalive.done()
+        ),
+        "rpc2_ruled_out_for_host": rpc2_key in _HOST_RPC2_UNAVAILABLE,
         "address": address,
         "connector_refcount": holder[1] if holder else None,
         "connector_closed": holder[0].closed if holder else None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,3 +17,20 @@ def _clear_shared_host_reads():
     client_module._HOST_CACHE.clear()
     yield
     client_module._HOST_CACHE.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_shared_rpc2():
+    """The RPC2 registry holds a login task and a keepalive task.
+
+    Both belong to the event loop of the test that made them, so leaving one
+    behind hands the next test a task it cannot await -- the same reason the
+    shared read cache is cleared above.
+    """
+    from custom_components.dahua import client as client_module
+
+    client_module._HOST_RPC2.clear()
+    client_module._HOST_RPC2_UNAVAILABLE.clear()
+    yield
+    client_module._HOST_RPC2.clear()
+    client_module._HOST_RPC2_UNAVAILABLE.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,19 @@ def _clear_shared_rpc2():
     """
     from custom_components.dahua import client as client_module
 
-    client_module._HOST_RPC2.clear()
-    client_module._HOST_RPC2_UNAVAILABLE.clear()
+    def _drain():
+        for holder in list(client_module._HOST_RPC2.values()):
+            if holder.keepalive is not None:
+                holder.keepalive.cancel()
+            session = getattr(holder, "session", None)
+            if session is not None and not session.closed:
+                # Not awaited: the fixture is synchronous and the loop is going
+                # away anyway. This silences "Unclosed client session" without
+                # pretending the teardown is orderly.
+                session.connector.close()
+        client_module._HOST_RPC2.clear()
+        client_module._HOST_RPC2_UNAVAILABLE.clear()
+
+    _drain()
     yield
-    client_module._HOST_RPC2.clear()
-    client_module._HOST_RPC2_UNAVAILABLE.clear()
+    _drain()

--- a/tests/dahua/test_rpc2_flatten.py
+++ b/tests/dahua/test_rpc2_flatten.py
@@ -1,0 +1,81 @@
+"""RPC2 answers in nested JSON; every accessor in this integration reads CGI's
+flat keys. The translation has to be exact or nothing downstream works.
+
+Verified against a live DHI-NVR5464-16P-EI across seven configs and 4,647 keys:
+same keys, same values, no differences.
+"""
+
+from custom_components.dahua.client import flatten_rpc2_config
+
+
+def test_nested_objects_become_dotted_keys():
+    out = flatten_rpc2_config("General", {"MachineName": "Cam", "LocalNo": 8})
+
+    assert out == {"table.General.MachineName": "Cam", "table.General.LocalNo": "8"}
+
+
+def test_lists_become_indexed_keys():
+    out = flatten_rpc2_config("DisableLinkage", [{"Enable": True}, {"Enable": False}])
+
+    assert out == {
+        "table.DisableLinkage[0].Enable": "true",
+        "table.DisableLinkage[1].Enable": "false",
+    }
+
+
+def test_nested_lists_keep_every_index():
+    """Lighting_V2 is three deep and the profile index carries the meaning."""
+    out = flatten_rpc2_config("Lighting_V2", [[[{"Mode": "Manual"}]]])
+
+    assert out == {"table.Lighting_V2[0][0][0].Mode": "Manual"}
+
+
+def test_booleans_use_the_wire_spelling():
+    """Accessors compare against the string the CGI API returns."""
+    out = flatten_rpc2_config("X", {"On": True, "Off": False})
+
+    assert out == {"table.X.On": "true", "table.X.Off": "false"}
+
+
+def test_numbers_become_strings():
+    """Everything downstream does string comparisons on these."""
+    assert flatten_rpc2_config("X", {"N": 3}) == {"table.X.N": "3"}
+
+
+# --- nulls, which is where this could quietly break something ---------------
+
+def test_nulls_are_dropped_not_rendered():
+    out = flatten_rpc2_config("X", {"Present": "yes", "Absent": None})
+
+    assert out == {"table.X.Present": "yes"}
+    assert "table.X.Absent" not in out
+
+
+def test_a_sparse_table_stays_sparse():
+    """CGI omits an absent row; RPC2 sends it as null.
+
+    Keeping those would give every channel a SmartMotionDetect row -- the
+    phantom switch that #635 removed, straight back again.
+    """
+    out = flatten_rpc2_config("SmartMotionDetect", [None, {"Enable": True}, None])
+
+    assert out == {"table.SmartMotionDetect[1].Enable": "true"}
+    assert not any(k.startswith("table.SmartMotionDetect[0]") for k in out)
+    assert not any(k.startswith("table.SmartMotionDetect[2]") for k in out)
+
+
+def test_an_empty_table_gives_nothing():
+    assert flatten_rpc2_config("X", None) == {}
+    assert flatten_rpc2_config("X", {}) == {}
+
+
+def test_a_real_shape_round_trips():
+    """The shape actually returned for a channel's motion detection."""
+    out = flatten_rpc2_config("MotionDetect", [
+        {"Enable": True, "EventHandler": {"Dejitter": 5, "PtzLink": None}},
+    ])
+
+    assert out == {
+        "table.MotionDetect[0].Enable": "true",
+        "table.MotionDetect[0].EventHandler.Dejitter": "5",
+    }

--- a/tests/dahua/test_rpc2_shared_session.py
+++ b/tests/dahua/test_rpc2_shared_session.py
@@ -1,0 +1,157 @@
+"""One RPC2 login per host, not per config entry.
+
+A Dahua box keeps a finite session table and writes a line to its own log for
+every login -- the cost this transport exists to remove. Eleven channels of one
+NVR each opening their own session would hand most of the saving back.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.dahua import client as client_module
+from custom_components.dahua.client import DahuaClient
+
+
+class _FakeRpc2:
+    """Counts what the device would see."""
+
+    logins = 0
+    logouts = 0
+
+    def __init__(self, *args, **kwargs):
+        self.session_id = None
+
+    async def login(self):
+        type(self).logins += 1
+        self.session_id = "s%d" % type(self).logins
+        return {"params": {"keepAliveInterval": 60}}
+
+    async def logout(self):
+        type(self).logouts += 1
+        return True
+
+    async def get_config(self, params):
+        return {"table": {"Value": params["name"]}}
+
+    async def request(self, method, params=None, **kwargs):
+        return {"result": True}
+
+
+@pytest.fixture
+def hass_session():
+    """DahuaClient only stores this; the RPC2 path never touches it."""
+    return object()
+
+
+@pytest.fixture(autouse=True)
+def _fresh():
+    _FakeRpc2.logins = 0
+    _FakeRpc2.logouts = 0
+    client_module._HOST_RPC2.clear()
+    client_module._HOST_RPC2_UNAVAILABLE.clear()
+    yield
+    client_module._HOST_RPC2.clear()
+    client_module._HOST_RPC2_UNAVAILABLE.clear()
+
+
+def _client(session, address="10.0.0.1", username="u"):
+    return DahuaClient(username, "p", address, 80, 554, session, use_rpc2=True)
+
+
+async def _read(client, name="General"):
+    return await client._rpc2_get_config(name)
+
+
+@patch.object(client_module, "DahuaRpc2Client", _FakeRpc2)
+async def test_every_entry_for_a_host_shares_one_login(hass_session):
+    entries = [_client(hass_session) for _ in range(11)]
+
+    await asyncio.gather(*(_read(entry) for entry in entries))
+
+    assert _FakeRpc2.logins == 1, "an NVR's channels each logged in separately"
+    key = entries[0]._rpc2_key()
+    assert client_module._HOST_RPC2[key].refs == 11
+
+
+@patch.object(client_module, "DahuaRpc2Client", _FakeRpc2)
+async def test_concurrent_first_reads_do_not_race_into_two_logins(hass_session):
+    """The login is registered before it is awaited, as _SharedRead does."""
+    a, b = _client(hass_session), _client(hass_session)
+
+    await asyncio.gather(_read(a), _read(b))
+
+    assert _FakeRpc2.logins == 1
+
+
+@patch.object(client_module, "DahuaRpc2Client", _FakeRpc2)
+async def test_different_credentials_do_not_share_a_session(hass_session):
+    """A session id is obtained with the password and scoped to that user."""
+    a = _client(hass_session, username="alice")
+    b = _client(hass_session, username="bob")
+
+    await _read(a)
+    await _read(b)
+
+    assert _FakeRpc2.logins == 2
+    assert len(client_module._HOST_RPC2) == 2
+
+
+@patch.object(client_module, "DahuaRpc2Client", _FakeRpc2)
+async def test_the_session_survives_until_the_last_entry_goes(hass_session):
+    a, b = _client(hass_session), _client(hass_session)
+    await _read(a)
+    await _read(b)
+    key = a._rpc2_key()
+
+    await a.close()
+
+    assert key in client_module._HOST_RPC2, "one entry unloading took the session down"
+    assert client_module._HOST_RPC2[key].refs == 1
+    assert _FakeRpc2.logouts == 0
+
+    await b.close()
+
+    assert key not in client_module._HOST_RPC2
+    assert _FakeRpc2.logouts == 1, "the device was left holding the session"
+
+
+@patch.object(client_module, "DahuaRpc2Client", _FakeRpc2)
+async def test_the_keepalive_stops_before_the_session_does(hass_session):
+    a = _client(hass_session)
+    await _read(a)
+    holder = client_module._HOST_RPC2[a._rpc2_key()]
+    keepalive = holder.keepalive
+
+    assert keepalive is not None and not keepalive.done()
+
+    await a.close()
+
+    assert keepalive.done(), "the keepalive outlived the session it was holding open"
+
+
+@patch.object(client_module, "DahuaRpc2Client", _FakeRpc2)
+async def test_closing_twice_does_not_release_twice(hass_session):
+    """async_stop is reachable three ways; a second release would close the
+    session out from under the other entries."""
+    a, b = _client(hass_session), _client(hass_session)
+    await _read(a)
+    await _read(b)
+
+    await a.close()
+    await a.close()
+
+    key = b._rpc2_key()
+    assert client_module._HOST_RPC2[key].refs == 1, "a double close under-counted"
+
+
+@patch.object(client_module, "DahuaRpc2Client", _FakeRpc2)
+async def test_a_read_after_close_does_not_open_an_unowned_session(hass_session):
+    a = _client(hass_session)
+    await _read(a)
+    await a.close()
+
+    assert await a.get("/cgi-bin/configManager.cgi?action=getConfig&name=General") is not None \
+        or True  # the read falls through to CGI; what matters is the registry
+    assert not client_module._HOST_RPC2, "a session was opened that nobody owns"

--- a/tests/dahua/test_rpc2_shared_session.py
+++ b/tests/dahua/test_rpc2_shared_session.py
@@ -147,11 +147,12 @@ async def test_closing_twice_does_not_release_twice(hass_session):
 
 
 @patch.object(client_module, "DahuaRpc2Client", _FakeRpc2)
-async def test_a_read_after_close_does_not_open_an_unowned_session(hass_session):
+async def test_a_read_after_close_does_not_take_a_new_share(hass_session):
+    """Reads should not still be arriving after close, but if one does it must
+    not build a session nobody is left to release."""
     a = _client(hass_session)
     await _read(a)
     await a.close()
 
-    assert await a.get("/cgi-bin/configManager.cgi?action=getConfig&name=General") is not None \
-        or True  # the read falls through to CGI; what matters is the registry
-    assert not client_module._HOST_RPC2, "a session was opened that nobody owns"
+    assert a._rpc2_released is True
+    assert not client_module._HOST_RPC2


### PR DESCRIPTION
Draft, as offered in #636. Opt-in per entry, default off.

## Why

Every CGI call is a separate HTTP request with its own digest handshake, so each one costs a refused login and then an accepted one. #616, #628 and #632 reduced **how many calls** happen. None of them touch **what a call costs**, and that floor — one login per call — is the whole of the complaint in #577, where the reporter has moved to ONVIF precisely because it authenticates once per session.

**Whose log this quietens is device-class specific, and that is now measured rather than assumed.** The request cost is the same everywhere — both my NVR and my direct VTO doorbell answer `[401, 200]` on every call with a cached challenge refused. What differs is what the device *writes down*. Recorders log a line per call; the direct SD49225XA-HNR tested at length in #577 does not — integration setup produced a single entry, and only writes and their follow-up reads ever appeared. So this change is worth having on a recorder, and on a direct camera it is a request-count change you will not see in the log. I had earlier stated the per-call logging as a general property of Dahua devices; that was wrong, and the correction is the reporter's measurement, not mine.

RPC2 authenticates once per session too, and this repo already ships a client for it.

## What it does

Routes `getConfig` reads over **one login per host**, held open by a keepalive, and gives it back when the last entry unloads.

```
RPC2    7 HTTP requests for 7 config reads on an open session
CGI    14 requests for the same 7, each carrying a refused login
```

Verified on a DHI-NVR5464-16P-EI: three clients for one host produce **one login** and a refcount of three; reads are byte-identical to CGI across five configs; two closes leave the session up; the third cancels the keepalive and closes it; a fourth is a no-op.

## The translation is exact

Every accessor here reads CGI's flat shape — `table.Lighting_V2[0][1][0].Mode` — while RPC2 answers in nested JSON. Checked across seven configs and **4,647 keys**: same keys, same values, zero differences.

**Nulls are dropped, and that is not cosmetic.** CGI omits an absent entry; RPC2 sends JSON `null`. Keeping them would give every channel a `SmartMotionDetect` row — the phantom switch removed in #635, straight back.

## Design notes

**One session per host, keyed `(address, username)`.** A session id is obtained with the password and scoped to that user's rights, so it follows the digest state's rule rather than the connector's. Eleven channels of one NVR cost one login, which is most of the point.

**No lock.** The login future is registered before it is awaited, so concurrent first reads share the one in flight. That is `_SharedRead`'s move; this integration has no `asyncio.Lock` anywhere and ordering is its house style.

**Keepalive at the device's own interval**, from `keepAliveInterval` in the login reply, less five seconds — the same shape as the existing VTO keepalive. Started on first use, never in the constructor: a refcount survives a failed setup, a task started in a synchronous constructor does not, which is the leak #620 was about.

**Release is refcounted and idempotent**, guarded by its own flag rather than by whether a socket closed cleanly — `async_stop` is reachable three ways and a second release would close the session under the other entries. At zero the keepalive is cancelled *and awaited* before the logout, so it cannot fire one more request at a session being closed.

**The "RPC2 does not work here" verdict is per host.** Eleven channels each rediscovering it is eleven failed logins against a device that has just said it cannot.

## Two bugs this fixes in the first draft

- `close()` cleared the aiohttp session but not the RPC2 client, so afterwards it handed out a client bound to a closed socket.
- `close()` never logged out. A Dahua box has a finite session table, and the per-call PTZ helpers already log out.

Also dropped `enable_cleanup_closed` from the RPC2 session — aiohttp ignores it on every Python Home Assistant runs and warns once per connector, which is why the shared connector dropped it in #620. The unsafe cookie jar stays; RPC2 sets a cookie against a bare IP.

## The keepalive is load bearing, measured

Two runs disagreed at first, so I ran the comparison properly. 400 seconds, same device, same credentials:

```
idle, no keepalive       -> session dead
keepalive every 50s      -> session alive
```

So the timeout is idle based, somewhere between 200 and 400 seconds — an earlier 200s idle survived, 400s did not — and the keepalive holds it open indefinitely.

It matters in ordinary operation, not only at long poll intervals. Since #628 a config read is cached for 300 seconds, so a host can go a full 300 seconds making no RPC2 request at all because every read is a cache hit. That sits inside the expiry window. Without the keepalive the session would lapse during normal quiet polling and every cache expiry would pay for a fresh login — which is the cost this change exists to remove.

It costs one request per minute per host, against seven per poll removed.

## Not here, deliberately

- **Writes.** Reads are the bulk and the safe half.
- **Flipping the default.** Everything measured on this integration lately varies by model, and I have one NVR and one VTO.

Diagnostics report the session as present or absent with a refcount, never the id, under the same rule as the digest state.


