### PR TITLE
Document the illuminator that 0.9.84-0.9.92 could leave switched on

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ Brand | 2 Megapixels | 4 Megapixels | 5 Megapixels | 8 Megapixels
 
 # Known Issues
 * IPC-D2B20-ZS doesn't work. Needs a [wrapper](https://gist.github.com/gxfxyz/48072a72be3a169bc43549e676713201), [7](https://github.com/bp2008/DahuaSunriseSunset/issues/7#issuecomment-829513144), [8](https://github.com/mcw0/Tools/issues/8#issuecomment-830669237)
+* **Versions between 0.9.84 and 0.9.92 could leave the illuminator switched on in a profile you are not using.** In that window the illuminator wrote to the wrong day/night profile on some cameras ([#605](https://github.com/rroller/dahua/issues/605), [#582](https://github.com/rroller/dahua/issues/582)); which versions affected you depends on the camera, and 0.9.93 fixed the write for both kinds. It does not undo what the earlier versions wrote. If you turned the illuminator on during that window, `Lighting_V2[<channel>][0][0].Mode` may still be `Manual` on the Day profile.
+
+  While the camera is in General mode this does nothing at all. But if the camera is ever switched to Day/Night profile management, the light comes on when that profile becomes active, looking as though it did so by itself. Home Assistant will report it as on and can turn it off — but only once you notice it.
+
+  The integration deliberately does not correct this for you, because doing so would mean writing to a profile you are not currently using, on every camera, unprompted. To check for it and clear it by hand, see [Curl/HTTP commands](#curlhttp-commands).
 
 # Events
 Events are streamed from the device and fired on the Home Assistant event bus.
@@ -355,6 +360,14 @@ http://192.168.1.203/cgi-bin/configManager.cgi?action=setConfig&VideoAnalyseRule
 
 # Enable/disable Audio Linkage for an IVS rule
 http://192.168.1.203/cgi-bin/configManager.cgi?action=setConfig&VideoAnalyseRule[0][3].EventHandler.VoiceEnable=false
+
+# Read the lighting profiles, to check for an illuminator left on by 0.9.84-0.9.92 (see Known Issues).
+# In Lighting_V2[a][b][c], a is the channel, b the profile (0 Day, 1 Night, 2 the one General mode uses)
+# and c the light: 0 is the illuminator, 1 the flood/security light.
+http://192.168.1.203/cgi-bin/configManager.cgi?action=getConfig&name=Lighting_V2
+
+# Clear it. Only run this if the Mode above is Manual on a profile the camera is not using
+http://192.168.1.203/cgi-bin/configManager.cgi?action=setConfig&Lighting_V2[0][0][0].Mode=Off
 ```
 
 # References and thanks


### PR DESCRIPTION
Documentation only. Closes out the loose end from #605.

## What this is

#638 (0.9.93) fixed *which* day/night profile the illuminator is written to. It does not undo what the earlier versions wrote, and @mattmcd1 found the leftovers on his own camera while verifying that fix:

> the buggy versions can leave `Lighting_V2[0][0][0].Mode=Manual` stranded on the inactive Day profile (ours was). Harmless in General mode, but it becomes a permanently-on light if the camera is ever switched back to Day/Night profile management

That is a real trap, and a delayed one. Under General mode the stranded value does nothing, so nobody has any reason to look. It only surfaces if the camera is later switched to Day/Night profile management — possibly months later, at which point a light comes on with nothing in Home Assistant having asked for it and no obvious cause.

## Why documenting rather than fixing it in code

Self-healing looks tempting: write `Lighting_V2[<ch>][0][0].Mode=Off` at startup where it is stranded. I would rather not, for two reasons.

It means writing to a profile the user is not currently using, on every affected camera, unprompted, to correct something that is doing nothing right now. And "read the value, decide it is wrong, write over it" is exactly the shape that produced #605 and #582 in the first place — three device behaviours disagree about which field is authoritative, and we would be acting on that judgement without the user asking.

There is also no reliable way to tell a stranded value from a deliberate one. A user who runs Day/Night profiles and genuinely wants the illuminator on during the day is indistinguishable from the residue.

So: a note in Known Issues describing the symptom, and the two commands to check and clear it, in the Curl/HTTP section alongside the existing IVS examples. Anyone who hits the surprise light can search for it and fix it in one call.

## For the release notes, if useful

> Earlier versions between 0.9.84 and 0.9.92 could leave the illuminator switched on in a day/night profile the camera was not using. 0.9.93 fixed the write but does not clean up the old value; see Known Issues in the README if a light ever comes on by itself after you change a camera's profile management.

Nothing in `custom_components/` is touched.
