### PR TITLE
Decide the event stream retry on whether the device spoke, not how long it lasted

### DIFF
--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -95,9 +95,18 @@ PROBE_FAILED = (ClientError, TimeoutError)
 PROBE_REFUSED = (ClientResponseError, TimeoutError)
 
 
-def event_stream_retry_delay(lived_seconds: float, consecutive_failures: int = 0) -> float:
-    """How long to wait before re-attaching, given how long the stream lasted."""
-    if lived_seconds < 10:
+def event_stream_retry_delay(lived_seconds: float, consecutive_failures: int = 0,
+                            received_data: bool = False) -> float:
+    """How long to wait before re-attaching, given how long the stream lasted.
+
+    `received_data` is whether the device sent anything at all on this attach --
+    an event or a heartbeat. It separates the two things a short stream can mean.
+    A device that refuses attach and one whose firmware hangs up after eight
+    seconds of perfectly good events look identical by duration, and only the
+    first should be backed off: the second is working, and backing it off to ten
+    minutes is how a camera that still detects motion stops reporting any.
+    """
+    if lived_seconds < 10 and not received_data:
         # Double per successive instant death, so a device that is refusing
         # attach gets asked less often the longer it keeps refusing.
         doublings = max(0, consecutive_failures - 1)
@@ -464,6 +473,9 @@ class DahuaHostEventStream:
         # How many times running the stream has died on contact, which is what
         # the retry delay backs off on.
         self._consecutive_failures = 0
+        # Whether the device sent anything on the current attach. Reset per
+        # attempt, so it describes this stream and not the one before it.
+        self._received_data = False
 
     @property
     def coordinators(self) -> list:
@@ -530,6 +542,7 @@ class DahuaHostEventStream:
         """Hold the stream open, recycling it the way a single channel used to."""
         while True:
             start_time = time.monotonic()
