### PR TITLE
Say what the failed poll actually failed with

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -138,6 +138,18 @@ def failure_backoff(base: timedelta, consecutive: int) -> timedelta:
     return min(base * (2 ** doublings), max(POLL_BACKOFF_CAP, base))
 
 
+def describe_update_failure(exception: BaseException) -> str:
+    """A short phrase naming why a poll failed, for a log line and the UI.
+
+    `str()` on the exceptions this actually raises is very often empty --
+    `asyncio.TimeoutError` and most `aiohttp.ClientError` subclasses carry no
+    message -- so formatting one straight into a log gives the reader a blank
+    where the cause should be. Falling back to the class name is the difference
+    between "TimeoutError" and nothing at all.
+    """
+    return str(exception).strip() or type(exception).__name__
+
+
 def jittered(seconds: float, fraction: float = EVENT_STREAM_JITTER) -> float:
     """Spread a shared interval so simultaneous callers stop being simultaneous."""
     if seconds <= 0 or fraction <= 0:
@@ -1036,12 +1048,17 @@ class DahuaDataUpdateCoordinator(DataUpdateCoordinator):
             self._restore_poll_interval()
             return data
         except Exception as exception:
-            _LOGGER.warning("Failed to sync device state for %s. See README to enable debug logs to get full exception",
-                            self._address)
+            detail = describe_update_failure(exception)
+            _LOGGER.warning("Failed to sync device state for %s: %s. See README to enable debug logs to get full exception",
+                            self._address, detail)
             _LOGGER.debug("Failed to sync device state for %s", self._address, exc_info=exception)
             consecutive = async_record_host_failure(self.hass, self._address, self.config_entry.entry_id)
             self._back_off_poll_interval(consecutive)
-            raise UpdateFailed() from exception
+            # Carried into UpdateFailed so the coordinator's own "Error fetching
+            # dahua data" line names the fault too. Raised bare, it prints that
+            # sentence and then nothing, which is what sends people to the
+            # debug-logging instructions for what is often a one-word answer.
+            raise UpdateFailed(detail) from exception
 
     def on_receive_vto_event(self, event: dict):
         event["DeviceName"] = self.get_device_name()

--- a/tests/dahua/test_update_failure_message.py
+++ b/tests/dahua/test_update_failure_message.py
@@ -1,0 +1,52 @@
+"""A failed poll must say what failed.
+
+The coordinator used to raise `UpdateFailed()` bare, so Home Assistant logged
+"Error fetching dahua data:" followed by nothing, and the integration's own
+warning pointed at the README rather than naming the fault. Diagnosing an
+intermittent device then means turning on debug logging and waiting for it to
+happen again, for what is usually a one-word answer.
+
+The exceptions raised here mostly carry no message of their own, which is the
+whole reason the naive `str(exception)` is not enough.
+"""
+
+import asyncio
+
+import aiohttp
+import pytest
+
+from custom_components.dahua import describe_update_failure
+
+
+# --- the empty ones, which are the common case --------------------------------
+
+def test_a_timeout_is_named_even_though_it_carries_no_message():
+    """`str(asyncio.TimeoutError())` is "" -- the case that produced a blank log."""
+    assert describe_update_failure(asyncio.TimeoutError()) == "TimeoutError"
+
+
+def test_a_bare_client_error_is_named():
+    assert describe_update_failure(aiohttp.ClientError()) == "ClientError"
+
+
+@pytest.mark.parametrize("exception", [
+    asyncio.TimeoutError(),
+    aiohttp.ClientError(),
+    aiohttp.ServerDisconnectedError(),
+    ValueError(),
+])
+def test_no_exception_ever_describes_as_empty(exception):
+    """Whatever arrives, the log line must not end in a blank."""
+    assert describe_update_failure(exception).strip() != ""
+
+
+# --- and when there is a message, keep it -------------------------------------
+
+def test_a_message_is_preferred_over_the_class_name():
+    """The class name is the fallback, not the answer."""
+    assert describe_update_failure(ValueError("boom")) == "boom"
+
+
+def test_surrounding_whitespace_is_not_reported_as_a_message():
+    """A message of only whitespace is as useless as none, so fall back."""
+    assert describe_update_failure(ValueError("   ")) == "ValueError"


### PR DESCRIPTION
Small one, from being on the receiving end of it today.

## The problem

When a poll fails, the two lines a user gets are:

```
WARNING [custom_components.dahua] Failed to sync device state for 192.168.0.213.
        See README to enable debug logs to get full exception
ERROR   [custom_components.dahua] Error fetching dahua data:
```

The second one ends there, because `_async_update_data` raises `UpdateFailed()` with no argument. Between them they name no cause at all, and the only route to one is to enable debug logging and wait for the fault to recur.

That is a long wait when the fault is intermittent. My own NVR has been failing roughly eight times an hour for three days; I turned on debug logging and it then went an hour without failing once. It is also the position every reporter of one of these issues starts from, which is part of why threads like #577 and #603 take as many rounds as they do.

## Why `str(exception)` on its own is not the fix

It would print the same blank. The exceptions this path actually sees mostly carry no message:

```python
str(asyncio.TimeoutError())        == ""
str(aiohttp.ClientError())         == ""
str(aiohttp.ServerDisconnectedError()) == ""
```

`client.py` raises `asyncio.TimeoutError` and `aiohttp.ClientError` by name in `_request`, so that is the common case rather than an edge one. Falling back to the class name is what makes the difference between `TimeoutError` and nothing.

## What it does

One pure helper next to `failure_backoff`, used in the warning and passed to `UpdateFailed`, so the coordinator's own line names the fault too:

```
WARNING ... Failed to sync device state for 192.168.0.213: TimeoutError. See README ...
ERROR   ... Error fetching dahua data: TimeoutError
```

Debug logging still gives the full traceback; this only stops the non-debug case from being silent.

## Verification

The helper is pure, so it is tested directly. I also checked the tests fail against the pre-fix behaviour rather than merely passing against the new one — substituting `return str(exception)` fails five of the six cases, the survivor being the one where the exception genuinely has a message.

No behaviour changes beyond the message: the same exception is raised, `from exception` is kept, the backoff and host-failure recording are untouched.