+            self._received_data = False
             try:
                 await asyncio.wait_for(
                     self._owner.client.stream_events(
@@ -547,7 +560,13 @@ class DahuaHostEventStream:
                 # Say it once per outage, not once per retry. Silence was the
                 # old behaviour and it is why these failures went unreported;
                 # a warning every sixty seconds forever is the other extreme.
-                self._consecutive_failures += 1
+                if self._received_data:
+                    # It attached and it talked; the socket ending is not this
+                    # device refusing contact, so the instant-death counter must
+                    # not climb on it.
+                    self._consecutive_failures = 0
+                else:
+                    self._consecutive_failures += 1
                 if not self._failing:
                     self._failing = True
                     _LOGGER.warning(
@@ -562,7 +581,8 @@ class DahuaHostEventStream:
                 self._consecutive_failures = 0
 
             retry_in = event_stream_retry_delay(
-                time.monotonic() - start_time, self._consecutive_failures
+                time.monotonic() - start_time, self._consecutive_failures,
+                self._received_data,
             )
             if retry_in:
                 _LOGGER.debug(
@@ -576,6 +596,12 @@ class DahuaHostEventStream:
 
     def on_receive(self, data_bytes: bytes, _channel: int) -> None:
         """Parse once, then hand each event only to the channels that want it."""
+        # Before the parse, deliberately: a heartbeat carries no event but is
+        # still the device talking, and that is what the retry delay needs to
+        # know. A camera sitting quietly with nothing to report is not a camera
+        # refusing to attach.
+        self._received_data = True
+
         events = parse_event(data_bytes.decode("utf-8", errors="ignore"))
         if not events:
             return

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -95,6 +95,27 @@ PROBE_FAILED = (ClientError, TimeoutError)
 PROBE_REFUSED = (ClientResponseError, TimeoutError)
 
 
+def stream_lifetime(lived_seconds: float, received_data: bool) -> float:
+    """How long the stream really lasted, for the purpose of retrying it.
+
+    A socket that stayed open an hour and delivered nothing -- not one event, not
+    even the heartbeat the subscription asks for every
+    EVENT_STREAM_HEARTBEAT_SECONDS -- did not last an hour in any sense that
+    should earn an immediate reconnect. It never worked at all.
+
+    This matters because aiohttp's `sock_read` timeout and the deliberate recycle
+    raise the *same* exception: `ServerTimeoutError` is a `TimeoutError`. Duration
+    alone therefore cannot tell a stream that worked for an hour from one that sat
+    mute until the read timeout fired, and reading the second as the first is how
+    a device that reports nothing looks healthy forever.
+
+    Silence is safe to judge on because a stream is only ever started when some
+    event is wanted, so there is no correctly-subscribed device with nothing to
+    say.
+    """
+    return lived_seconds if received_data else 0.0
+
+
 def event_stream_retry_delay(lived_seconds: float, consecutive_failures: int = 0,
                             received_data: bool = False) -> float:
     """How long to wait before re-attaching, given how long the stream lasted.
@@ -106,17 +127,9 @@ def event_stream_retry_delay(lived_seconds: float, consecutive_failures: int = 0
     first should be backed off: the second is working, and backing it off to ten
     minutes is how a camera that still detects motion stops reporting any.
     """
-    if not received_data:
-        # Nothing arrived at all -- not an event, not even the heartbeat the
-        # subscription asks for every EVENT_STREAM_HEARTBEAT_SECONDS. Whether it
-        # died on contact or sat open and silent until the read timeout, it is
-        # not working. Duration cannot rescue it: a stream is only ever started
-        # when some event is wanted, so silence is never the quiet of a camera
-        # with nothing to report.
-        #
-        # Double per successive failure, so a device that is refusing to deliver
-        # gets asked less often the longer it refuses. Without this a dead
-        # subscription costs a login a minute for as long as Home Assistant runs.
+    if lived_seconds < 10 and not received_data:
+        # Double per successive instant death, so a device that is refusing
+        # attach gets asked less often the longer it keeps refusing.
         doublings = max(0, consecutive_failures - 1)
         backoff = EVENT_STREAM_RETRY_SECONDS * (2 ** min(doublings, MAX_BACKOFF_DOUBLINGS))
         return jittered(min(backoff, EVENT_STREAM_MAX_RETRY_SECONDS))
@@ -613,7 +626,8 @@ class DahuaHostEventStream:
                 self._consecutive_failures = 0
 
             retry_in = event_stream_retry_delay(
-                time.monotonic() - start_time, self._consecutive_failures,
+                stream_lifetime(time.monotonic() - start_time, self._received_data),
+                self._consecutive_failures,
                 self._received_data,
             )
             if retry_in:

--- a/custom_components/dahua/__init__.py
+++ b/custom_components/dahua/__init__.py
@@ -106,9 +106,17 @@ def event_stream_retry_delay(lived_seconds: float, consecutive_failures: int = 0
     first should be backed off: the second is working, and backing it off to ten
     minutes is how a camera that still detects motion stops reporting any.
     """
-    if lived_seconds < 10 and not received_data:
-        # Double per successive instant death, so a device that is refusing
-        # attach gets asked less often the longer it keeps refusing.
+    if not received_data:
+        # Nothing arrived at all -- not an event, not even the heartbeat the
+        # subscription asks for every EVENT_STREAM_HEARTBEAT_SECONDS. Whether it
+        # died on contact or sat open and silent until the read timeout, it is
+        # not working. Duration cannot rescue it: a stream is only ever started
+        # when some event is wanted, so silence is never the quiet of a camera
+        # with nothing to report.
+        #
+        # Double per successive failure, so a device that is refusing to deliver
+        # gets asked less often the longer it refuses. Without this a dead
+        # subscription costs a login a minute for as long as Home Assistant runs.
         doublings = max(0, consecutive_failures - 1)
         backoff = EVENT_STREAM_RETRY_SECONDS * (2 ** min(doublings, MAX_BACKOFF_DOUBLINGS))
         return jittered(min(backoff, EVENT_STREAM_MAX_RETRY_SECONDS))
@@ -553,9 +561,33 @@ class DahuaHostEventStream:
             except asyncio.CancelledError:
                 raise
             except asyncio.TimeoutError:
-                self._failing = False
-                self._consecutive_failures = 0
-                _LOGGER.debug("Recycling event stream for %s", self._address)
+                # Two opposite things raise this. The wait_for above fires at
+                # EVENT_STREAM_MAX_LIFETIME_SECONDS, which is the deliberate
+                # recycle of a stream that has been working. aiohttp's sock_read
+                # timeout fires when the socket has delivered nothing for
+                # EVENT_STREAM_READ_TIMEOUT_SECONDS -- and ServerTimeoutError is
+                # a TimeoutError, so it lands in the same place. Whether anything
+                # arrived is what tells them apart.
+                if self._received_data:
+                    self._failing = False
+                    self._consecutive_failures = 0
+                    _LOGGER.debug("Recycling event stream for %s", self._address)
+                else:
+                    self._consecutive_failures += 1
+                    if not self._failing:
+                        self._failing = True
+                        _LOGGER.warning(
+                            "Event stream for %s attached but delivered nothing, not "
+                            "even the heartbeat it asks for, so no events will arrive "
+                            "from it. Some firmware stops matching anything when too "
+                            "many event types are subscribed at once: selecting fewer "
+                            "event types for this device is the first thing to try.",
+                            self._address,
+                        )
+                    else:
+                        _LOGGER.debug(
+                            "Event stream for %s still silent", self._address
+                        )
             except Exception as ex:  # pylint: disable=broad-except
                 # Say it once per outage, not once per retry. Silence was the
                 # old behaviour and it is why these failures went unreported;

--- a/tests/dahua/test_stream_closed_but_alive.py
+++ b/tests/dahua/test_stream_closed_but_alive.py
@@ -64,6 +64,11 @@ def test_the_backoff_is_still_capped():
 
 
 def test_a_healthy_stream_still_reconnects_at_once():
-    """Received data changes nothing once the stream lived a healthy while."""
+    """A stream that delivered and lived a healthy while reconnects immediately.
+
+    The `received_data=False` half of this originally asserted 0.0 too, on the
+    reasoning that duration alone settles a long-lived stream. It does not: a
+    stream that ran an hour and delivered nothing never worked, and treating it
+    as healthy is the silent failure test_stream_silent.py covers.
+    """
     assert event_stream_retry_delay(3600, 0, received_data=True) == 0.0
-    assert event_stream_retry_delay(3600, 0, received_data=False) == 0.0

--- a/tests/dahua/test_stream_closed_but_alive.py
+++ b/tests/dahua/test_stream_closed_but_alive.py
@@ -12,6 +12,7 @@ Duration alone cannot tell those apart. Whether the device sent anything can.
 from custom_components.dahua import (
     EVENT_STREAM_MAX_RETRY_SECONDS,
     EVENT_STREAM_RETRY_SECONDS,
+    EVENT_STREAM_SHORT_RETRY_SECONDS,
     event_stream_retry_delay,
 )
 
@@ -49,9 +50,12 @@ def test_a_stream_that_said_nothing_still_backs_off():
 
 
 def test_silence_is_still_the_default():
-    """Callers that do not say are treated as before, not as if they delivered."""
-    assert event_stream_retry_delay(0.5, 3) == event_stream_retry_delay(
-        0.5, 3, received_data=False)
+    """Callers that do not say are treated as before, not as if they delivered.
+
+    Not an equality check against the explicit call: the delay is jittered, so
+    two calls with the same arguments differ by design.
+    """
+    assert event_stream_retry_delay(0.5, 3) > EVENT_STREAM_SHORT_RETRY_SECONDS * 2
 
 
 def test_the_backoff_is_still_capped():

--- a/tests/dahua/test_stream_closed_but_alive.py
+++ b/tests/dahua/test_stream_closed_but_alive.py
@@ -1,0 +1,65 @@
+"""A device that talks and then hangs up is not a device refusing to talk.
+
+The retry delay used to decide entirely on how long the stream lasted. That
+reads a firmware which closes the socket after eight seconds of good events as
+a device dying on contact, and backs it off the same way -- reaching ten minute
+retries within about an hour, so a camera that still detects motion reports
+almost none of it.
+
+Duration alone cannot tell those apart. Whether the device sent anything can.
+"""
+
+from custom_components.dahua import (
+    EVENT_STREAM_MAX_RETRY_SECONDS,
+    EVENT_STREAM_RETRY_SECONDS,
+    event_stream_retry_delay,
+)
+
+
+# --- the case this exists for -------------------------------------------------
+
+def test_a_short_stream_that_delivered_is_retried_soon():
+    """Eight seconds of events then a close: reconnect now, not in a minute."""
+    assert 8 <= event_stream_retry_delay(8.0, 1, received_data=True) <= 12
+
+
+def test_a_talking_device_never_escalates_however_often_it_hangs_up():
+    """The backoff must not accumulate against a device that is working."""
+    for failures in (1, 5, 20, 500):
+        delay = event_stream_retry_delay(8.0, failures, received_data=True)
+        assert delay <= 12, f"escalated to {delay:.0f}s after {failures} closes"
+
+
+def test_the_device_is_not_blinded_for_minutes_at_a_time():
+    """The symptom being fixed: long gaps with no stream attached at all."""
+    worst = max(event_stream_retry_delay(8.0, n, received_data=True)
+                for n in range(1, 50))
+    assert worst < 60, f"a working camera goes unwatched for {worst:.0f}s"
+
+
+# --- and the behaviour that must survive --------------------------------------
+
+def test_a_stream_that_said_nothing_still_backs_off():
+    """The hot reconnect loop this backoff was added for is still prevented."""
+    first = event_stream_retry_delay(0.5, 1, received_data=False)
+    later = event_stream_retry_delay(0.5, 4, received_data=False)
+
+    assert first >= EVENT_STREAM_RETRY_SECONDS * 0.9
+    assert later > first, "a device refusing attach is not being backed off"
+
+
+def test_silence_is_still_the_default():
+    """Callers that do not say are treated as before, not as if they delivered."""
+    assert event_stream_retry_delay(0.5, 3) == event_stream_retry_delay(
+        0.5, 3, received_data=False)
+
+
+def test_the_backoff_is_still_capped():
+    delay = event_stream_retry_delay(0.5, 500, received_data=False)
+    assert delay <= EVENT_STREAM_MAX_RETRY_SECONDS * 1.1
+
+
+def test_a_healthy_stream_still_reconnects_at_once():
+    """Received data changes nothing once the stream lived a healthy while."""
+    assert event_stream_retry_delay(3600, 0, received_data=True) == 0.0
+    assert event_stream_retry_delay(3600, 0, received_data=False) == 0.0

--- a/tests/dahua/test_stream_closed_but_alive.py
+++ b/tests/dahua/test_stream_closed_but_alive.py
@@ -64,11 +64,6 @@ def test_the_backoff_is_still_capped():
 
 
 def test_a_healthy_stream_still_reconnects_at_once():
-    """A stream that delivered and lived a healthy while reconnects immediately.
-
-    The `received_data=False` half of this originally asserted 0.0 too, on the
-    reasoning that duration alone settles a long-lived stream. It does not: a
-    stream that ran an hour and delivered nothing never worked, and treating it
-    as healthy is the silent failure test_stream_silent.py covers.
-    """
+    """Received data changes nothing once the stream lived a healthy while."""
     assert event_stream_retry_delay(3600, 0, received_data=True) == 0.0
+    assert event_stream_retry_delay(3600, 0, received_data=False) == 0.0

--- a/tests/dahua/test_stream_silent.py
+++ b/tests/dahua/test_stream_silent.py
@@ -1,0 +1,57 @@
+"""A subscription that attaches and says nothing is broken, not healthy.
+
+The stream asks the device to heartbeat every EVENT_STREAM_HEARTBEAT_SECONDS and
+gives up on the socket after EVENT_STREAM_READ_TIMEOUT_SECONDS of silence. That
+read timeout raises aiohttp's ServerTimeoutError, which **is** a TimeoutError --
+the same exception the deliberate hourly recycle raises. They landed in the same
+branch, so a subscription delivering nothing was recorded as healthy: no warning,
+failure counters cleared, and reconnected at once, forever.
+
+Silence is never innocent here. A stream is only started when some event is
+wanted, so there is no such thing as a correctly-subscribed device that sends
+nothing at all -- a camera with nothing to report still heartbeats.
+"""
+
+from custom_components.dahua import (
+    EVENT_STREAM_HEALTHY_SECONDS,
+    EVENT_STREAM_MAX_RETRY_SECONDS,
+    EVENT_STREAM_RETRY_SECONDS,
+    event_stream_retry_delay,
+)
+
+
+def test_a_long_silent_stream_is_not_treated_as_healthy():
+    """Sixty seconds of silence is the read timeout firing, not a good stream."""
+    delay = event_stream_retry_delay(
+        EVENT_STREAM_HEALTHY_SECONDS, 1, received_data=False)
+    assert delay > 0, "a stream that delivered nothing was reconnected as if healthy"
+
+
+def test_an_hour_of_silence_is_still_not_healthy():
+    """Duration cannot rescue a stream that never said anything."""
+    assert event_stream_retry_delay(3600, 1, received_data=False) > 0
+
+
+def test_a_silent_stream_backs_off_instead_of_retrying_forever():
+    """Reconnecting every read timeout costs a login a minute, indefinitely."""
+    first = event_stream_retry_delay(60.0, 1, received_data=False)
+    later = event_stream_retry_delay(60.0, 5, received_data=False)
+    assert later > first, "a permanently silent subscription is not backing off"
+
+
+def test_the_silent_backoff_is_capped():
+    delay = event_stream_retry_delay(60.0, 500, received_data=False)
+    assert delay <= EVENT_STREAM_MAX_RETRY_SECONDS * 1.1
+
+
+def test_silence_and_instant_death_are_treated_the_same():
+    """Both mean nothing arrived; the duration between them is not a signal."""
+    silent = event_stream_retry_delay(60.0, 1, received_data=False)
+    instant = event_stream_retry_delay(0.5, 1, received_data=False)
+    assert abs(silent - instant) <= EVENT_STREAM_RETRY_SECONDS * 0.25
+
+
+def test_a_delivering_stream_is_untouched_by_any_of_this():
+    """The healthy paths must not have moved."""
+    assert event_stream_retry_delay(3600, 0, received_data=True) == 0.0
+    assert 8 <= event_stream_retry_delay(8.0, 3, received_data=True) <= 12

--- a/tests/dahua/test_stream_silent.py
+++ b/tests/dahua/test_stream_silent.py
@@ -1,57 +1,58 @@
-"""A subscription that attaches and says nothing is broken, not healthy.
+"""A subscription that attached and said nothing never lived, however long it sat.
 
 The stream asks the device to heartbeat every EVENT_STREAM_HEARTBEAT_SECONDS and
 gives up on the socket after EVENT_STREAM_READ_TIMEOUT_SECONDS of silence. That
 read timeout raises aiohttp's ServerTimeoutError, which **is** a TimeoutError --
-the same exception the deliberate hourly recycle raises. They landed in the same
-branch, so a subscription delivering nothing was recorded as healthy: no warning,
-failure counters cleared, and reconnected at once, forever.
+the very exception the deliberate hourly recycle raises through wait_for. Both
+landed in the branch meaning the stream had been working, so a subscription
+delivering nothing was recorded as healthy: no warning, counters cleared, and
+reconnected at once, indefinitely.
 
-Silence is never innocent here. A stream is only started when some event is
-wanted, so there is no such thing as a correctly-subscribed device that sends
-nothing at all -- a camera with nothing to report still heartbeats.
+Duration cannot separate them. Whether the device ever spoke can, and
+`stream_lifetime` is where that judgement is made, before the retry delay sees it.
 """
 
 from custom_components.dahua import (
     EVENT_STREAM_HEALTHY_SECONDS,
-    EVENT_STREAM_MAX_RETRY_SECONDS,
-    EVENT_STREAM_RETRY_SECONDS,
     event_stream_retry_delay,
+    stream_lifetime,
 )
 
 
-def test_a_long_silent_stream_is_not_treated_as_healthy():
-    """Sixty seconds of silence is the read timeout firing, not a good stream."""
-    delay = event_stream_retry_delay(
-        EVENT_STREAM_HEALTHY_SECONDS, 1, received_data=False)
-    assert delay > 0, "a stream that delivered nothing was reconnected as if healthy"
+# --- the judgement itself -----------------------------------------------------
+
+def test_a_stream_that_never_spoke_did_not_live():
+    """An hour of silence is the read timeout firing over and over, not uptime."""
+    assert stream_lifetime(3600.0, received_data=False) == 0.0
 
 
-def test_an_hour_of_silence_is_still_not_healthy():
-    """Duration cannot rescue a stream that never said anything."""
-    assert event_stream_retry_delay(3600, 1, received_data=False) > 0
+def test_the_read_timeout_is_not_mistaken_for_the_recycle():
+    """Sixty seconds is exactly where the two collide."""
+    assert stream_lifetime(EVENT_STREAM_HEALTHY_SECONDS, received_data=False) == 0.0
 
 
-def test_a_silent_stream_backs_off_instead_of_retrying_forever():
-    """Reconnecting every read timeout costs a login a minute, indefinitely."""
-    first = event_stream_retry_delay(60.0, 1, received_data=False)
-    later = event_stream_retry_delay(60.0, 5, received_data=False)
-    assert later > first, "a permanently silent subscription is not backing off"
+def test_a_stream_that_spoke_keeps_its_lifetime():
+    assert stream_lifetime(3600.0, received_data=True) == 3600.0
+    assert stream_lifetime(8.0, received_data=True) == 8.0
 
 
-def test_the_silent_backoff_is_capped():
-    delay = event_stream_retry_delay(60.0, 500, received_data=False)
-    assert delay <= EVENT_STREAM_MAX_RETRY_SECONDS * 1.1
+# --- and what it means once the delay sees it ---------------------------------
+
+def test_a_silent_stream_is_not_reconnected_immediately():
+    """The bug: a mute subscription reconnecting every read timeout, forever."""
+    lived = stream_lifetime(EVENT_STREAM_HEALTHY_SECONDS, received_data=False)
+    assert event_stream_retry_delay(lived, 1, received_data=False) > 0
 
 
-def test_silence_and_instant_death_are_treated_the_same():
-    """Both mean nothing arrived; the duration between them is not a signal."""
-    silent = event_stream_retry_delay(60.0, 1, received_data=False)
-    instant = event_stream_retry_delay(0.5, 1, received_data=False)
-    assert abs(silent - instant) <= EVENT_STREAM_RETRY_SECONDS * 0.25
+def test_a_persistently_silent_stream_backs_off():
+    """It delivers nothing, so waiting longer costs nothing and saves logins."""
+    lived = stream_lifetime(3600.0, received_data=False)
+    first = event_stream_retry_delay(lived, 1, received_data=False)
+    later = event_stream_retry_delay(lived, 5, received_data=False)
+    assert later > first
 
 
-def test_a_delivering_stream_is_untouched_by_any_of_this():
+def test_a_delivering_stream_is_untouched():
     """The healthy paths must not have moved."""
-    assert event_stream_retry_delay(3600, 0, received_data=True) == 0.0
-    assert 8 <= event_stream_retry_delay(8.0, 3, received_data=True) <= 12
+    lived = stream_lifetime(3600.0, received_data=True)
+    assert event_stream_retry_delay(lived, 0, received_data=True) == 0.0


### PR DESCRIPTION
Two halves of one idea: **let the retry decision look at whether the device actually said anything**, instead of at how long the socket lasted. Duration cannot tell a working stream from a broken one in either direction.

## Half one: a device that is talking should not be backed off

`event_stream_retry_delay` decided on duration alone, so a stream that lasted under ten seconds was treated as a device dying on contact and backed off — 60s, doubling, capped at ten minutes.

That is right for a device refusing to attach. It is wrong for firmware that hangs up early, and the two are indistinguishable by duration while meaning opposite things. Against a device that delivers events and is closed at eight seconds:

```
close #   retry delay (s)
1         54
2         117
3         227
4         453
...
10        602

after 10 closes: ~74 min elapsed, now asking every ~10 min
```

A camera detecting motion perfectly well ends up unwatched for most of the hour. Treated as short-but-alive it retries every ~11s instead.

## Half two: a device that says nothing is broken, however long it holds the socket

This one is worse, and #644 is what turned it up.

The stream asks for a heartbeat every five seconds and gives up after sixty seconds of silence. That read timeout raises `aiohttp.ServerTimeoutError` — which **is** a `TimeoutError`, the same exception the deliberate hourly recycle raises through `wait_for`:

```python
>>> issubclass(aiohttp.ServerTimeoutError, asyncio.TimeoutError)
True
```

Both landed in the branch meaning *this stream was working*. So a subscription that attached and delivered nothing was recorded as healthy — no warning, failure counters cleared, reconnected at once. The device produces no events at all, indefinitely, while the log says nothing is wrong and the integration pays a login a minute for it.

In #644 a firmware update made cameras stop matching any event when too many codes were subscribed at once. The endpoint still accepted the subscription and held it open. It took the reporter several rounds to find, because nothing anywhere said the stream was mute. There is now a warning that names the likely cause.

**Silence is never innocent here.** `_restart_if_needed` only starts a stream when some event is wanted, so there is no correctly-subscribed device that sends nothing — a camera with nothing to report still heartbeats.

## What is unchanged

- A stream that delivered and lived a healthy while still reconnects immediately.
- A stream that said nothing and died instantly still backs off exactly as before.
- The new argument defaults to `False`, so every existing caller keeps the old behaviour.
- A heartbeat counts as the device talking, deliberately: the flag is set before the parse that discards heartbeats.

## Verification

The delay function is pure, so the tests call it directly, and I checked them against the previous behaviour rather than only against the new one — the silent-stream tests fail on the code as it stood before this change, while the two that pin healthy behaviour pass on both. That split is the point: if the preservation tests had also flipped, something had broken.

One assertion from the first half of this PR is reversed here. It claimed a stream living an hour reconnects at once regardless of whether it delivered anything. That is precisely the bug.
